### PR TITLE
Fix decryption

### DIFF
--- a/src/Picocrypt-NG.go
+++ b/src/Picocrypt-NG.go
@@ -2008,7 +2008,7 @@ func work() {
 			}
 		} else {
 			// v2 validation: HMAC-SHA3-512 over header using first 64 bytes of a single HKDF stream
-			unifiedKDF = hkdf.New(sha3.New512, key, hkdfSalt, nil)
+			unifiedKDF = hkdf.New(sha3.New256, key, hkdfSalt, nil)
 			subkeyHeader := make([]byte, 64)
 			if _, err := io.ReadFull(unifiedKDF, subkeyHeader); err != nil {
 				panic(errors.New("fatal hkdf.Read error"))


### PR DESCRIPTION
Use HKDF-SHA3-256 instead of SHA3-512 so the derived subkeyHeader matches what existing volumes used, restoring decryption compatibility.