### PR TITLE
ci(linux): run non-race tests on arm64 runners

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -61,7 +61,11 @@ jobs:
     - name: Run tests
       run: |
         cd src
-        go test -v -race -timeout 15m ./...
+        if [ "${{ matrix.arch }}" = "amd64" ]; then
+          CGO_ENABLED=1 go test -v -race -timeout 15m ./...
+        else
+          CGO_ENABLED=1 go test -v -timeout 15m ./...
+        fi
 
     - name: Build GUI
       run: |

--- a/.github/workflows/pr-test-build-linux.yml
+++ b/.github/workflows/pr-test-build-linux.yml
@@ -58,7 +58,11 @@ jobs:
     - name: Run tests
       run: |
         cd src
-        go test -v -race -timeout 15m ./...
+        if [ "${{ matrix.arch }}" = "amd64" ]; then
+          CGO_ENABLED=1 go test -v -race -timeout 15m ./...
+        else
+          CGO_ENABLED=1 go test -v -timeout 15m ./...
+        fi
 
     - name: Build GUI
       run: |


### PR DESCRIPTION
## Summary
- run Linux tests with `-race` only on `amd64`
- run Linux tests without `-race` on `arm64` (still with `CGO_ENABLED=1`)
- apply same logic to both release and PR test Linux workflows

## Why
Recent Linux arm64 jobs in PR #89 and post-merge runs failed during the `Run tests` step before build/artifact stages.
