### PR TITLE
fix(ci): restore macOS Sequoia GUI compatibility

### DIFF
--- a/.github/scripts/assert-macos-minos.sh
+++ b/.github/scripts/assert-macos-minos.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <mach-o-binary> <max_minos>" >&2
+  exit 2
+fi
+
+binary="$1"
+max_minos="$2"
+
+if command -v llvm-otool >/dev/null 2>&1; then
+  otool_bin="llvm-otool"
+elif command -v otool >/dev/null 2>&1; then
+  otool_bin="otool"
+else
+  echo "Neither llvm-otool nor otool is available" >&2
+  exit 2
+fi
+
+if [ ! -f "$binary" ]; then
+  echo "Binary not found: $binary" >&2
+  exit 2
+fi
+
+if ! otool_output="$("$otool_bin" -l "$binary" 2>&1)"; then
+  echo "Failed to inspect Mach-O load commands: $otool_bin -l $binary" >&2
+  printf '%s\n' "$otool_output" >&2
+  exit 2
+fi
+
+minos="$(printf '%s\n' "$otool_output" | awk '
+function normalize(version, out, i, n, parts) {
+  n = split(version, parts, ".")
+  for (i = 1; i <= 3; i++) {
+    out[i] = (i <= n && parts[i] != "") ? parts[i] + 0 : 0
+  }
+}
+function compare(a, b, va, vb, i) {
+  normalize(a, va)
+  normalize(b, vb)
+  for (i = 1; i <= 3; i++) {
+    if (va[i] < vb[i]) return -1
+    if (va[i] > vb[i]) return 1
+  }
+  return 0
+}
+$1=="minos" {
+  if (!found || compare($2, highest) > 0) {
+    highest = $2
+    found = 1
+  }
+}
+END {
+  if (found) print highest
+}
+')"
+if [ -z "$minos" ]; then
+  echo "Could not extract minos from: $binary" >&2
+  exit 2
+fi
+
+if ! awk -v minos="$minos" -v max="$max_minos" '
+function normalize(version, out, i, n, parts) {
+  n = split(version, parts, ".")
+  for (i = 1; i <= 3; i++) {
+    out[i] = (i <= n && parts[i] != "") ? parts[i] + 0 : 0
+  }
+}
+BEGIN {
+  normalize(minos, current)
+  normalize(max, allowed)
+  for (i = 1; i <= 3; i++) {
+    if (current[i] < allowed[i]) exit 0
+    if (current[i] > allowed[i]) exit 1
+  }
+  exit 0
+}
+'; then
+  echo "FAIL: $binary minos=$minos exceeds allowed max=$max_minos" >&2
+  exit 1
+fi
+
+echo "PASS: $binary minos=$minos (<= $max_minos)"

--- a/.github/scripts/test-macos-sequoia-guard.sh
+++ b/.github/scripts/test-macos-sequoia-guard.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail=0
+
+if [ ! -f ".github/scripts/assert-macos-minos.sh" ]; then
+  echo "Missing .github/scripts/assert-macos-minos.sh" >&2
+  fail=1
+fi
+
+for expected in \
+  '      - ".github/workflows/build-macos.yml"' \
+  '      - ".github/scripts/assert-macos-minos.sh"'
+do
+  if ! rg -Fq "$expected" ".github/workflows/build-macos.yml"; then
+    echo ".github/workflows/build-macos.yml is missing trigger path: $expected" >&2
+    fail=1
+  fi
+done
+
+for workflow in \
+  ".github/workflows/build-macos.yml" \
+  ".github/workflows/pr-test-build-macos.yml"
+do
+  for expected in \
+    'MACOSX_DEPLOYMENT_TARGET: "15.0"' \
+    'CGO_CFLAGS: "-mmacosx-version-min=15.0"' \
+    'CGO_LDFLAGS: "-mmacosx-version-min=15.0"' \
+    'bash .github/scripts/assert-macos-minos.sh src/Picocrypt-NG 15.0'
+  do
+    if ! rg -Fq "$expected" "$workflow"; then
+      echo "$workflow is missing: $expected" >&2
+      fail=1
+    fi
+  done
+done
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+
+echo "PASS: macOS Sequoia guard is present in both workflows"

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -7,6 +7,8 @@ on:
   push:
     paths:
       - "VERSION"
+      - ".github/workflows/build-macos.yml"
+      - ".github/scripts/assert-macos-minos.sh"
     branches:
       - main
   workflow_dispatch:
@@ -18,6 +20,10 @@ concurrency:
 jobs:
   build:
     runs-on: macos-26
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "15.0"
+      CGO_CFLAGS: "-mmacosx-version-min=15.0"
+      CGO_LDFLAGS: "-mmacosx-version-min=15.0"
     steps:
     - uses: actions/checkout@v6
 
@@ -48,6 +54,10 @@ jobs:
         go build -v -ldflags="-s -w" -o Picocrypt-NG ./cmd/picocrypt
       env:
         CGO_ENABLED: 1
+
+    - name: Verify macOS GUI deployment target
+      run: |
+        bash .github/scripts/assert-macos-minos.sh src/Picocrypt-NG 15.0
 
     - name: Build CLI-only (no graphics dependencies)
       run: |

--- a/.github/workflows/pr-test-build-macos.yml
+++ b/.github/workflows/pr-test-build-macos.yml
@@ -15,6 +15,10 @@ concurrency:
 jobs:
   pr-test-build-macos:
     runs-on: macos-26
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "15.0"
+      CGO_CFLAGS: "-mmacosx-version-min=15.0"
+      CGO_LDFLAGS: "-mmacosx-version-min=15.0"
     steps:
     - uses: actions/checkout@v6
 
@@ -45,6 +49,10 @@ jobs:
         go build -v -ldflags="-s -w" -o Picocrypt-NG ./cmd/picocrypt
       env:
         CGO_ENABLED: 1
+
+    - name: Verify macOS GUI deployment target
+      run: |
+        bash .github/scripts/assert-macos-minos.sh src/Picocrypt-NG 15.0
 
     - name: Build CLI-only (no graphics dependencies)
       run: |


### PR DESCRIPTION
## Summary
- restore `MACOSX_DEPLOYMENT_TARGET=15.0` and matching `-mmacosx-version-min=15.0` for macOS GUI CI builds
- add a Mach-O minOS guard so the GUI artifact cannot regress back above Sequoia support
- trigger `build-macos` when its workflow or guard script changes so merging this PR refreshes the current macOS release asset

Fixes #73.

## Test Plan
- [x] `bash .github/scripts/test-macos-sequoia-guard.sh`
- [x] `env GOCACHE=/tmp/go-build-cache go test ./internal/util/... ./internal/header/... ./internal/fileops/... ./internal/keyfile/... ./internal/encoding/...`
- [ ] `env GOCACHE=/tmp/go-build-cache go test ./...` on a full macOS-capable environment

## Context
`2.07` shipped a macOS GUI artifact with `minos 15.0`, but `2.08` regressed to `minos 26.0`, which made the app incompatible with macOS Sequoia. This PR restores the Sequoia-compatible deployment target and prevents the regression from reappearing.