### PR TITLE
Harden Windows workflow against unverified installer execution

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -59,6 +59,11 @@ jobs:
       shell: pwsh
       run: |
         Invoke-WebRequest -OutFile reshacker_setup.zip https://github.com/user-attachments/files/18878075/reshacker_setup.zip
+        $expectedHash = "E5A5B6D6BE38AE3EB20E72B09F257F284BAB2DEB5F37164E9F2FAEFD23F27CF4"
+        $actualHash = (Get-FileHash reshacker_setup.zip -Algorithm SHA256).Hash
+        if ($actualHash -ne $expectedHash) {
+          throw "reshacker_setup.zip SHA256 mismatch. Expected $expectedHash but got $actualHash"
+        }
         Expand-Archive -DestinationPath reshacker_setup reshacker_setup.zip
         reshacker_setup/reshacker_setup.exe /SILENT
         Start-Sleep -Seconds 60


### PR DESCRIPTION
### Motivation
- Mitigate a CI supply-chain risk where the Windows build job downloaded and executed an unverified Resource Hacker installer from an external URL, which could allow arbitrary code execution in CI and backdoor produced binaries.

### Description
- Add a pinned SHA-256 integrity check for `reshacker_setup.zip` in `.github/workflows/build-windows.yml` using `(Get-FileHash ...)` and throw an error to fail the step if the hash does not match the expected value, preserving the existing extraction and execution flow otherwise.

### Testing
- Verified by downloading the remote payload with `curl` and computing its SHA-256 with `sha256sum` (observed hash `e5a5b6d6be38ae3eb20e72b09f257f284bab2deb5f37164e9f2faefd23f27cf4`), confirmed the workflow file change via `git diff`, and attempted to run `actionlint` but the binary is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1bd4d3538832087a1ed1b57ebb44c)