### PR TITLE
Verify integrity of downloaded tools in Windows workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -58,7 +58,12 @@ jobs:
     - name: Add icon, manifest, and version info
       shell: pwsh
       run: |
+        $reshackerSha256 = "E5A5B6D6BE38AE3EB20E72B09F257F284BAB2DEB5F37164E9F2FAEFD23F27CF4"
         Invoke-WebRequest -OutFile reshacker_setup.zip https://github.com/user-attachments/files/18878075/reshacker_setup.zip
+        $actualReshackerSha256 = (Get-FileHash reshacker_setup.zip -Algorithm SHA256).Hash
+        if ($actualReshackerSha256 -ne $reshackerSha256) {
+          throw "reshacker_setup.zip hash mismatch: expected $reshackerSha256, got $actualReshackerSha256"
+        }
         Expand-Archive -DestinationPath reshacker_setup reshacker_setup.zip
         reshacker_setup/reshacker_setup.exe /SILENT
         Start-Sleep -Seconds 60
@@ -78,7 +83,12 @@ jobs:
     - name: Compress with upx
       shell: pwsh
       run: |
+        $upxSha256 = "41C7492EDEED0F7E67D347CA9E8D2131E2AF7CA7A7695F92283A8E655C251C13"
         Invoke-WebRequest -OutFile upx.zip https://github.com/upx/upx/releases/download/v5.1.0/upx-5.1.0-win64.zip
+        $actualUpxSha256 = (Get-FileHash upx.zip -Algorithm SHA256).Hash
+        if ($actualUpxSha256 -ne $upxSha256) {
+          throw "upx.zip hash mismatch: expected $upxSha256, got $actualUpxSha256"
+        }
         Expand-Archive -DestinationPath upx upx.zip
         upx/upx-5.1.0-win64/upx.exe --lzma -o src/Picocrypt-NG.exe src/5.exe
         upx/upx-5.1.0-win64/upx.exe --lzma src/Picocrypt-NG-cli.exe


### PR DESCRIPTION
### Motivation
- The Windows CI workflow downloaded and executed external tooling (`Resource Hacker` and `UPX`) without integrity checks, creating a supply-chain risk if those downloads are tampered with. 
- The change pins and verifies SHA-256 checksums before extracting or running any downloaded archives to ensure the build tools are authentic.

### Description
- Added SHA-256 pin variables and verification using `Get-FileHash` in `.github/workflows/build-windows.yml` for the `Add icon, manifest, and version info` step to validate `reshacker_setup.zip` before extraction/execution. 
- Added SHA-256 pin variables and verification using `Get-FileHash` in the `Compress with upx` step to validate `upx.zip` before extraction/execution. 
- The workflow now throws an explicit error and fails the job if any downloaded archive hash does not match the expected value, preserving the original build actions when downloads are authentic.

### Testing
- Downloaded both archives and computed current hashes with `curl -L --fail -o /tmp/reshacker_setup.zip <url> && sha256sum /tmp/reshacker_setup.zip` and `curl -L --fail -o /tmp/upx-5.1.0-win64.zip <url> && sha256sum /tmp/upx-5.1.0-win64.zip`, and pinned those SHA-256 values in the workflow; the downloads and hashing succeeded. 
- Verified the workflow diff with `git diff -- .github/workflows/build-windows.yml` and inspected the modified lines with `nl -ba .github/workflows/build-windows.yml | sed -n '52,100p'`; these checks succeeded. 
- Attempted YAML parse validation with a small Python snippet using `yaml.safe_load`, but `PyYAML` was not available in the environment so parser-based validation could not be run; manual inspection was used instead and shows a syntactically valid workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1bda70388832095cae182737c472c)