### PR TITLE
Harden remaining sec-fix follow-up paths and test coverage

### DIFF
--- a/.github/workflows/android-instrumented.yml
+++ b/.github/workflows/android-instrumented.yml
@@ -5,6 +5,15 @@ permissions:
 
 on:
   workflow_dispatch:
+    inputs:
+      test_scope:
+        description: Instrumented test scope
+        required: true
+        default: focused
+        type: choice
+        options:
+          - focused
+          - extended
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -110,7 +119,12 @@ jobs:
         api-level: 36
         arch: x86_64
         script: |
-          cd android && ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=io.github.picocrypt_ng.picocrypt_ng.ui.components.PasswordCardTest,io.github.picocrypt_ng.picocrypt_ng.ui.components.ProgressCardTest
+          cd android
+          TEST_CLASSES="io.github.picocrypt_ng.picocrypt_ng.ui.components.PasswordCardTest,io.github.picocrypt_ng.picocrypt_ng.ui.components.ProgressCardTest"
+          if [ "${{ inputs.test_scope }}" = "extended" ]; then
+            TEST_CLASSES="$TEST_CLASSES,io.github.picocrypt_ng.picocrypt_ng.OperationManagerIntegrationTest"
+          fi
+          ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class="$TEST_CLASSES"
 
     - name: Prepare artifacts
       run: |

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -77,6 +77,77 @@ jobs:
         echo "ORG_GRADLE_PROJECT_PICOCRYPT_VERSION_NAME=$VERSION" >> "$GITHUB_ENV"
         echo "ORG_GRADLE_PROJECT_PICOCRYPT_VERSION_CODE=$VERSION_CODE" >> "$GITHUB_ENV"
 
+    - name: Build Go Mobile AAR
+      working-directory: android
+      run: |
+        chmod +x build-gomobile.sh
+        ./build-gomobile.sh
+
+    - name: Make gradlew executable
+      working-directory: android
+      run: chmod +x gradlew
+
+    - name: Run Unit Tests
+      working-directory: android
+      run: ./gradlew test
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: build-android-gomobile
+        path: android/app/libs/picocrypt-mobile.aar
+        if-no-files-found: error
+        compression-level: 9
+
+  release:
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Download artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: build-android-gomobile
+        path: android/app/libs
+
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
+      with:
+        api-level: 36
+        build-tools: "36.0.0"
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        distribution: "temurin"
+        java-version: "17"
+
+    - name: Cache Gradle dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+          android/.gradle
+        key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/*.gradle*', 'android/gradle/wrapper/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Get version tag
+      run: |
+        VERSION=$(cat VERSION)
+        echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+        IFS='.' read -r major minor patch <<< "$VERSION"
+        major=${major:-0}
+        minor=${minor:-0}
+        patch=${patch:-0}
+        VERSION_CODE=$((10#$major * 10000 + 10#$minor * 100 + 10#$patch))
+        echo "ORG_GRADLE_PROJECT_PICOCRYPT_VERSION_NAME=$VERSION" >> "$GITHUB_ENV"
+        echo "ORG_GRADLE_PROJECT_PICOCRYPT_VERSION_CODE=$VERSION_CODE" >> "$GITHUB_ENV"
+
     - name: Decode Android signing keystore
       env:
         ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
@@ -96,19 +167,9 @@ jobs:
         echo "ORG_GRADLE_PROJECT_PICOCRYPT_KEY_ALIAS=$ANDROID_KEY_ALIAS" >> "$GITHUB_ENV"
         echo "ORG_GRADLE_PROJECT_PICOCRYPT_KEY_PASSWORD=$ANDROID_KEY_PASSWORD" >> "$GITHUB_ENV"
 
-    - name: Build Go Mobile AAR
-      working-directory: android
-      run: |
-        chmod +x build-gomobile.sh
-        ./build-gomobile.sh
-
     - name: Make gradlew executable
       working-directory: android
       run: chmod +x gradlew
-
-    - name: Run Unit Tests
-      working-directory: android
-      run: ./gradlew test
 
     - name: Build Signed Release APK
       working-directory: android
@@ -118,33 +179,6 @@ jobs:
       run: |
         mkdir -p out
         cp android/app/build/outputs/apk/release/app-release.apk out/Picocrypt-NG-android-release.apk
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v7
-      with:
-        name: build-android
-        path: out/*.apk
-        if-no-files-found: error
-        compression-level: 9
-
-  release:
-    needs: build
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Download artifact
-      uses: actions/download-artifact@v8
-      with:
-        name: build-android
-        path: out
-
-    - name: Get version tag
-      run: |
-        VERSION=$(cat VERSION)
-        echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
     - name: Generate checksums
       run: |

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,7 +1,7 @@
 name: build-android
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   push:
@@ -18,6 +18,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v6
 
@@ -124,6 +126,25 @@ jobs:
         path: out/*.apk
         if-no-files-found: error
         compression-level: 9
+
+  release:
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Download artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: build-android
+        path: out
+
+    - name: Get version tag
+      run: |
+        VERSION=$(cat VERSION)
+        echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
     - name: Generate checksums
       run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,7 +1,7 @@
 name: build-macos
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   push:
@@ -20,6 +20,8 @@ concurrency:
 jobs:
   build:
     runs-on: macos-26
+    permissions:
+      contents: read
     env:
       MACOSX_DEPLOYMENT_TARGET: "15.0"
       CGO_CFLAGS: "-mmacosx-version-min=15.0"
@@ -88,6 +90,20 @@ jobs:
         if-no-files-found: error
         compression-level: 9
 
+  release:
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Download artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: build-macos
+        path: artifacts/build-macos
+
     - name: Get version tag
       run: |
         VERSION=$(cat VERSION)
@@ -95,17 +111,17 @@ jobs:
 
     - name: Generate checksums
       run: |
-        HASH=$(shasum -a 256 Picocrypt-NG.dmg | cut -d ' ' -f1)
+        HASH=$(sha256sum artifacts/build-macos/Picocrypt-NG.dmg | cut -d ' ' -f1)
         echo "CHECKSUM_PICOCRYPT_NG=$HASH" >> $GITHUB_ENV
-        HASH_CLI=$(shasum -a 256 src/Picocrypt-NG-cli-macos | cut -d ' ' -f1)
+        HASH_CLI=$(sha256sum artifacts/build-macos/Picocrypt-NG-cli-macos | cut -d ' ' -f1)
         echo "CHECKSUM_PICOCRYPT_NG_CLI_MACOS=$HASH_CLI" >> $GITHUB_ENV
 
     - name: Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae
       with:
         files: |
-          Picocrypt-NG.dmg
-          src/Picocrypt-NG-cli-macos
+          artifacts/build-macos/Picocrypt-NG.dmg
+          artifacts/build-macos/Picocrypt-NG-cli-macos
         tag_name: ${{ env.VERSION }}
         make_latest: true
         append_body: true

--- a/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/MainActivityUITest.kt
+++ b/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/MainActivityUITest.kt
@@ -1,7 +1,11 @@
 package io.github.picocrypt_ng.picocrypt_ng
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
@@ -19,61 +23,20 @@ class MainActivityUITest {
     
     @Test
     fun mainActivity_displays_on_launch() {
-        // Activity should be launched automatically by createAndroidComposeRule
-        // Verify the main UI is displayed
         composeTestRule.onRoot().assertIsDisplayed()
     }
     
     @Test
-    fun mainActivity_displays_file_selection_ui() {
-        // Verify that file selection components are displayed
-        composeTestRule.onRoot().assertIsDisplayed()
-        
-        // The UI should be visible and interactive
-        // Note: Specific UI element testing depends on the actual implementation
-        // and may require test tags to be added to the composables
+    fun mainActivity_displays_logo_and_file_selection_ui() {
+        composeTestRule.onNodeWithContentDescription("logo icon").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("logo text").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Choose file").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Choose a file").assertIsDisplayed()
     }
     
     @Test
-    fun mainActivity_handles_form_state_updates() {
-        // Test that the activity responds to form state changes
-        // This is tested indirectly through the UI being displayed
-        composeTestRule.onRoot().assertIsDisplayed()
-    }
-    
-    @Test
-    fun mainActivity_displays_progress_during_operation() {
-        // Test that progress UI is displayed when an operation is active
-        // Note: This requires setting up an actual operation, which may need
-        // Go mobile bindings. For now, we verify the UI can be displayed.
-        composeTestRule.onRoot().assertIsDisplayed()
-    }
-    
-    @Test
-    fun mainActivity_displays_error_dialog_on_error() {
-        // Test that error dialogs are displayed when errors occur
-        // Note: This requires triggering an error condition
-        composeTestRule.onRoot().assertIsDisplayed()
-    }
-    
-    @Test
-    fun mainActivity_handles_operation_cancellation() {
-        // Test that the activity handles operation cancellation
-        // Note: This requires setting up an operation first
-        composeTestRule.onRoot().assertIsDisplayed()
-    }
-    
-    @Test
-    fun mainActivity_shows_encrypt_ui_for_non_pcv_files() {
-        // Test that encryption UI is shown when a non-.pcv file is selected
-        // Note: This requires file selection, which may need additional setup
-        composeTestRule.onRoot().assertIsDisplayed()
-    }
-    
-    @Test
-    fun mainActivity_shows_decrypt_ui_for_pcv_files() {
-        // Test that decryption UI is shown when a .pcv file is selected
-        // Note: This requires file selection, which may need additional setup
-        composeTestRule.onRoot().assertIsDisplayed()
+    fun mainActivity_hides_work_buttons_before_file_selection() {
+        composeTestRule.onAllNodesWithText("Encrypt File").assertCountEquals(0)
+        composeTestRule.onAllNodesWithText("Decrypt File").assertCountEquals(0)
     }
 }

--- a/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerIntegrationTest.kt
+++ b/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerIntegrationTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
@@ -132,48 +133,43 @@ class OperationManagerIntegrationTest {
         )
         
         val result = OperationManager.startEncrypt(context, formData)
-        
-        // Result may succeed or fail depending on Go mobile bindings availability
-        // But if it succeeds, operation state should be set
-        result.onSuccess { operationID ->
-            assertNotNull("Operation ID should not be null", operationID)
-            
-            val operationState = OperationManager.currentOperation.first()
-            assertNotNull("Operation state should be set", operationState)
-            assertEquals("Operation ID should match", operationID, operationState?.id)
-            assertEquals("Operation type should be ENCRYPT", OperationType.ENCRYPT, operationState?.type)
-            assertEquals("Input file should match", testFile.absolutePath, operationState?.inputFile)
-            assertNotNull("Output file should be set", operationState?.outputFile)
-            assertTrue("Output file should end with .pcv", operationState?.outputFile?.endsWith(".pcv") == true)
-        }
+
+        assertTrue("Encrypt should start successfully: ${result.exceptionOrNull()}", result.isSuccess)
+        val operationID = result.getOrThrow()
+
+        val operationState = OperationManager.currentOperation.first()
+        assertNotNull("Operation state should be set", operationState)
+        assertEquals("Operation ID should match", operationID, operationState?.id)
+        assertEquals("Operation type should be ENCRYPT", OperationType.ENCRYPT, operationState?.type)
+        assertEquals("Input file should match", testFile.absolutePath, operationState?.inputFile)
+        assertNotNull("Output file should be set", operationState?.outputFile)
+        assertTrue("Output file should end with .pcv", operationState?.outputFile?.endsWith(".pcv") == true)
     }
     
     @Test
     fun startDecrypt_creates_operation_state_on_success() = runTest {
-        // Create a test file
-        val internalDir = File(context.filesDir, "picocrypt_files")
-        internalDir.mkdirs()
-        val testFile = File(internalDir, "input_file.pcv")
-        testFile.writeText("test encrypted content")
-        
-        val formData = decryptFormData(
-            copiedFilePath = testFile.absolutePath,
-            password = "testpassword"
+        val password = "testpassword"
+        val encryptedFile = createEncryptedVolume(
+            sourceText = "test encrypted content",
+            password = password
         )
-        
+
+        val formData = decryptFormData(
+            copiedFilePath = encryptedFile.absolutePath,
+            password = password
+        )
+
         val result = OperationManager.startDecrypt(context, formData)
-        
-        // Result may succeed or fail depending on Go mobile bindings availability
-        result.onSuccess { operationID ->
-            assertNotNull("Operation ID should not be null", operationID)
-            
-            val operationState = OperationManager.currentOperation.first()
-            assertNotNull("Operation state should be set", operationState)
-            assertEquals("Operation ID should match", operationID, operationState?.id)
-            assertEquals("Operation type should be DECRYPT", OperationType.DECRYPT, operationState?.type)
-            assertEquals("Input file should match", testFile.absolutePath, operationState?.inputFile)
-            assertNotNull("Output file should be set", operationState?.outputFile)
-        }
+
+        assertTrue("Decrypt should start successfully: ${result.exceptionOrNull()}", result.isSuccess)
+        val operationID = result.getOrThrow()
+
+        val operationState = OperationManager.currentOperation.first()
+        assertNotNull("Operation state should be set", operationState)
+        assertEquals("Operation ID should match", operationID, operationState?.id)
+        assertEquals("Operation type should be DECRYPT", OperationType.DECRYPT, operationState?.type)
+        assertEquals("Input file should match", encryptedFile.absolutePath, operationState?.inputFile)
+        assertNotNull("Output file should be set", operationState?.outputFile)
     }
     
     @Test
@@ -281,5 +277,43 @@ class OperationManagerIntegrationTest {
         OperationManager.clearOperation(shouldCleanupFiles = false)
         operationState = OperationManager.currentOperation.first()
         assertNull("Should be null after clearing", operationState)
+    }
+
+    private suspend fun createEncryptedVolume(sourceText: String, password: String): File {
+        val internalDir = File(context.filesDir, "picocrypt_files")
+        internalDir.mkdirs()
+        val inputFile = File(internalDir, "integration_input.txt")
+        inputFile.writeText(sourceText)
+
+        val result = OperationManager.startEncrypt(
+            context,
+            encryptFormData(
+                copiedFilePath = inputFile.absolutePath,
+                password = password,
+                confirmPassword = password
+            )
+        )
+        assertTrue("Encrypt setup should start successfully: ${result.exceptionOrNull()}", result.isSuccess)
+
+        val completed = waitForOperationToFinish()
+        assertTrue("Encrypt setup operation should complete successfully", completed.done)
+        assertNull("Encrypt setup should not finish with error", completed.error)
+
+        val encryptedFile = File(completed.outputFile)
+        OperationManager.clearOperation(context, shouldCleanupFiles = false)
+
+        assertTrue("Encrypted file should exist for decrypt test", encryptedFile.exists())
+        return encryptedFile
+    }
+
+    private suspend fun waitForOperationToFinish(maxPolls: Int = 200): OperationState {
+        repeat(maxPolls) {
+            val state = OperationManager.pollProgress()
+            if (state != null && state.done) {
+                return state
+            }
+            delay(50)
+        }
+        throw AssertionError("Timed out waiting for operation to finish")
     }
 }

--- a/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerIntegrationTest.kt
+++ b/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerIntegrationTest.kt
@@ -177,16 +177,12 @@ class OperationManagerIntegrationTest {
     }
     
     @Test
-    fun pollProgress_updates_operation_state() = runTest {
-        // This test requires an active operation
-        // We'll test that pollProgress doesn't throw when called
-        // Full testing requires Go mobile bindings
-        
+    fun pollProgress_returns_null_without_active_operation() = runTest {
+        OperationManager.clearOperation(shouldCleanupFiles = false)
+
         val result = OperationManager.pollProgress()
-        
-        // Should return null if no operation, or OperationState if operation exists
-        // Should not throw
-        assertNotNull("Result should not be null (may be null if no operation)", result != null || result == null)
+
+        assertNull("pollProgress should return null when no operation is active", result)
     }
     
     @Test

--- a/src/internal/cli/tempdir.go
+++ b/src/internal/cli/tempdir.go
@@ -22,7 +22,7 @@ const (
 
 // ChooseTempDir selects an appropriate temp directory for buffering.
 // For known-size files: system temp > output dir > cwd > ~/.cache/picocrypt
-// For stdin (size=0): system temp > cache
+// For stdin (size=0): user cache > system temp
 // estimatedSize is the expected file size (0 for unknown stdin).
 // outputPath is used to determine the output directory as a fallback.
 func ChooseTempDir(estimatedSize int64, outputPath string) (string, error) {
@@ -103,16 +103,15 @@ func buildCandidates(outputPath string) []string {
 }
 
 // buildCandidatesForStdin returns user-scoped candidates for stdin buffering.
-// Avoid output dir/CWD because stdin plaintext should not be buffered there.
+// Prefer the user cache before system temp so stdin plaintext avoids shared temp
+// locations when possible. Output dir/CWD are intentionally excluded.
 func buildCandidatesForStdin(outputPath string) []string {
 	_ = outputPath
-	candidates := []string{os.TempDir()}
-
 	if cacheDir, err := userCacheDir(); err == nil {
-		candidates = append(candidates, cacheDir)
+		return []string{cacheDir, os.TempDir()}
 	}
 
-	return candidates
+	return []string{os.TempDir()}
 }
 
 // userCacheDir returns platform-specific cache dir, creating it if needed.

--- a/src/internal/cli/tempdir_test.go
+++ b/src/internal/cli/tempdir_test.go
@@ -195,17 +195,15 @@ func TestBuildCandidatesForStdin(t *testing.T) {
 		t.Errorf("expected at least 2 candidates, got %d", len(candidates))
 	}
 
-	// First should be system temp
-	if candidates[0] != os.TempDir() {
-		t.Errorf("first candidate should be os.TempDir(), got %s", candidates[0])
-	}
-
 	cacheDir, err := userCacheDir()
 	if err != nil {
 		t.Fatalf("userCacheDir() error = %v", err)
 	}
-	if candidates[1] != cacheDir {
-		t.Errorf("second candidate should be user cache dir %s, got %s", cacheDir, candidates[1])
+	if candidates[0] != cacheDir {
+		t.Errorf("first candidate should be user cache dir %s, got %s", cacheDir, candidates[0])
+	}
+	if candidates[1] != os.TempDir() {
+		t.Errorf("second candidate should be os.TempDir(), got %s", candidates[1])
 	}
 
 	disallowed := map[string]bool{
@@ -228,16 +226,15 @@ func TestBuildCandidatesForStdin_NoOutput(t *testing.T) {
 		t.Errorf("expected at least 2 candidates, got %d", len(candidates))
 	}
 
-	if candidates[0] != os.TempDir() {
-		t.Errorf("first candidate should be os.TempDir(), got %s", candidates[0])
-	}
-
 	cacheDir, err := userCacheDir()
 	if err != nil {
 		t.Fatalf("userCacheDir() error = %v", err)
 	}
-	if candidates[1] != cacheDir {
-		t.Errorf("second candidate should be user cache dir %s, got %s", cacheDir, candidates[1])
+	if candidates[0] != cacheDir {
+		t.Errorf("first candidate should be user cache dir %s, got %s", cacheDir, candidates[0])
+	}
+	if candidates[1] != os.TempDir() {
+		t.Errorf("second candidate should be os.TempDir(), got %s", candidates[1])
 	}
 }
 
@@ -251,12 +248,16 @@ func TestBuildCandidatesForStdin_StdoutOutput(t *testing.T) {
 		}
 	}
 
-	if candidates[0] != os.TempDir() {
-		t.Errorf("first candidate should be os.TempDir(), got %s", candidates[0])
+	cacheDir, err := userCacheDir()
+	if err != nil {
+		t.Fatalf("userCacheDir() error = %v", err)
+	}
+	if candidates[0] != cacheDir {
+		t.Errorf("first candidate should be user cache dir %s, got %s", cacheDir, candidates[0])
 	}
 }
 
-func TestChooseTempDir_StdinPrefersSystemTemp(t *testing.T) {
+func TestChooseTempDir_StdinPrefersUserCache(t *testing.T) {
 	TempDirOverride = ""
 
 	// Create a writable temp dir to simulate output location
@@ -269,9 +270,12 @@ func TestChooseTempDir_StdinPrefersSystemTemp(t *testing.T) {
 		t.Fatalf("ChooseTempDir() error = %v", err)
 	}
 
-	// Should prefer system temp for stdin when available
-	if dir != os.TempDir() {
-		t.Errorf("stdin mode should prefer system temp %s, got %s", os.TempDir(), dir)
+	cacheDir, err := userCacheDir()
+	if err != nil {
+		t.Fatalf("userCacheDir() error = %v", err)
+	}
+	if dir != cacheDir {
+		t.Errorf("stdin mode should prefer user cache %s, got %s", cacheDir, dir)
 	}
 }
 

--- a/src/internal/fileops/chunks_test.go
+++ b/src/internal/fileops/chunks_test.go
@@ -30,6 +30,7 @@ func TestSplitChunkBase(t *testing.T) {
 	}{
 		{path: "/tmp/archive.zip.pcv.0", want: "/tmp/archive.zip.pcv", ok: true},
 		{path: "/tmp/ARCHIVE.ZIP.PCV.0", want: "/tmp/ARCHIVE.ZIP.PCV", ok: true},
+		{path: "/tmp/dir.pcv.0/file.pcv.1", want: "/tmp/dir.pcv.0/file.pcv", ok: true},
 		{path: "/tmp/backup.pcv.tmp1", want: "", ok: false},
 	}
 

--- a/src/internal/fileops/diskspace.go
+++ b/src/internal/fileops/diskspace.go
@@ -1,0 +1,3 @@
+package fileops
+
+var availableExtractionSpace = availableSpace

--- a/src/internal/fileops/diskspace.go
+++ b/src/internal/fileops/diskspace.go
@@ -1,3 +1,0 @@
-package fileops
-
-var availableExtractionSpace = availableSpace

--- a/src/internal/fileops/diskspace_openbsd.go
+++ b/src/internal/fileops/diskspace_openbsd.go
@@ -1,0 +1,26 @@
+//go:build openbsd
+
+package fileops
+
+import (
+	"errors"
+	"math"
+
+	"golang.org/x/sys/unix"
+)
+
+func availableSpace(path string) (int64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	blocks := int64(stat.F_bavail)
+	bsize := int64(stat.F_bsize)
+	if blocks < 0 || bsize <= 0 {
+		return 0, errors.New("invalid filesystem stats")
+	}
+	if blocks > math.MaxInt64/bsize {
+		return 0, errors.New("available space exceeds int64 max")
+	}
+	return blocks * bsize, nil
+}

--- a/src/internal/fileops/diskspace_unix.go
+++ b/src/internal/fileops/diskspace_unix.go
@@ -1,0 +1,26 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || solaris
+
+package fileops
+
+import (
+	"errors"
+	"math"
+
+	"golang.org/x/sys/unix"
+)
+
+func availableSpace(path string) (int64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	if stat.Bavail > uint64(math.MaxInt64) {
+		return 0, errors.New("available blocks exceeds int64 max")
+	}
+	blocks := int64(stat.Bavail)
+	bsize := int64(stat.Bsize)
+	if bsize > 0 && blocks > math.MaxInt64/bsize {
+		return 0, errors.New("available space exceeds int64 max")
+	}
+	return blocks * bsize, nil
+}

--- a/src/internal/fileops/diskspace_wasm.go
+++ b/src/internal/fileops/diskspace_wasm.go
@@ -1,0 +1,9 @@
+//go:build wasm
+
+package fileops
+
+import "errors"
+
+func availableSpace(_ string) (int64, error) {
+	return 0, errors.New("disk space check not supported in WASM")
+}

--- a/src/internal/fileops/diskspace_windows.go
+++ b/src/internal/fileops/diskspace_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package fileops
+
+import (
+	"errors"
+	"math"
+
+	"golang.org/x/sys/windows"
+)
+
+func availableSpace(path string) (int64, error) {
+	var freeBytesAvailable, totalBytes, totalFreeBytes uint64
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	err = windows.GetDiskFreeSpaceEx(pathPtr, &freeBytesAvailable, &totalBytes, &totalFreeBytes)
+	if err != nil {
+		return 0, err
+	}
+	if freeBytesAvailable > uint64(math.MaxInt64) {
+		return 0, errors.New("available space exceeds int64 max")
+	}
+	return int64(freeBytesAvailable), nil
+}

--- a/src/internal/fileops/unpack.go
+++ b/src/internal/fileops/unpack.go
@@ -260,6 +260,9 @@ func Unpack(opts UnpackOptions) (retErr error) {
 	if err != nil {
 		return err
 	}
+	if available, err := availableExtractionSpace(extractDir); err == nil && totalSize > available {
+		return fmt.Errorf("insufficient disk space for extraction: need %d bytes, have %d", totalSize, available)
+	}
 
 	// First pass: create all directories and cache normalized paths
 	// Cache normalized paths to avoid redundant normalization in second pass

--- a/src/internal/fileops/unpack.go
+++ b/src/internal/fileops/unpack.go
@@ -16,12 +16,13 @@ import (
 
 // UnpackOptions configures archive extraction
 type UnpackOptions struct {
-	ZipPath    string // Path to .zip file
-	ExtractDir string // Directory to extract to (empty = same as zip, minus .zip)
-	SameLevel  bool   // Extract to same directory as zip (not a subdirectory)
-	Progress   ProgressFunc
-	Status     StatusFunc
-	Cancel     CancelFunc // Cancellation check callback (optional)
+	ZipPath        string // Path to .zip file
+	ExtractDir     string // Directory to extract to (empty = same as zip, minus .zip)
+	SameLevel      bool   // Extract to same directory as zip (not a subdirectory)
+	Progress       ProgressFunc
+	Status         StatusFunc
+	Cancel         CancelFunc                  // Cancellation check callback (optional)
+	AvailableSpace func(string) (int64, error) // Override free-space probe (optional, mainly for tests)
 }
 
 // normalizeZipPath normalizes a path from a zip file by converting all separators
@@ -260,13 +261,11 @@ func Unpack(opts UnpackOptions) (retErr error) {
 	if err != nil {
 		return err
 	}
-	if available, err := availableExtractionSpace(extractDir); err == nil && totalSize > available {
-		return fmt.Errorf("insufficient disk space for extraction: need %d bytes, have %d", totalSize, available)
-	}
 
 	// First pass: create all directories and cache normalized paths
 	// Cache normalized paths to avoid redundant normalization in second pass
 	normalizedPaths := make(map[*zip.File]string, len(reader.File))
+	desiredSizes := make(map[string]int64)
 	for _, f := range reader.File {
 		// Normalize and validate path to prevent zip slip attacks
 		if hasUnsafeWindowsTrimTraversalComponent(f.Name) {
@@ -281,7 +280,28 @@ func Unpack(opts UnpackOptions) (retErr error) {
 		// Cache the output path for second pass
 		normalizedPaths[f] = outPath
 
-		// Directory entries are created by prepareExtractionPath().
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		size, ok := util.SafeUint64ToInt64(f.UncompressedSize64)
+		if !ok {
+			return fmt.Errorf("file %s: uncompressed size exceeds int64 max", f.Name)
+		}
+		if size > desiredSizes[outPath] {
+			desiredSizes[outPath] = size
+		}
+	}
+
+	requiredAdditionalBytes, err := requiredAdditionalBytesForExtraction(desiredSizes)
+	if err != nil {
+		return err
+	}
+	probe := opts.AvailableSpace
+	if probe == nil {
+		probe = availableSpace
+	}
+	if available, err := probe(extractDir); err == nil && requiredAdditionalBytes > available {
+		return fmt.Errorf("insufficient disk space for extraction: need %d bytes, have %d", requiredAdditionalBytes, available)
 	}
 
 	// Second pass: extract files

--- a/src/internal/fileops/unpack_space.go
+++ b/src/internal/fileops/unpack_space.go
@@ -1,0 +1,43 @@
+package fileops
+
+import (
+	"fmt"
+	"math"
+	"os"
+)
+
+func requiredAdditionalBytesForExtraction(desiredSizes map[string]int64) (int64, error) {
+	var required int64
+	for path, desiredSize := range desiredSizes {
+		existingSize, err := existingExtractionFileSize(path)
+		if err != nil {
+			return 0, err
+		}
+		if desiredSize <= existingSize {
+			continue
+		}
+
+		delta := desiredSize - existingSize
+		if required > math.MaxInt64-delta {
+			return 0, fmt.Errorf("required extraction size exceeds int64 max")
+		}
+		required += delta
+	}
+	return required, nil
+}
+
+func existingExtractionFileSize(path string) (int64, error) {
+	info, err := os.Lstat(path)
+	switch {
+	case os.IsNotExist(err):
+		return 0, nil
+	case err != nil:
+		return 0, err
+	case info.Mode()&os.ModeSymlink != 0:
+		return 0, fmt.Errorf("refusing to stat symlink during extraction: %s", path)
+	case info.IsDir():
+		return 0, fmt.Errorf("path exists as directory: %s", path)
+	default:
+		return info.Size(), nil
+	}
+}

--- a/src/internal/fileops/unpack_test.go
+++ b/src/internal/fileops/unpack_test.go
@@ -3,6 +3,7 @@ package fileops
 import (
 	"archive/zip"
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -233,6 +234,63 @@ func TestUnpackRejectsHighlyCompressedFileAboveFloor(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "decompression limit exceeded") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUnpackRejectsArchiveWhenDeclaredSizeExceedsAvailableSpace(t *testing.T) {
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "space-check.zip")
+	data := []byte("payload requiring space")
+	createDeflatedZipWithContent(t, zipPath, "payload.txt", data)
+
+	originalAvailableSpace := availableExtractionSpace
+	availableExtractionSpace = func(path string) (int64, error) {
+		return int64(len(data) - 1), nil
+	}
+	defer func() {
+		availableExtractionSpace = originalAvailableSpace
+	}()
+
+	err := Unpack(UnpackOptions{
+		ZipPath:    zipPath,
+		ExtractDir: filepath.Join(tmpDir, "out"),
+	})
+	if err == nil {
+		t.Fatal("expected insufficient disk space error")
+	}
+	if !strings.Contains(err.Error(), "insufficient disk space") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUnpackSkipsDiskSpaceGuardWhenSpaceCheckUnavailable(t *testing.T) {
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "space-check-fallback.zip")
+	data := []byte("payload requiring fallback")
+	createDeflatedZipWithContent(t, zipPath, "payload.txt", data)
+
+	originalAvailableSpace := availableExtractionSpace
+	availableExtractionSpace = func(path string) (int64, error) {
+		return 0, errors.New("statfs unavailable")
+	}
+	defer func() {
+		availableExtractionSpace = originalAvailableSpace
+	}()
+
+	extractDir := filepath.Join(tmpDir, "out")
+	if err := Unpack(UnpackOptions{
+		ZipPath:    zipPath,
+		ExtractDir: extractDir,
+	}); err != nil {
+		t.Fatalf("Unpack should fall back to existing ratio guard when disk space is unavailable: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(extractDir, "payload.txt"))
+	if err != nil {
+		t.Fatalf("Read unpacked file: %v", err)
+	}
+	if !bytes.Equal(content, data) {
+		t.Fatal("unpacked content mismatch")
 	}
 }
 

--- a/src/internal/fileops/unpack_test.go
+++ b/src/internal/fileops/unpack_test.go
@@ -243,17 +243,12 @@ func TestUnpackRejectsArchiveWhenDeclaredSizeExceedsAvailableSpace(t *testing.T)
 	data := []byte("payload requiring space")
 	createDeflatedZipWithContent(t, zipPath, "payload.txt", data)
 
-	originalAvailableSpace := availableExtractionSpace
-	availableExtractionSpace = func(path string) (int64, error) {
-		return int64(len(data) - 1), nil
-	}
-	defer func() {
-		availableExtractionSpace = originalAvailableSpace
-	}()
-
 	err := Unpack(UnpackOptions{
 		ZipPath:    zipPath,
 		ExtractDir: filepath.Join(tmpDir, "out"),
+		AvailableSpace: func(path string) (int64, error) {
+			return int64(len(data) - 1), nil
+		},
 	})
 	if err == nil {
 		t.Fatal("expected insufficient disk space error")
@@ -269,18 +264,13 @@ func TestUnpackSkipsDiskSpaceGuardWhenSpaceCheckUnavailable(t *testing.T) {
 	data := []byte("payload requiring fallback")
 	createDeflatedZipWithContent(t, zipPath, "payload.txt", data)
 
-	originalAvailableSpace := availableExtractionSpace
-	availableExtractionSpace = func(path string) (int64, error) {
-		return 0, errors.New("statfs unavailable")
-	}
-	defer func() {
-		availableExtractionSpace = originalAvailableSpace
-	}()
-
 	extractDir := filepath.Join(tmpDir, "out")
 	if err := Unpack(UnpackOptions{
 		ZipPath:    zipPath,
 		ExtractDir: extractDir,
+		AvailableSpace: func(path string) (int64, error) {
+			return 0, errors.New("statfs unavailable")
+		},
 	}); err != nil {
 		t.Fatalf("Unpack should fall back to existing ratio guard when disk space is unavailable: %v", err)
 	}
@@ -291,6 +281,40 @@ func TestUnpackSkipsDiskSpaceGuardWhenSpaceCheckUnavailable(t *testing.T) {
 	}
 	if !bytes.Equal(content, data) {
 		t.Fatal("unpacked content mismatch")
+	}
+}
+
+func TestUnpackAllowsOverwriteWhenNetNewUsageFits(t *testing.T) {
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "space-overwrite.zip")
+	data := []byte("replacement payload")
+	createDeflatedZipWithContent(t, zipPath, "payload.txt", data)
+
+	extractDir := filepath.Join(tmpDir, "out")
+	if err := os.MkdirAll(extractDir, 0700); err != nil {
+		t.Fatalf("Create extract dir: %v", err)
+	}
+	existingPath := filepath.Join(extractDir, "payload.txt")
+	if err := os.WriteFile(existingPath, bytes.Repeat([]byte("x"), len(data)+8), 0600); err != nil {
+		t.Fatalf("Create existing file: %v", err)
+	}
+
+	if err := Unpack(UnpackOptions{
+		ZipPath:    zipPath,
+		ExtractDir: extractDir,
+		AvailableSpace: func(path string) (int64, error) {
+			return 0, nil
+		},
+	}); err != nil {
+		t.Fatalf("Unpack should allow overwrite when net-new usage fits: %v", err)
+	}
+
+	content, err := os.ReadFile(existingPath)
+	if err != nil {
+		t.Fatalf("Read overwritten file: %v", err)
+	}
+	if !bytes.Equal(content, data) {
+		t.Fatal("overwritten content mismatch")
 	}
 }
 

--- a/src/internal/ui/advanced_section_test.go
+++ b/src/internal/ui/advanced_section_test.go
@@ -6,12 +6,10 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
-	"fyne.io/fyne/v2/test"
 )
 
 func TestBuildEncryptOptionsDoNotUseTooltipCheckboxes(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	a := createTestApp(t)
 	a.advancedContainer = container.NewVBox()
@@ -24,8 +22,7 @@ func TestBuildEncryptOptionsDoNotUseTooltipCheckboxes(t *testing.T) {
 }
 
 func TestBuildDecryptOptionsDoNotUseTooltipCheckboxes(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	a := createTestApp(t)
 	a.advancedContainer = container.NewVBox()
@@ -39,8 +36,7 @@ func TestBuildDecryptOptionsDoNotUseTooltipCheckboxes(t *testing.T) {
 }
 
 func TestBuildMobileEncryptOptionsDoNotUseTooltipCheckboxes(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	a := createTestApp(t)
 	a.advancedContainer = container.NewVBox()
@@ -53,8 +49,7 @@ func TestBuildMobileEncryptOptionsDoNotUseTooltipCheckboxes(t *testing.T) {
 }
 
 func TestBuildMobileDecryptOptionsDoNotUseTooltipCheckboxes(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	a := createTestApp(t)
 	a.advancedContainer = container.NewVBox()

--- a/src/internal/ui/app.go
+++ b/src/internal/ui/app.go
@@ -447,7 +447,7 @@ func (a *App) refreshAdvanced() {
 // This mirrors the exact logic from the original giu implementation.
 func (a *App) updateUIState() {
 	hasFiles := len(a.State.AllFiles) > 0 || len(a.State.OnlyFiles) > 0 || len(a.State.OnlyFolders) > 0
-	isScanning := a.State.Scanning
+	isScanning := a.State.IsScanning()
 
 	// Main content disabled - matches giu: (len(allFiles) == 0 && len(onlyFiles) == 0) || scanning
 	// Note: we also check onlyFolders for consistency

--- a/src/internal/ui/drop.go
+++ b/src/internal/ui/drop.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	dropScanBatchSize       = 128
-	dropScanFlushInterval   = 50 * time.Millisecond
-	startupPathAccessStatus = "Failed to access startup path"
+	dropScanBatchSize              = 128
+	dropScanFlushInterval          = 50 * time.Millisecond
+	startupPathAccessStatus        = "Failed to access startup path"
+	startupPathPartialAccessStatus = "Some startup paths could not be accessed"
 )
 
 type scannedFile struct {
@@ -74,10 +75,18 @@ func (a *App) applyStartupPaths(paths []string) {
 
 	a.onDrop(validPaths)
 	if err != nil {
-		a.State.MainStatus = startupPathAccessStatus
+		a.State.MainStatus = startupPathPartialAccessStatus
 		a.State.MainStatusColor = util.YELLOW
 		a.refreshUI()
 	}
+}
+
+func (a *App) applyFolderWalkError() {
+	a.State.SetScanning(false)
+	a.resetUI()
+	a.State.MainStatus = "Failed to walk through dropped items"
+	a.State.MainStatusColor = util.RED
+	a.refreshUI()
 }
 
 func (a *App) appendScannedFiles(files []scannedFile) {
@@ -207,14 +216,10 @@ func (a *App) onDrop(names []string) {
 
 		for _, name := range a.State.OnlyFolders {
 			if filepath.Walk(name, func(path string, info os.FileInfo, err error) error {
-					if err != nil {
-						fyne.DoAndWait(func() {
-							a.State.SetScanning(false)
-							a.resetUI()
-							a.State.MainStatus = "Failed to walk through dropped items"
-							a.State.MainStatusColor = util.RED
-							a.refreshUI()
-						})
+				if err != nil {
+					fyne.DoAndWait(func() {
+						a.applyFolderWalkError()
+					})
 					return err
 				}
 				// If 'path' is a valid regular file, add to 'allFiles'
@@ -226,14 +231,10 @@ func (a *App) onDrop(names []string) {
 					}
 				}
 				return nil
-				}) != nil {
-					fyne.DoAndWait(func() {
-						a.State.SetScanning(false)
-						a.resetUI()
-						a.State.MainStatus = "Failed to walk through dropped items"
-						a.State.MainStatusColor = util.RED
-						a.refreshUI()
-					})
+			}) != nil {
+				fyne.DoAndWait(func() {
+					a.applyFolderWalkError()
+				})
 				return
 			}
 		}

--- a/src/internal/ui/drop.go
+++ b/src/internal/ui/drop.go
@@ -73,6 +73,11 @@ func (a *App) applyStartupPaths(paths []string) {
 	}
 
 	a.onDrop(validPaths)
+	if err != nil {
+		a.State.MainStatus = startupPathAccessStatus
+		a.State.MainStatusColor = util.YELLOW
+		a.refreshUI()
+	}
 }
 
 func (a *App) appendScannedFiles(files []scannedFile) {

--- a/src/internal/ui/drop.go
+++ b/src/internal/ui/drop.go
@@ -202,13 +202,14 @@ func (a *App) onDrop(names []string) {
 
 		for _, name := range a.State.OnlyFolders {
 			if filepath.Walk(name, func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					fyne.DoAndWait(func() {
-						a.resetUI()
-						a.State.MainStatus = "Failed to walk through dropped items"
-						a.State.MainStatusColor = util.RED
-						a.refreshUI()
-					})
+					if err != nil {
+						fyne.DoAndWait(func() {
+							a.State.SetScanning(false)
+							a.resetUI()
+							a.State.MainStatus = "Failed to walk through dropped items"
+							a.State.MainStatusColor = util.RED
+							a.refreshUI()
+						})
 					return err
 				}
 				// If 'path' is a valid regular file, add to 'allFiles'
@@ -220,13 +221,14 @@ func (a *App) onDrop(names []string) {
 					}
 				}
 				return nil
-			}) != nil {
-				fyne.DoAndWait(func() {
-					a.resetUI()
-					a.State.MainStatus = "Failed to walk through dropped items"
-					a.State.MainStatusColor = util.RED
-					a.refreshUI()
-				})
+				}) != nil {
+					fyne.DoAndWait(func() {
+						a.State.SetScanning(false)
+						a.resetUI()
+						a.State.MainStatus = "Failed to walk through dropped items"
+						a.State.MainStatusColor = util.RED
+						a.refreshUI()
+					})
 				return
 			}
 		}

--- a/src/internal/ui/drop_test.go
+++ b/src/internal/ui/drop_test.go
@@ -466,8 +466,8 @@ func TestApplyStartupPathsPreservesPartialAccessWarning(t *testing.T) {
 	if state.InputFile != inputFile {
 		t.Fatalf("InputFile = %q; want %q", state.InputFile, inputFile)
 	}
-	if state.MainStatus != startupPathAccessStatus {
-		t.Fatalf("MainStatus = %q; want %q", state.MainStatus, startupPathAccessStatus)
+	if state.MainStatus != startupPathPartialAccessStatus {
+		t.Fatalf("MainStatus = %q; want %q", state.MainStatus, startupPathPartialAccessStatus)
 	}
 }
 

--- a/src/internal/ui/drop_test.go
+++ b/src/internal/ui/drop_test.go
@@ -17,7 +17,6 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
-	"fyne.io/fyne/v2/test"
 )
 
 // TestFileTypeDetection tests detection of encrypted vs plain files.
@@ -282,8 +281,7 @@ func TestApplyDropErrorPreservesStatusAfterReset(t *testing.T) {
 }
 
 func TestApplyStartupPathsLoadsInitialFiles(t *testing.T) {
-	fyneApp := test.NewApp()
-	defer fyneApp.Quit()
+	fyneApp := newTestFyneApp(t)
 
 	a := createUIReadyDropTestApp(t, fyneApp)
 	inputFile := filepath.Join(t.TempDir(), "report.txt")
@@ -315,8 +313,7 @@ func TestApplyStartupPathsLoadsInitialFiles(t *testing.T) {
 }
 
 func TestApplyStartupPathsIgnoresMacOSProcessSerialNumber(t *testing.T) {
-	fyneApp := test.NewApp()
-	defer fyneApp.Quit()
+	fyneApp := newTestFyneApp(t)
 
 	a := createUIReadyDropTestApp(t, fyneApp)
 
@@ -337,8 +334,7 @@ func TestApplyStartupPathsIgnoresMacOSProcessSerialNumber(t *testing.T) {
 }
 
 func TestApplyStartupPathsIgnoresMissingNonFlagArgs(t *testing.T) {
-	fyneApp := test.NewApp()
-	defer fyneApp.Quit()
+	fyneApp := newTestFyneApp(t)
 
 	a := createUIReadyDropTestApp(t, fyneApp)
 
@@ -356,8 +352,7 @@ func TestApplyStartupPathsIgnoresMissingNonFlagArgs(t *testing.T) {
 }
 
 func TestApplyStartupPathsSkipsInvalidArgsWhenValidPathsRemain(t *testing.T) {
-	fyneApp := test.NewApp()
-	defer fyneApp.Quit()
+	fyneApp := newTestFyneApp(t)
 
 	a := createUIReadyDropTestApp(t, fyneApp)
 	tempDir := t.TempDir()
@@ -385,8 +380,7 @@ func TestApplyStartupPathsSkipsInvalidArgsWhenValidPathsRemain(t *testing.T) {
 }
 
 func TestApplyStartupPathsAllowsHyphenPrefixedFilename(t *testing.T) {
-	fyneApp := test.NewApp()
-	defer fyneApp.Quit()
+	fyneApp := newTestFyneApp(t)
 
 	a := createUIReadyDropTestApp(t, fyneApp)
 	inputFile := filepath.Join(t.TempDir(), "-secret.txt")
@@ -409,8 +403,7 @@ func TestApplyStartupPathsAllowsHyphenPrefixedFilename(t *testing.T) {
 }
 
 func TestApplyStartupPathsReportsAccessError(t *testing.T) {
-	fyneApp := test.NewApp()
-	defer fyneApp.Quit()
+	fyneApp := newTestFyneApp(t)
 
 	a := createUIReadyDropTestApp(t, fyneApp)
 	originalStat := startupPathStat
@@ -434,8 +427,7 @@ func TestApplyStartupPathsReportsAccessError(t *testing.T) {
 }
 
 func TestApplyStartupPathsPreservesPartialAccessWarning(t *testing.T) {
-	fyneApp := test.NewApp()
-	defer fyneApp.Quit()
+	fyneApp := newTestFyneApp(t)
 
 	a := createUIReadyDropTestApp(t, fyneApp)
 	inputFile := filepath.Join(t.TempDir(), "report.txt")
@@ -506,8 +498,7 @@ func TestCollectStartupPathsSkipsMissingAndReportsAccessError(t *testing.T) {
 }
 
 func TestAppendScannedFilesUpdatesState(t *testing.T) {
-	fyneApp := test.NewApp()
-	defer fyneApp.Quit()
+	fyneApp := newTestFyneApp(t)
 
 	a := createUIReadyDropTestApp(t, fyneApp)
 
@@ -540,8 +531,7 @@ func TestFolderWalkErrorClearsScanningState(t *testing.T) {
 		t.Skip("permission-based walk failure setup is not reliable on Windows")
 	}
 
-	fyneApp := test.NewApp()
-	defer fyneApp.Quit()
+	fyneApp := newTestFyneApp(t)
 
 	a := createUIReadyDropTestApp(t, fyneApp)
 	rootDir := t.TempDir()
@@ -575,8 +565,7 @@ func TestFolderWalkErrorClearsScanningState(t *testing.T) {
 }
 
 func TestScheduleStartupPathsDefersUntilLifecycleStart(t *testing.T) {
-	fyneApp := test.NewApp()
-	defer fyneApp.Quit()
+	fyneApp := newTestFyneApp(t)
 
 	a := createUIReadyDropTestApp(t, fyneApp)
 	inputFile := filepath.Join(t.TempDir(), "startup.txt")
@@ -998,34 +987,36 @@ func snapshotDropState(t *testing.T, a *App) dropStateSnapshot {
 }
 
 type lifecycleCaptureApp struct {
-	driver   fyne.Driver
-	started  func()
-	stopped  func()
-	bg       func()
-	fg       func()
+	driver  fyne.Driver
+	started func()
+	stopped func()
+	bg      func()
+	fg      func()
 }
 
 func newLifecycleCaptureApp(base fyne.App) *lifecycleCaptureApp {
 	return &lifecycleCaptureApp{driver: base.Driver()}
 }
 
-func (a *lifecycleCaptureApp) NewWindow(title string) fyne.Window { return fyne.CurrentApp().NewWindow(title) }
-func (a *lifecycleCaptureApp) OpenURL(*url.URL) error             { return nil }
-func (a *lifecycleCaptureApp) Icon() fyne.Resource                { return nil }
-func (a *lifecycleCaptureApp) SetIcon(fyne.Resource)              {}
-func (a *lifecycleCaptureApp) Run()                               {}
-func (a *lifecycleCaptureApp) Quit()                              {}
-func (a *lifecycleCaptureApp) Driver() fyne.Driver                { return a.driver }
-func (a *lifecycleCaptureApp) UniqueID() string                   { return "lifecycle-capture-app" }
+func (a *lifecycleCaptureApp) NewWindow(title string) fyne.Window {
+	return fyne.CurrentApp().NewWindow(title)
+}
+func (a *lifecycleCaptureApp) OpenURL(*url.URL) error              { return nil }
+func (a *lifecycleCaptureApp) Icon() fyne.Resource                 { return nil }
+func (a *lifecycleCaptureApp) SetIcon(fyne.Resource)               {}
+func (a *lifecycleCaptureApp) Run()                                {}
+func (a *lifecycleCaptureApp) Quit()                               {}
+func (a *lifecycleCaptureApp) Driver() fyne.Driver                 { return a.driver }
+func (a *lifecycleCaptureApp) UniqueID() string                    { return "lifecycle-capture-app" }
 func (a *lifecycleCaptureApp) SendNotification(*fyne.Notification) {}
-func (a *lifecycleCaptureApp) Settings() fyne.Settings            { return fyne.CurrentApp().Settings() }
-func (a *lifecycleCaptureApp) Preferences() fyne.Preferences      { return fyne.CurrentApp().Preferences() }
-func (a *lifecycleCaptureApp) Storage() fyne.Storage              { return fyne.CurrentApp().Storage() }
-func (a *lifecycleCaptureApp) Lifecycle() fyne.Lifecycle          { return a }
-func (a *lifecycleCaptureApp) Metadata() fyne.AppMetadata         { return fyne.AppMetadata{} }
-func (a *lifecycleCaptureApp) CloudProvider() fyne.CloudProvider  { return nil }
+func (a *lifecycleCaptureApp) Settings() fyne.Settings             { return fyne.CurrentApp().Settings() }
+func (a *lifecycleCaptureApp) Preferences() fyne.Preferences       { return fyne.CurrentApp().Preferences() }
+func (a *lifecycleCaptureApp) Storage() fyne.Storage               { return fyne.CurrentApp().Storage() }
+func (a *lifecycleCaptureApp) Lifecycle() fyne.Lifecycle           { return a }
+func (a *lifecycleCaptureApp) Metadata() fyne.AppMetadata          { return fyne.AppMetadata{} }
+func (a *lifecycleCaptureApp) CloudProvider() fyne.CloudProvider   { return nil }
 func (a *lifecycleCaptureApp) SetCloudProvider(fyne.CloudProvider) {}
-func (a *lifecycleCaptureApp) Clipboard() fyne.Clipboard          { return fyne.CurrentApp().Clipboard() }
+func (a *lifecycleCaptureApp) Clipboard() fyne.Clipboard           { return fyne.CurrentApp().Clipboard() }
 
 func (a *lifecycleCaptureApp) SetOnEnteredForeground(fn func()) { a.fg = fn }
 func (a *lifecycleCaptureApp) SetOnExitedForeground(fn func())  { a.bg = fn }

--- a/src/internal/ui/drop_test.go
+++ b/src/internal/ui/drop_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -494,6 +495,45 @@ func TestAppendScannedFilesUpdatesState(t *testing.T) {
 	}
 	if !strings.Contains(a.State.InputLabel, "35") && !strings.Contains(a.State.InputLabel, "B") {
 		t.Fatalf("InputLabel = %q; want size summary", a.State.InputLabel)
+	}
+}
+
+func TestFolderWalkErrorClearsScanningState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-based walk failure setup is not reliable on Windows")
+	}
+
+	fyneApp := test.NewApp()
+	defer fyneApp.Quit()
+
+	a := createUIReadyDropTestApp(t, fyneApp)
+	rootDir := t.TempDir()
+	blockedDir := filepath.Join(rootDir, "blocked")
+	if err := os.Mkdir(blockedDir, 0700); err != nil {
+		t.Fatalf("create blocked dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "visible.txt"), []byte("ok"), 0600); err != nil {
+		t.Fatalf("create visible file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blockedDir, "secret.txt"), []byte("secret"), 0600); err != nil {
+		t.Fatalf("create blocked file: %v", err)
+	}
+	if err := os.Chmod(blockedDir, 0); err != nil {
+		t.Fatalf("chmod blocked dir: %v", err)
+	}
+	defer func() {
+		_ = os.Chmod(blockedDir, 0700)
+	}()
+
+	fyne.DoAndWait(func() {
+		a.onDrop([]string{rootDir})
+	})
+
+	waitForDropProcessing(t, a)
+	fyne.DoAndWait(func() {})
+
+	if a.State.IsScanning() {
+		t.Fatal("Scanning should be false after folder walk error")
 	}
 }
 

--- a/src/internal/ui/drop_test.go
+++ b/src/internal/ui/drop_test.go
@@ -194,8 +194,7 @@ func itoa(n int) string {
 
 // TestDropStateTransitions tests state changes during drop handling.
 func TestDropStateTransitions(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	t.Run("SingleFileDropSetsEncryptMode", func(t *testing.T) {
 		state := app.NewState()
@@ -246,7 +245,7 @@ func TestDropStateTransitions(t *testing.T) {
 }
 
 func TestApplyDropErrorPreservesStatusAfterReset(t *testing.T) {
-	test.NewApp()
+	newTestFyneApp(t)
 
 	testCases := []struct {
 		name              string

--- a/src/internal/ui/drop_test.go
+++ b/src/internal/ui/drop_test.go
@@ -434,6 +434,44 @@ func TestApplyStartupPathsReportsAccessError(t *testing.T) {
 	}
 }
 
+func TestApplyStartupPathsPreservesPartialAccessWarning(t *testing.T) {
+	fyneApp := test.NewApp()
+	defer fyneApp.Quit()
+
+	a := createUIReadyDropTestApp(t, fyneApp)
+	inputFile := filepath.Join(t.TempDir(), "report.txt")
+	if err := os.WriteFile(inputFile, []byte("quarterly report"), 0644); err != nil {
+		t.Fatalf("Create test file: %v", err)
+	}
+
+	originalStat := startupPathStat
+	startupPathStat = func(path string) (os.FileInfo, error) {
+		if path == "blocked.txt" {
+			return nil, os.ErrPermission
+		}
+		return originalStat(path)
+	}
+	defer func() {
+		startupPathStat = originalStat
+	}()
+
+	fyne.DoAndWait(func() {
+		a.applyStartupPaths([]string{"blocked.txt", inputFile})
+	})
+	waitForDropProcessing(t, a)
+	state := snapshotDropState(t, a)
+
+	if state.Mode != "encrypt" {
+		t.Fatalf("Mode = %q; want encrypt", state.Mode)
+	}
+	if state.InputFile != inputFile {
+		t.Fatalf("InputFile = %q; want %q", state.InputFile, inputFile)
+	}
+	if state.MainStatus != startupPathAccessStatus {
+		t.Fatalf("MainStatus = %q; want %q", state.MainStatus, startupPathAccessStatus)
+	}
+}
+
 func TestCollectStartupPathsAllowsHyphenPrefixedFilename(t *testing.T) {
 	validPaths, err := collectStartupPaths([]string{"-secret.txt"}, func(path string) (os.FileInfo, error) {
 		return nil, nil

--- a/src/internal/ui/fyne_test_helpers_test.go
+++ b/src/internal/ui/fyne_test_helpers_test.go
@@ -11,6 +11,9 @@ func newTestFyneApp(t *testing.T) fyne.App {
 	t.Helper()
 
 	app := test.NewApp()
-	t.Cleanup(app.Quit)
+	t.Cleanup(func() {
+		fyne.DoAndWait(func() {})
+		app.Quit()
+	})
 	return app
 }

--- a/src/internal/ui/fyne_test_helpers_test.go
+++ b/src/internal/ui/fyne_test_helpers_test.go
@@ -1,0 +1,16 @@
+package ui
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+)
+
+func newTestFyneApp(t *testing.T) fyne.App {
+	t.Helper()
+
+	app := test.NewApp()
+	t.Cleanup(app.Quit)
+	return app
+}

--- a/src/internal/ui/operations_test.go
+++ b/src/internal/ui/operations_test.go
@@ -12,7 +12,6 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
-	"fyne.io/fyne/v2/test"
 )
 
 // TestOnClickStartValidation tests the validation logic in onClickStart.
@@ -214,8 +213,7 @@ func TestApplyRecursiveSelectionRestoresSavedSettings(t *testing.T) {
 }
 
 func TestCreateReporterCallbacksUpdateStateAndCancelButton(t *testing.T) {
-	fyneApp := test.NewApp()
-	defer fyneApp.Quit()
+	fyneApp := newTestFyneApp(t)
 
 	a := createUIReadyDropTestApp(t, fyneApp)
 	fyne.DoAndWait(func() {

--- a/src/internal/ui/operations_test.go
+++ b/src/internal/ui/operations_test.go
@@ -17,8 +17,7 @@ import (
 
 // TestOnClickStartValidation tests the validation logic in onClickStart.
 func TestOnClickStartValidation(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	t.Run("NoMode", func(t *testing.T) {
 		a := createTestApp(t)
@@ -115,8 +114,7 @@ func TestOnClickStartValidation(t *testing.T) {
 }
 
 func TestUpdateOutputFileForCompressClearsDialogConfirmation(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	a := createTestApp(t)
 	a.State.Mode = "encrypt"
@@ -135,8 +133,7 @@ func TestUpdateOutputFileForCompressClearsDialogConfirmation(t *testing.T) {
 }
 
 func TestCreateReporterUsesAtomicCancelledFlag(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	a := createTestApp(t)
 	a.State.Working = false
@@ -154,8 +151,7 @@ func TestCreateReporterUsesAtomicCancelledFlag(t *testing.T) {
 }
 
 func TestApplyRecursiveSelectionRestoresSavedSettings(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	tmpDir := t.TempDir()
 	inputPath := filepath.Join(tmpDir, "input.txt")

--- a/src/internal/ui/password_test.go
+++ b/src/internal/ui/password_test.go
@@ -5,14 +5,11 @@ import (
 	"testing"
 
 	"Picocrypt-NG/internal/app"
-
-	"fyne.io/fyne/v2/test"
 )
 
 // TestPasswordStrengthScoring tests password strength calculation.
 func TestPasswordStrengthScoring(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	// Note: zxcvbn library returns scores 0-4
 	testCases := []struct {
@@ -48,8 +45,7 @@ func TestPasswordStrengthScoring(t *testing.T) {
 
 // TestPasswordVisibilityToggle tests show/hide password functionality.
 func TestPasswordVisibilityToggle(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	a := createTestApp(t)
 
@@ -350,8 +346,7 @@ func TestPasswordValidationIndicator(t *testing.T) {
 
 // TestPasswordEntryOnChanged tests password entry change handling.
 func TestPasswordEntryOnChanged(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	t.Run("PasswordUpdate", func(t *testing.T) {
 		state := app.NewState()

--- a/src/internal/ui/widgets_test.go
+++ b/src/internal/ui/widgets_test.go
@@ -12,8 +12,7 @@ import (
 // TestPasswordStrengthIndicator tests the password strength indicator widget.
 func TestPasswordStrengthIndicator(t *testing.T) {
 	// Create test app
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	t.Run("NewPasswordStrengthIndicator", func(t *testing.T) {
 		indicator := NewPasswordStrengthIndicator()
@@ -92,8 +91,7 @@ func TestPasswordStrengthIndicator(t *testing.T) {
 
 // TestValidationIndicator tests the validation indicator widget.
 func TestValidationIndicator(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	t.Run("NewValidationIndicator", func(t *testing.T) {
 		indicator := NewValidationIndicator()
@@ -160,8 +158,7 @@ func TestValidationIndicator(t *testing.T) {
 
 // TestPasswordEntry tests the password entry widget.
 func TestPasswordEntry(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	t.Run("NewPasswordEntry", func(t *testing.T) {
 		entry := NewPasswordEntry()
@@ -214,8 +211,7 @@ func TestPasswordEntry(t *testing.T) {
 
 // TestColoredLabel tests the colored label widget.
 func TestColoredLabel(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	t.Run("NewColoredLabel", func(t *testing.T) {
 		testColor := color.RGBA{R: 255, G: 0, B: 0, A: 255}
@@ -275,8 +271,7 @@ func TestColoredLabel(t *testing.T) {
 
 // TestDisabledEntry tests the disabled entry widget.
 func TestDisabledEntry(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	t.Run("NewDisabledEntry", func(t *testing.T) {
 		entry := NewDisabledEntry()
@@ -302,8 +297,7 @@ func TestDisabledEntry(t *testing.T) {
 
 // TestTooltipButton tests the tooltip button widget.
 func TestTooltipButton(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	t.Run("NewTooltipButton", func(t *testing.T) {
 		tapped := false
@@ -340,8 +334,7 @@ func TestTooltipButton(t *testing.T) {
 
 // TestFixedWidthLayout tests the fixed width layout.
 func TestFixedWidthLayout(t *testing.T) {
-	test.NewApp()
-	defer test.NewApp()
+	newTestFyneApp(t)
 
 	t.Run("MinSize_Empty", func(t *testing.T) {
 		layout := &fixedWidthLayout{width: 100}

--- a/src/internal/volume/decrypt.go
+++ b/src/internal/volume/decrypt.go
@@ -19,6 +19,8 @@ import (
 	"Picocrypt-NG/internal/util"
 )
 
+var unpackArchive = fileops.Unpack
+
 // Decrypt performs a complete volume decryption operation.
 // This is the main entry point for decryption.
 // If ctx is nil, a background context is used.
@@ -675,7 +677,7 @@ func decryptFinalize(ctx *OperationContext, req *DecryptRequest) error {
 		}
 
 		ctx.SetStatus("Unzipping...")
-		err := fileops.Unpack(fileops.UnpackOptions{
+		err := unpackArchive(fileops.UnpackOptions{
 			ZipPath:   zipPath,
 			SameLevel: req.SameLevel,
 			Progress: func(p float32, info string) {

--- a/src/internal/volume/roundtrip_test.go
+++ b/src/internal/volume/roundtrip_test.go
@@ -3,6 +3,7 @@ package volume
 import (
 	"archive/zip"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"testing"
 
 	"Picocrypt-NG/internal/encoding"
+	"Picocrypt-NG/internal/fileops"
 )
 
 // TestRoundTripBasic tests basic encrypt -> decrypt cycle
@@ -1063,6 +1065,80 @@ func TestAutoUnzipSameLevel(t *testing.T) {
 	}
 
 	t.Log("Auto-unzip same-level: SUCCESS")
+}
+
+func TestAutoUnzipRestoresRenamedOutputOnUnpackFailure(t *testing.T) {
+	rsCodecs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("Failed to create RS codecs: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	testContent := []byte("Auto-unzip rollback test content!")
+	testDir := filepath.Join(tmpDir, "rollback_folder")
+	if err := os.MkdirAll(testDir, 0755); err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+	testFile := filepath.Join(testDir, "rollback.txt")
+	if err := os.WriteFile(testFile, testContent, 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	zipPath := filepath.Join(tmpDir, "rollback.zip")
+	if err := createTestZip(zipPath, testDir, "rollback_folder"); err != nil {
+		t.Fatalf("Failed to create test zip: %v", err)
+	}
+
+	encryptedPath := filepath.Join(tmpDir, "rollback.zip.pcv")
+	decryptedPath := filepath.Join(tmpDir, "rollback")
+	reporter := &GoldenTestReporter{}
+
+	encReq := &EncryptRequest{
+		InputFile:  zipPath,
+		OutputFile: encryptedPath,
+		Password:   "rollback_password",
+		Reporter:   reporter,
+		RSCodecs:   rsCodecs,
+	}
+	if err := Encrypt(context.Background(), encReq); err != nil {
+		t.Fatalf("Encrypt failed: %v", err)
+	}
+
+	_ = os.Remove(zipPath)
+	_ = os.RemoveAll(testDir)
+
+	originalUnpackArchive := unpackArchive
+	unpackArchive = func(opts fileops.UnpackOptions) error {
+		return errors.New("insufficient disk space for extraction")
+	}
+	defer func() {
+		unpackArchive = originalUnpackArchive
+	}()
+
+	decReq := &DecryptRequest{
+		InputFile:    encryptedPath,
+		OutputFile:   decryptedPath,
+		Password:     "rollback_password",
+		AutoUnzip:    true,
+		ForceDecrypt: false,
+		Reporter:     reporter,
+		RSCodecs:     rsCodecs,
+	}
+
+	err = Decrypt(context.Background(), decReq)
+	if err == nil {
+		t.Fatal("expected decrypt to fail when unpack step fails")
+	}
+	if !strings.Contains(err.Error(), "unzip") {
+		t.Fatalf("expected unzip error, got %v", err)
+	}
+
+	if _, statErr := os.Stat(decryptedPath); statErr != nil {
+		t.Fatalf("expected original decrypted output path to be restored, stat err: %v", statErr)
+	}
+	if _, statErr := os.Stat(decryptedPath + ".zip"); !os.IsNotExist(statErr) {
+		t.Fatalf("temporary renamed zip should not remain after unpack failure")
+	}
 }
 
 // createTestZip creates a zip file from a directory

--- a/src/internal/workflowpolicy/helpers_test.go
+++ b/src/internal/workflowpolicy/helpers_test.go
@@ -6,7 +6,27 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
+
+type workflowDoc struct {
+	Permissions map[string]string      `yaml:"permissions"`
+	Jobs        map[string]workflowJob `yaml:"jobs"`
+}
+
+type workflowJob struct {
+	Permissions map[string]string `yaml:"permissions"`
+	Steps       []workflowStep    `yaml:"steps"`
+}
+
+type workflowStep struct {
+	Name string            `yaml:"name"`
+	Uses string            `yaml:"uses"`
+	Run  string            `yaml:"run"`
+	With map[string]any    `yaml:"with"`
+	Env  map[string]string `yaml:"env"`
+}
 
 func repoRoot(t *testing.T) string {
 	t.Helper()
@@ -38,6 +58,103 @@ func mustReadWorkflow(t *testing.T, relPath string) string {
 		t.Fatalf("read workflow %s: %v", relPath, err)
 	}
 	return strings.ReplaceAll(string(content), "\r\n", "\n")
+}
+
+func mustReadWorkflowDoc(t *testing.T, relPath string) workflowDoc {
+	t.Helper()
+	return mustParseWorkflowYAML(t, mustReadWorkflow(t, relPath))
+}
+
+func mustParseWorkflowYAML(t *testing.T, content string) workflowDoc {
+	t.Helper()
+
+	var workflow workflowDoc
+	if err := yaml.Unmarshal([]byte(content), &workflow); err != nil {
+		t.Fatalf("unmarshal workflow yaml: %v", err)
+	}
+	return workflow
+}
+
+func mustPermission(t *testing.T, permissions map[string]string, key, want string) {
+	t.Helper()
+
+	if permissions == nil {
+		t.Fatalf("expected permissions map with %q=%q, got nil", key, want)
+	}
+	if got := permissions[key]; got != want {
+		t.Fatalf("permission %q = %q, want %q", key, got, want)
+	}
+}
+
+func mustEffectivePermission(t *testing.T, workflow workflowDoc, job workflowJob, key, want string) {
+	t.Helper()
+
+	if job.Permissions != nil {
+		if got, ok := job.Permissions[key]; ok {
+			if got != want {
+				t.Fatalf("job permission %q = %q, want %q", key, got, want)
+			}
+			return
+		}
+	}
+
+	mustPermission(t, workflow.Permissions, key, want)
+}
+
+func mustJob(t *testing.T, workflow workflowDoc, name string) workflowJob {
+	t.Helper()
+
+	job, ok := workflow.Jobs[name]
+	if !ok {
+		t.Fatalf("expected workflow to contain job %q", name)
+	}
+	return job
+}
+
+func mustStepNamed(t *testing.T, job workflowJob, name string) workflowStep {
+	t.Helper()
+
+	for _, step := range job.Steps {
+		if step.Name == name {
+			return step
+		}
+	}
+	t.Fatalf("expected job to contain step named %q", name)
+	return workflowStep{}
+}
+
+func mustStepUsing(t *testing.T, job workflowJob, uses string) workflowStep {
+	t.Helper()
+
+	for _, step := range job.Steps {
+		if step.Uses == uses {
+			return step
+		}
+	}
+	t.Fatalf("expected job to contain step using %q", uses)
+	return workflowStep{}
+}
+
+func mustNotHaveStepNamed(t *testing.T, job workflowJob, name string) {
+	t.Helper()
+
+	for _, step := range job.Steps {
+		if step.Name == name {
+			t.Fatalf("expected job not to contain step named %q", name)
+		}
+	}
+}
+
+func mustHaveStepUsingPrefix(t *testing.T, job workflowJob, prefix string) workflowStep {
+	t.Helper()
+
+	for _, step := range job.Steps {
+		if strings.HasPrefix(step.Uses, prefix) {
+			return step
+		}
+	}
+	t.Fatalf("expected job to contain step using prefix %q", prefix)
+	return workflowStep{}
 }
 
 func mustContain(t *testing.T, content, substring string) {

--- a/src/internal/workflowpolicy/helpers_test.go
+++ b/src/internal/workflowpolicy/helpers_test.go
@@ -67,3 +67,17 @@ func mustMatch(t *testing.T, content, pattern string) {
 		t.Fatalf("expected workflow to match %q", pattern)
 	}
 }
+
+func mustExtractSection(t *testing.T, content, pattern string) string {
+	t.Helper()
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		t.Fatalf("compile pattern %q: %v", pattern, err)
+	}
+	matches := re.FindStringSubmatch(content)
+	if len(matches) < 2 {
+		t.Fatalf("expected workflow to contain section matching %q", pattern)
+	}
+	return matches[1]
+}

--- a/src/internal/workflowpolicy/parse_test.go
+++ b/src/internal/workflowpolicy/parse_test.go
@@ -1,0 +1,56 @@
+package workflowpolicy
+
+import "testing"
+
+func TestParseWorkflowYAMLExtractsPermissionsJobsAndSteps(t *testing.T) {
+	content := `
+permissions:
+  contents: read
+jobs:
+  build:
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Release
+        uses: softprops/action-gh-release@1234567890123456789012345678901234567890
+        with:
+          tag_name: v1.00
+        env:
+          GH_TOKEN: token
+`
+
+	workflow := mustParseWorkflowYAML(t, content)
+	mustPermission(t, workflow.Permissions, "contents", "read")
+
+	build := mustJob(t, workflow, "build")
+	mustPermission(t, build.Permissions, "contents", "read")
+
+	step := mustStepNamed(t, build, "Release")
+	if step.Uses != "softprops/action-gh-release@1234567890123456789012345678901234567890" {
+		t.Fatalf("step uses = %q", step.Uses)
+	}
+	if step.With["tag_name"] != "v1.00" {
+		t.Fatalf("step with[tag_name] = %#v", step.With["tag_name"])
+	}
+	if step.Env["GH_TOKEN"] != "token" {
+		t.Fatalf("step env[GH_TOKEN] = %q", step.Env["GH_TOKEN"])
+	}
+}
+
+func TestMustParseWorkflowYAMLFindsStepByUses(t *testing.T) {
+	content := `
+jobs:
+  release:
+    steps:
+      - uses: actions/download-artifact@v8
+      - uses: softprops/action-gh-release@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+
+	workflow := mustParseWorkflowYAML(t, content)
+	release := mustJob(t, workflow, "release")
+	step := mustStepUsing(t, release, "softprops/action-gh-release@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if step.Uses == "" {
+		t.Fatal("expected matching step uses")
+	}
+}

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -7,7 +7,9 @@ func TestReleaseActionsPinnedToFullSHA(t *testing.T) {
 		name string
 		path string
 	}{
+		{name: "build-android", path: ".github/workflows/build-android.yml"},
 		{name: "build-linux", path: ".github/workflows/build-linux.yml"},
+		{name: "build-macos", path: ".github/workflows/build-macos.yml"},
 		{name: "build-windows", path: ".github/workflows/build-windows.yml"},
 		{name: "build-snapcraft", path: ".github/workflows/build-snapcraft.yml"},
 	}
@@ -21,9 +23,19 @@ func TestReleaseActionsPinnedToFullSHA(t *testing.T) {
 }
 
 func TestBuildPermissionsStayLeastPrivilege(t *testing.T) {
+	buildAndroid := mustReadWorkflow(t, ".github/workflows/build-android.yml")
+	mustContain(t, buildAndroid, "permissions:\n  contents: read")
+	mustMatch(t, buildAndroid, `(?s)\n  build:\n(?:.*\n)*?    permissions:\n      contents: read\n`)
+	mustMatch(t, buildAndroid, `(?s)\n  release:\n(?:.*\n)*?    permissions:\n      contents: write\n`)
+
 	buildLinux := mustReadWorkflow(t, ".github/workflows/build-linux.yml")
 	mustContain(t, buildLinux, "permissions:\n  contents: read")
 	mustContain(t, buildLinux, "release:\n    needs: build\n    runs-on: ubuntu-24.04\n    permissions:\n      contents: write")
+
+	buildMacOS := mustReadWorkflow(t, ".github/workflows/build-macos.yml")
+	mustContain(t, buildMacOS, "permissions:\n  contents: read")
+	mustMatch(t, buildMacOS, `(?s)\n  build:\n(?:.*\n)*?    permissions:\n      contents: read\n`)
+	mustMatch(t, buildMacOS, `(?s)\n  release:\n(?:.*\n)*?    permissions:\n      contents: write\n`)
 
 	buildWindows := mustReadWorkflow(t, ".github/workflows/build-windows.yml")
 	mustContain(t, buildWindows, "permissions:\n  contents: read")

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -6,46 +6,50 @@ func TestReleaseActionsPinnedToFullSHA(t *testing.T) {
 	testCases := []struct {
 		name string
 		path string
+		job  string
 	}{
-		{name: "build-android", path: ".github/workflows/build-android.yml"},
-		{name: "build-linux", path: ".github/workflows/build-linux.yml"},
-		{name: "build-macos", path: ".github/workflows/build-macos.yml"},
-		{name: "build-windows", path: ".github/workflows/build-windows.yml"},
-		{name: "build-snapcraft", path: ".github/workflows/build-snapcraft.yml"},
+		{name: "build-android", path: ".github/workflows/build-android.yml", job: "release"},
+		{name: "build-linux", path: ".github/workflows/build-linux.yml", job: "release"},
+		{name: "build-macos", path: ".github/workflows/build-macos.yml", job: "release"},
+		{name: "build-windows", path: ".github/workflows/build-windows.yml", job: "release"},
+		{name: "build-snapcraft", path: ".github/workflows/build-snapcraft.yml", job: "release"},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			content := mustReadWorkflow(t, tc.path)
-			mustMatch(t, content, `softprops/action-gh-release@[0-9a-f]{40}`)
+			workflow := mustReadWorkflowDoc(t, tc.path)
+			releaseJob := mustJob(t, workflow, tc.job)
+			releaseStep := mustHaveStepUsingPrefix(t, releaseJob, "softprops/action-gh-release@")
+			mustMatch(t, releaseStep.Uses, `softprops/action-gh-release@[0-9a-f]{40}`)
 		})
 	}
 }
 
 func TestBuildPermissionsStayLeastPrivilege(t *testing.T) {
-	buildAndroid := mustReadWorkflow(t, ".github/workflows/build-android.yml")
-	mustContain(t, buildAndroid, "permissions:\n  contents: read")
-	mustMatch(t, buildAndroid, `(?s)\n  build:\n(?:.*\n)*?    permissions:\n      contents: read\n`)
-	mustMatch(t, buildAndroid, `(?s)\n  release:\n(?:.*\n)*?    permissions:\n      contents: write\n`)
+	buildAndroid := mustReadWorkflowDoc(t, ".github/workflows/build-android.yml")
+	mustPermission(t, buildAndroid.Permissions, "contents", "read")
+	mustEffectivePermission(t, buildAndroid, mustJob(t, buildAndroid, "build"), "contents", "read")
+	mustPermission(t, mustJob(t, buildAndroid, "release").Permissions, "contents", "write")
 
-	buildLinux := mustReadWorkflow(t, ".github/workflows/build-linux.yml")
-	mustContain(t, buildLinux, "permissions:\n  contents: read")
-	mustContain(t, buildLinux, "release:\n    needs: build\n    runs-on: ubuntu-24.04\n    permissions:\n      contents: write")
+	buildLinux := mustReadWorkflowDoc(t, ".github/workflows/build-linux.yml")
+	mustPermission(t, buildLinux.Permissions, "contents", "read")
+	mustEffectivePermission(t, buildLinux, mustJob(t, buildLinux, "build"), "contents", "read")
+	mustEffectivePermission(t, buildLinux, mustJob(t, buildLinux, "release"), "contents", "write")
 
-	buildMacOS := mustReadWorkflow(t, ".github/workflows/build-macos.yml")
-	mustContain(t, buildMacOS, "permissions:\n  contents: read")
-	mustMatch(t, buildMacOS, `(?s)\n  build:\n(?:.*\n)*?    permissions:\n      contents: read\n`)
-	mustMatch(t, buildMacOS, `(?s)\n  release:\n(?:.*\n)*?    permissions:\n      contents: write\n`)
+	buildMacOS := mustReadWorkflowDoc(t, ".github/workflows/build-macos.yml")
+	mustPermission(t, buildMacOS.Permissions, "contents", "read")
+	mustEffectivePermission(t, buildMacOS, mustJob(t, buildMacOS, "build"), "contents", "read")
+	mustEffectivePermission(t, buildMacOS, mustJob(t, buildMacOS, "release"), "contents", "write")
 
-	buildWindows := mustReadWorkflow(t, ".github/workflows/build-windows.yml")
-	mustContain(t, buildWindows, "permissions:\n  contents: read")
-	mustContain(t, buildWindows, "build:\n    runs-on: windows-2025\n    permissions:\n      contents: read")
-	mustContain(t, buildWindows, "release:\n    needs: build\n    runs-on: windows-2025\n    permissions:\n      contents: write")
+	buildWindows := mustReadWorkflowDoc(t, ".github/workflows/build-windows.yml")
+	mustPermission(t, buildWindows.Permissions, "contents", "read")
+	mustEffectivePermission(t, buildWindows, mustJob(t, buildWindows, "build"), "contents", "read")
+	mustEffectivePermission(t, buildWindows, mustJob(t, buildWindows, "release"), "contents", "write")
 
-	buildSnapcraft := mustReadWorkflow(t, ".github/workflows/build-snapcraft.yml")
-	mustContain(t, buildSnapcraft, "permissions:\n  contents: read")
-	mustContain(t, buildSnapcraft, "build-snapcraft:\n    runs-on: ubuntu-latest\n    permissions:\n      contents: read")
-	mustContain(t, buildSnapcraft, "release:\n    needs: build-snapcraft\n    runs-on: ubuntu-latest\n    permissions:\n      contents: write")
+	buildSnapcraft := mustReadWorkflowDoc(t, ".github/workflows/build-snapcraft.yml")
+	mustPermission(t, buildSnapcraft.Permissions, "contents", "read")
+	mustEffectivePermission(t, buildSnapcraft, mustJob(t, buildSnapcraft, "build-snapcraft"), "contents", "read")
+	mustEffectivePermission(t, buildSnapcraft, mustJob(t, buildSnapcraft, "release"), "contents", "write")
 }
 
 func TestLinuxUPXDownloadsRemainChecksumGated(t *testing.T) {
@@ -72,8 +76,10 @@ func TestLinuxDebPackagingDoesNotUseExternalScaffold(t *testing.T) {
 }
 
 func TestSnapcraftActionPinnedToFullSHA(t *testing.T) {
-	content := mustReadWorkflow(t, ".github/workflows/build-snapcraft.yml")
-	mustMatch(t, content, `snapcore/action-build@[0-9a-f]{40}`)
+	workflow := mustReadWorkflowDoc(t, ".github/workflows/build-snapcraft.yml")
+	buildJob := mustJob(t, workflow, "build-snapcraft")
+	buildStep := mustHaveStepUsingPrefix(t, buildJob, "snapcore/action-build@")
+	mustMatch(t, buildStep.Uses, `snapcore/action-build@[0-9a-f]{40}`)
 }
 
 func TestAndroidPRWorkflowStaysFastAndCompileFocused(t *testing.T) {
@@ -87,18 +93,21 @@ func TestAndroidPRWorkflowStaysFastAndCompileFocused(t *testing.T) {
 }
 
 func TestAndroidReleaseWorkflowKeepsSigningSecretsOutOfBuildJob(t *testing.T) {
-	content := mustReadWorkflow(t, ".github/workflows/build-android.yml")
+	workflow := mustReadWorkflowDoc(t, ".github/workflows/build-android.yml")
+	buildJob := mustJob(t, workflow, "build")
+	releaseJob := mustJob(t, workflow, "release")
 
-	buildSection := mustExtractSection(t, content, `(?s)\n  build:\n(.*?)\n  release:\n`)
-	mustContain(t, buildSection, "Build Go Mobile AAR")
-	mustContain(t, buildSection, "./gradlew test")
-	mustNotContain(t, buildSection, "ANDROID_KEYSTORE_BASE64")
-	mustNotContain(t, buildSection, "Build Signed Release APK")
+	mustStepNamed(t, buildJob, "Build Go Mobile AAR")
+	mustStepNamed(t, buildJob, "Run Unit Tests")
+	mustNotHaveStepNamed(t, buildJob, "Decode Android signing keystore")
+	mustNotHaveStepNamed(t, buildJob, "Build Signed Release APK")
 
-	releaseSection := mustExtractSection(t, content, `(?s)\n  release:\n(.*)$`)
-	mustContain(t, releaseSection, "ANDROID_KEYSTORE_BASE64")
-	mustContain(t, releaseSection, "Build Signed Release APK")
-	mustContain(t, releaseSection, "actions/download-artifact@v8")
+	releaseStep := mustStepNamed(t, releaseJob, "Decode Android signing keystore")
+	if _, ok := releaseStep.Env["ANDROID_KEYSTORE_BASE64"]; !ok {
+		t.Fatal("release keystore decode step should declare ANDROID_KEYSTORE_BASE64")
+	}
+	mustStepNamed(t, releaseJob, "Build Signed Release APK")
+	mustStepUsing(t, releaseJob, "actions/download-artifact@v8")
 }
 
 func TestAndroidInstrumentedWorkflowIsManualAndPinned(t *testing.T) {
@@ -137,12 +146,23 @@ func TestWindowsLegacyReleaseWorkflowIsCLIOnly(t *testing.T) {
 }
 
 func TestWindowsLegacyWorkflowsCacheLegacyGo(t *testing.T) {
-	for _, path := range []string{
-		".github/workflows/pr-test-build-windows-legacy.yml",
-		".github/workflows/build-windows-legacy.yml",
-	} {
-		content := mustReadWorkflow(t, path)
-		mustContain(t, content, "actions/cache@v4")
-		mustContain(t, content, "C:\\go-legacy")
+	testCases := []struct {
+		path string
+		job  string
+	}{
+		{path: ".github/workflows/pr-test-build-windows-legacy.yml", job: "pr-test-build-windows-legacy"},
+		{path: ".github/workflows/build-windows-legacy.yml", job: "build"},
+	}
+
+	for _, tc := range testCases {
+		workflow := mustReadWorkflowDoc(t, tc.path)
+		job := mustJob(t, workflow, tc.job)
+		cacheStep := mustStepNamed(t, job, "Cache go-legacy-win7")
+		if cacheStep.Uses != "actions/cache@v4" {
+			t.Fatalf("cache step uses = %q, want actions/cache@v4", cacheStep.Uses)
+		}
+		if cacheStep.With["path"] != `C:\go-legacy` {
+			t.Fatalf("cache step path = %#v, want C:\\go-legacy", cacheStep.With["path"])
+		}
 	}
 }

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -104,12 +104,18 @@ func TestAndroidReleaseWorkflowKeepsSigningSecretsOutOfBuildJob(t *testing.T) {
 func TestAndroidInstrumentedWorkflowIsManualAndPinned(t *testing.T) {
 	content := mustReadWorkflow(t, ".github/workflows/android-instrumented.yml")
 	mustContain(t, content, "workflow_dispatch:")
+	mustContain(t, content, "test_scope:")
+	mustContain(t, content, "default: focused")
+	mustContain(t, content, "- focused")
+	mustContain(t, content, "- extended")
 	mustMatch(t, content, `ReactiveCircus/android-emulator-runner@[0-9a-f]{40}`)
 	mustContain(t, content, "connectedDebugAndroidTest")
 	mustContain(t, content, "PasswordCardTest")
 	mustContain(t, content, "ProgressCardTest")
+	mustContain(t, content, "OperationManagerIntegrationTest")
 	mustNotContain(t, content, "connectedDebugAndroidTest \\")
-	mustContain(t, content, "cd android && ./gradlew connectedDebugAndroidTest")
+	mustContain(t, content, "TEST_CLASSES=")
+	mustContain(t, content, "./gradlew connectedDebugAndroidTest")
 }
 
 func TestWindowsLegacyPRWorkflowIsCLIOnly(t *testing.T) {

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -86,6 +86,21 @@ func TestAndroidPRWorkflowStaysFastAndCompileFocused(t *testing.T) {
 	mustNotContain(t, content, "connectedDebugAndroidTest")
 }
 
+func TestAndroidReleaseWorkflowKeepsSigningSecretsOutOfBuildJob(t *testing.T) {
+	content := mustReadWorkflow(t, ".github/workflows/build-android.yml")
+
+	buildSection := mustExtractSection(t, content, `(?s)\n  build:\n(.*?)\n  release:\n`)
+	mustContain(t, buildSection, "Build Go Mobile AAR")
+	mustContain(t, buildSection, "./gradlew test")
+	mustNotContain(t, buildSection, "ANDROID_KEYSTORE_BASE64")
+	mustNotContain(t, buildSection, "Build Signed Release APK")
+
+	releaseSection := mustExtractSection(t, content, `(?s)\n  release:\n(.*)$`)
+	mustContain(t, releaseSection, "ANDROID_KEYSTORE_BASE64")
+	mustContain(t, releaseSection, "Build Signed Release APK")
+	mustContain(t, releaseSection, "actions/download-artifact@v8")
+}
+
 func TestAndroidInstrumentedWorkflowIsManualAndPinned(t *testing.T) {
 	content := mustReadWorkflow(t, ".github/workflows/android-instrumented.yml")
 	mustContain(t, content, "workflow_dispatch:")


### PR DESCRIPTION
## Summary
- carry forward the remaining post-#102 `sec-fix` hardening commits onto current `main`
- tighten temp-file, path-access, and unzip disk-space handling in the Go codepaths
- harden Android/macOS workflow handling and Android signing secret isolation
- expand and clean up UI, workflow-policy, volume, and Android test coverage

## Notable areas
- `src/internal/cli`: prefer user cache for stdin temp files
- `src/internal/fileops`: check unzip free space before extraction and simplify disk-space handling
- `src/internal/ui`: handle partial startup path access errors and tighten UI edge cases/tests
- `src/internal/workflowpolicy`: structural parsing refactor plus tests
- `.github/workflows` and `android/`: CI/instrumented-test hardening

## Verification
- `go test ./...`
- `go test -race ./internal/cli ./internal/fileops ./internal/ui ./internal/volume ./internal/workflowpolicy`

## Notes
- This branch was rebased onto `main` after merging Dependabot PRs #112 and #106 on 2026-04-09.
