### PR TITLE
Phase 1A: fix startup .pcv decrypt behavior for double-click flows

### DIFF
--- a/src/internal/ui/drop.go
+++ b/src/internal/ui/drop.go
@@ -36,6 +36,22 @@ func isIgnoredStartupArg(path string) bool {
 	return path == "" || strings.HasPrefix(path, "-psn_")
 }
 
+func isDecryptVolumePath(path string) bool {
+	if fileops.IsSplitChunkPath(path) {
+		return true
+	}
+
+	return strings.HasSuffix(strings.ToLower(filepath.Base(path)), ".pcv")
+}
+
+func trimPCVSuffix(path string) string {
+	if !strings.HasSuffix(strings.ToLower(filepath.Base(path)), ".pcv") {
+		return path
+	}
+
+	return path[:len(path)-4]
+}
+
 func collectStartupPaths(paths []string, statFn func(string) (os.FileInfo, error)) ([]string, error) {
 	validPaths := make([]string, 0, len(paths))
 	var firstErr error
@@ -155,7 +171,7 @@ func (a *App) onDrop(names []string) {
 			isSplit := fileops.IsSplitChunkPath(names[0])
 
 			// Decide if encrypting or decrypting
-			if strings.HasSuffix(names[0], ".pcv") || isSplit {
+			if isDecryptVolumePath(names[0]) {
 				a.handleDecryptDrop(names[0], isSplit)
 				// For decrypt, no folder scanning needed
 				a.State.SetScanning(false)
@@ -273,10 +289,14 @@ func (a *App) handleDecryptDrop(name string, isSplit bool) {
 
 	// Get the correct input and output filenames
 	if isSplit {
-		ind := strings.Index(name, ".pcv")
-		name = name[:ind+4]
+		basePath, ok := fileops.SplitChunkBase(name)
+		if !ok {
+			a.applyDropError("Failed to derive split volume path", false)
+			return
+		}
+		name = basePath
 		a.State.InputFile = name
-		a.State.OutputFile = name[:ind]
+		a.State.OutputFile = trimPCVSuffix(name)
 		a.State.Recombine = true
 
 		// Find out the number of split chunks
@@ -292,7 +312,7 @@ func (a *App) handleDecryptDrop(name string, isSplit bool) {
 		a.State.RequiredFreeSpace = a.State.CompressTotal
 	} else {
 		a.State.InputFile = name
-		a.State.OutputFile = name[:len(name)-4]
+		a.State.OutputFile = trimPCVSuffix(name)
 	}
 
 	// Open the input file in read-only mode

--- a/src/internal/ui/drop_test.go
+++ b/src/internal/ui/drop_test.go
@@ -31,6 +31,7 @@ func TestFileTypeDetection(t *testing.T) {
 		{"PlainText", "document.txt", false, false, true},
 		{"PlainPDF", "report.pdf", false, false, true},
 		{"EncryptedPcv", "secret.pcv", true, false, false},
+		{"EncryptedPcvUppercase", "secret.PCV", true, false, false},
 		{"SplitChunk0", "secret.pcv.0", true, true, false},
 		{"SplitChunk1", "secret.pcv.1", true, true, false},
 		{"SplitChunk99", "secret.pcv.99", true, true, false},
@@ -45,8 +46,9 @@ func TestFileTypeDetection(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			isPcv := strings.HasSuffix(tc.filename, ".pcv")
 			isSplit := detectSplitVolume(tc.filename)
+			isDecrypt := isDecryptVolumePath(tc.filename)
+			isPcv := isDecrypt && !isSplit
 
 			if isPcv != tc.isPcv && !isSplit {
 				t.Errorf("isPcv = %v; want %v for %q", isPcv, tc.isPcv, tc.filename)
@@ -56,7 +58,7 @@ func TestFileTypeDetection(t *testing.T) {
 			}
 
 			// Determine encrypt mode
-			isEncrypt := !isPcv && !isSplit
+			isEncrypt := !isDecrypt
 			if isEncrypt != tc.isEncrypt {
 				t.Errorf("isEncrypt = %v; want %v for %q", isEncrypt, tc.isEncrypt, tc.filename)
 			}
@@ -85,9 +87,10 @@ func TestSplitVolumeBasePath(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Extract base path (logic from handleDecryptDrop)
-			ind := strings.Index(tc.chunkPath, ".pcv")
-			basePath := tc.chunkPath[:ind+4]
+			basePath, ok := fileops.SplitChunkBase(tc.chunkPath)
+			if !ok {
+				t.Fatalf("SplitChunkBase(%q) returned ok=false", tc.chunkPath)
+			}
 
 			if basePath != tc.expectedBase {
 				t.Errorf("basePath = %q; want %q", basePath, tc.expectedBase)
@@ -106,12 +109,12 @@ func TestOutputPathFromDecrypt(t *testing.T) {
 		{"SimplePcv", "/path/secret.pcv", "/path/secret"},
 		{"NestedPcv", "/a/b/c/file.pcv", "/a/b/c/file"},
 		{"MultipleDots", "/path/file.tar.gz.pcv", "/path/file.tar.gz"},
+		{"UppercasePcv", "/path/SECRET.PCV", "/path/SECRET"},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Remove .pcv suffix (logic from handleDecryptDrop)
-			output := tc.inputPath[:len(tc.inputPath)-4]
+			output := trimPCVSuffix(tc.inputPath)
 
 			if output != tc.outputPath {
 				t.Errorf("output = %q; want %q", output, tc.outputPath)
@@ -309,6 +312,81 @@ func TestApplyStartupPathsLoadsInitialFiles(t *testing.T) {
 	}
 	if len(state.OnlyFiles) != 1 || state.OnlyFiles[0] != inputFile {
 		t.Fatalf("OnlyFiles = %#v; want [%q]", state.OnlyFiles, inputFile)
+	}
+}
+
+func TestApplyStartupPathsLoadsDecryptVolume(t *testing.T) {
+	fyneApp := newTestFyneApp(t)
+
+	a := createUIReadyDropTestApp(t, fyneApp)
+	inputFile := filepath.Join("..", "..", "testdata", "golden", "pico_test_v2.txt.pcv")
+
+	fyne.DoAndWait(func() {
+		a.applyStartupPaths([]string{inputFile})
+	})
+	state := snapshotDropState(t, a)
+
+	if state.Mode != "decrypt" {
+		t.Fatalf("Mode = %q; want decrypt", state.Mode)
+	}
+	if state.InputFile != inputFile {
+		t.Fatalf("InputFile = %q; want %q", state.InputFile, inputFile)
+	}
+	if state.OutputFile != strings.TrimSuffix(inputFile, ".pcv") {
+		t.Fatalf("OutputFile = %q; want %q", state.OutputFile, strings.TrimSuffix(inputFile, ".pcv"))
+	}
+	if len(state.OnlyFiles) != 1 || state.OnlyFiles[0] != inputFile {
+		t.Fatalf("OnlyFiles = %#v; want [%q]", state.OnlyFiles, inputFile)
+	}
+}
+
+func TestApplyStartupPathsWithMacOSProcessSerialLoadsDecryptVolume(t *testing.T) {
+	fyneApp := newTestFyneApp(t)
+
+	a := createUIReadyDropTestApp(t, fyneApp)
+	inputFile := filepath.Join("..", "..", "testdata", "golden", "pico_test_v2.txt.pcv")
+
+	fyne.DoAndWait(func() {
+		a.applyStartupPaths([]string{"-psn_0_12345", inputFile})
+	})
+	state := snapshotDropState(t, a)
+
+	if state.Mode != "decrypt" {
+		t.Fatalf("Mode = %q; want decrypt", state.Mode)
+	}
+	if state.InputFile != inputFile {
+		t.Fatalf("InputFile = %q; want %q", state.InputFile, inputFile)
+	}
+}
+
+func TestApplyStartupPathsTreatsUppercaseVolumeExtensionAsDecrypt(t *testing.T) {
+	fyneApp := newTestFyneApp(t)
+
+	a := createUIReadyDropTestApp(t, fyneApp)
+	tempDir := t.TempDir()
+	original := filepath.Join("..", "..", "testdata", "golden", "pico_test_v2.txt.pcv")
+	inputFile := filepath.Join(tempDir, "PICO_TEST_V2.TXT.PCV")
+	data, err := os.ReadFile(original)
+	if err != nil {
+		t.Fatalf("Read golden volume: %v", err)
+	}
+	if err := os.WriteFile(inputFile, data, 0644); err != nil {
+		t.Fatalf("Write uppercase volume: %v", err)
+	}
+
+	fyne.DoAndWait(func() {
+		a.applyStartupPaths([]string{inputFile})
+	})
+	state := snapshotDropState(t, a)
+
+	if state.Mode != "decrypt" {
+		t.Fatalf("Mode = %q; want decrypt", state.Mode)
+	}
+	if state.InputFile != inputFile {
+		t.Fatalf("InputFile = %q; want %q", state.InputFile, inputFile)
+	}
+	if state.OutputFile != strings.TrimSuffix(inputFile, ".PCV") {
+		t.Fatalf("OutputFile = %q; want %q", state.OutputFile, strings.TrimSuffix(inputFile, ".PCV"))
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix GUI startup .pcv handling so uppercase volume paths also enter decrypt mode
- route split-volume startup handling through the canonical fileops.SplitChunkBase() helper
- add TDD regressions for startup decrypt behavior, including macOS -psn_* launch arguments and uppercase .PCV
- align stale UI tests with the current startup/decrypt contract

## What this PR does
This is phase 1A of the .pcv double-click/open work.
It improves runtime startup correctness when the app is launched with a .pcv path on Windows/macOS-oriented code paths.

Covered here:
- startup .pcv -> decrypt mode
- startup .PCV -> decrypt mode
- startup with macOS -psn_* prefix + .pcv path
- split-volume base extraction uses canonical helper

Not claimed as solved in this PR:
- macOS OS-level file association
- Windows out-of-box file association / installer / registry setup
- closing issue #110 without later platform-level verification

## Verification
- go test -timeout 90s -v -run '^Test(FileTypeDetection|SplitVolumeBasePath|OutputPathFromDecrypt|ApplyStartupPathsLoadsDecryptVolume|ApplyStartupPathsWithMacOSProcessSerialLoadsDecryptVolume|ApplyStartupPathsTreatsUppercaseVolumeExtensionAsDecrypt)$' ./internal/ui
- go test -race ./internal/ui
- go test ./...

## Notes
- Bounded macOS feasibility discovery found no clean, documented source-controlled document-type metadata hook ready for immediate phase-1 use in the current packaging flow, so OS-level macOS association remains a separate follow-up gate.
