### PR TITLE
fix: macOS file opening (#127) + crypto/CLI/WASM hardening batch

### DIFF
--- a/src/cmd/wasm/main.go
+++ b/src/cmd/wasm/main.go
@@ -17,11 +17,41 @@ func main() {
 	<-make(chan struct{})
 }
 
+// errInvalidArg is the bridge-level error code returned to JS when an exported
+// callback is invoked with a malformed argument (wrong arity, a non-Uint8Array
+// data argument, or a non-string password). It is a non-zero number distinct
+// from the internal/wasm pipeline codes 1-5 so the consuming site keeps
+// detecting failure via `typeof result === 'number'`.
+const errInvalidArg = 6
+
+// validateArgs reports whether args carries the expected (Uint8Array, string)
+// pair. It performs every check via type predicates that cannot panic, so it is
+// safe to call before any args[0].Get/CopyBytesToGo access. A malformed call
+// from JS (null, a number, a non-Uint8Array typed array, a missing password)
+// is rejected here instead of crashing the instance.
+func validateArgs(args []js.Value) bool {
+	if len(args) < 2 {
+		return false
+	}
+	if !args[0].InstanceOf(js.Global().Get("Uint8Array")) {
+		return false
+	}
+	return args[1].Type() == js.TypeString
+}
+
 // args[0] = Uint8Array, args[1] = password string
 // returns Uint8Array (0 prefix + plaintext) or error code int
-func decrypt(this js.Value, args []js.Value) any {
-	if len(args) < 2 {
-		return 1
+func decrypt(this js.Value, args []js.Value) (result any) {
+	// Recover from any panic so a malformed js.Value cannot escape FuncOf and
+	// kill the WASM instance; return the same error code the caller handles.
+	defer func() {
+		if r := recover(); r != nil {
+			result = errInvalidArg
+		}
+	}()
+
+	if !validateArgs(args) {
+		return errInvalidArg
 	}
 
 	length := args[0].Get("length").Int()
@@ -42,18 +72,26 @@ func decrypt(this js.Value, args []js.Value) any {
 	}
 	defer crypto.SecureZero(plaintext)
 
-	result := js.Global().Get("Uint8Array").New(len(plaintext) + 1)
+	out := js.Global().Get("Uint8Array").New(len(plaintext) + 1)
 	resultData := make([]byte, len(plaintext)+1)
 	defer crypto.SecureZero(resultData)
 	resultData[0] = 0
 	copy(resultData[1:], plaintext)
-	js.CopyBytesToJS(result, resultData)
-	return result
+	js.CopyBytesToJS(out, resultData)
+	return out
 }
 
-func encrypt(this js.Value, args []js.Value) any {
-	if len(args) < 2 {
-		return 1
+func encrypt(this js.Value, args []js.Value) (result any) {
+	// Recover from any panic so a malformed js.Value cannot escape FuncOf and
+	// kill the WASM instance; return the same error code the caller handles.
+	defer func() {
+		if r := recover(); r != nil {
+			result = errInvalidArg
+		}
+	}()
+
+	if !validateArgs(args) {
+		return errInvalidArg
 	}
 
 	length := args[0].Get("length").Int()
@@ -74,11 +112,11 @@ func encrypt(this js.Value, args []js.Value) any {
 	}
 	defer crypto.SecureZero(ciphertext)
 
-	result := js.Global().Get("Uint8Array").New(len(ciphertext) + 1)
+	out := js.Global().Get("Uint8Array").New(len(ciphertext) + 1)
 	resultData := make([]byte, len(ciphertext)+1)
 	defer crypto.SecureZero(resultData)
 	resultData[0] = 0
 	copy(resultData[1:], ciphertext)
-	js.CopyBytesToJS(result, resultData)
-	return result
+	js.CopyBytesToJS(out, resultData)
+	return out
 }

--- a/src/cmd/wasm/validate_wasm_test.go
+++ b/src/cmd/wasm/validate_wasm_test.go
@@ -1,0 +1,121 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"syscall/js"
+	"testing"
+)
+
+// These tests run under a live JS host via the wasm exec shim, e.g.:
+//
+//	cd src && GOOS=js GOARCH=wasm go test ./cmd/wasm/ \
+//	    -exec "$(go env GOROOT)/lib/wasm/go_js_wasm_exec"
+//
+// The //go:build js && wasm tag excludes them from a normal `go test ./...`, so
+// they only ever execute where syscall/js is real. No node on PATH => the exec
+// shim cannot run them at all (they are skipped by absence, never silently
+// passed).
+
+// TestInvalidArgErrorCodeContract pins the bridge-level error code returned to
+// JS for a malformed argument. WHY: the consuming website detects failure via
+// `typeof result === 'number'` and maps the internal/wasm codes 1-5; a new
+// malformed-argument code must stay a non-zero number distinct from 1-5 so the
+// site still treats it as failure (not success, not a hang).
+func TestInvalidArgErrorCodeContract(t *testing.T) {
+	if errInvalidArg == 0 {
+		t.Fatal("errInvalidArg must be non-zero so JS sees an error number, not success")
+	}
+	for _, c := range []int{1, 2, 3, 4, 5} {
+		if errInvalidArg == c {
+			t.Fatalf("errInvalidArg=%d collides with internal/wasm code %d", errInvalidArg, c)
+		}
+	}
+}
+
+// TestValidateArgsArity locks the arity gate: fewer than two arguments is
+// rejected before any js.Value field access (which would panic).
+func TestValidateArgsArity(t *testing.T) {
+	if validateArgs([]js.Value{}) {
+		t.Fatal("validateArgs must reject zero args")
+	}
+	if validateArgs([]js.Value{js.Undefined()}) {
+		t.Fatal("validateArgs must reject fewer than 2 args")
+	}
+}
+
+// TestValidateArgsRejectsBadShapes locks the type gate: args[0] must be a real
+// Uint8Array and args[1] must be a string. Each rejected shape here is one that
+// would otherwise drive args[0].Get("length").Int() / CopyBytesToGo into a
+// panic and kill the instance.
+func TestValidateArgsRejectsBadShapes(t *testing.T) {
+	validData := js.Global().Get("Uint8Array").New(4)
+	cases := []struct {
+		name string
+		a0   js.Value
+		a1   js.Value
+	}{
+		{"null data", js.Null(), js.ValueOf("pw")},
+		{"undefined data", js.Undefined(), js.ValueOf("pw")},
+		{"number data", js.ValueOf(42), js.ValueOf("pw")},
+		{"string data", js.ValueOf("not-bytes"), js.ValueOf("pw")},
+		{"wrong typed array", js.Global().Get("Int8Array").New(4), js.ValueOf("pw")},
+		{"non-string password", validData, js.ValueOf(42)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if validateArgs([]js.Value{tc.a0, tc.a1}) {
+				t.Fatalf("validateArgs accepted invalid args (%s)", tc.name)
+			}
+		})
+	}
+}
+
+// TestValidateArgsAcceptsValid ensures the gate does not reject a legitimate
+// (Uint8Array, string) pair.
+func TestValidateArgsAcceptsValid(t *testing.T) {
+	if !validateArgs([]js.Value{js.Global().Get("Uint8Array").New(4), js.ValueOf("pw")}) {
+		t.Fatal("validateArgs rejected a valid (Uint8Array, string) pair")
+	}
+}
+
+// TestCallbacksDoNotCrashOnBadArg is the core DoS regression: a malformed
+// argument that on HEAD drives args[0].Get("length").Int() to panic out of the
+// js.FuncOf trampoline (permanently killing the WASM instance, with main()
+// parked on <-make(chan struct{}) and no recovery short of page reload) must
+// instead return the int errInvalidArg and leave the instance alive. The test
+// invokes the exported callbacks directly with a number where a Uint8Array is
+// expected and asserts a clean int return — proving no panic escaped.
+func TestCallbacksDoNotCrashOnBadArg(t *testing.T) {
+	badArgs := []js.Value{js.ValueOf(42), js.ValueOf("pw")}
+	callbacks := []struct {
+		name string
+		fn   func(js.Value, []js.Value) any
+	}{
+		{"encrypt", encrypt},
+		{"decrypt", decrypt},
+	}
+	for _, cb := range callbacks {
+		t.Run(cb.name, func(t *testing.T) {
+			got := cb.fn(js.Undefined(), badArgs)
+			n, ok := got.(int)
+			if !ok {
+				t.Fatalf("%s(badArg) returned %T (%v); want int errInvalidArg", cb.name, got, got)
+			}
+			if n != errInvalidArg {
+				t.Fatalf("%s(badArg)=%d; want errInvalidArg=%d", cb.name, n, errInvalidArg)
+			}
+		})
+	}
+}
+
+// The recover() defers in encrypt/decrypt are a forward-looking backstop for a
+// Go panic occurring between validation and use. They are not separately unit
+// tested here because, once validateArgs has accepted the arguments, a genuine
+// Uint8Array drives no panic at all, and the only "instanceof Uint8Array but not
+// a real typed array" shape (e.g. Object.create(Uint8Array.prototype)) throws a
+// JS host exception inside syscall/js when its length getter runs — that is not a
+// Go panic and recover() cannot intercept it. Such a shape can only come from
+// adversarial same-origin JS; the consuming site's contract passes a real
+// Uint8Array. The realistic malformed-argument cases are covered by
+// TestValidateArgsRejectsBadShapes and TestCallbacksDoNotCrashOnBadArg above.

--- a/src/internal/cli/decrypt.go
+++ b/src/internal/cli/decrypt.go
@@ -138,17 +138,11 @@ func runDecrypt(cmd *cobra.Command, args []string) error {
 		decQuiet = true
 	}
 
-	// Track temp files for cleanup
+	// Track temp files for cleanup. The stdout temp holds decrypted plaintext and
+	// the stdin temp holds the .pcv input; both are securely wiped before unlink.
 	var stdinTempFile string
 	var stdoutTempFile string
-	defer func() {
-		if stdinTempFile != "" {
-			_ = os.Remove(stdinTempFile)
-		}
-		if stdoutTempFile != "" {
-			_ = os.Remove(stdoutTempFile)
-		}
-	}()
+	defer func() { cleanupTempFiles(stdinTempFile, stdoutTempFile) }()
 
 	outputFile := decOutput
 	if outputFile == "" && useStdin {
@@ -349,9 +343,10 @@ func runDecrypt(cmd *cobra.Command, args []string) error {
 
 	if err != nil {
 		reporter.PrintError("%v", err)
-		// Clean up partial output on error (temp files cleaned by defer)
+		// Clean up partial output on error (temp files cleaned by defer).
+		// Securely wipe the partially-written .incomplete output.
 		if !useStdout {
-			_ = os.Remove(outputFile + ".incomplete")
+			_ = wipeTempFile(outputFile + ".incomplete")
 		}
 		return err
 	}

--- a/src/internal/cli/encrypt.go
+++ b/src/internal/cli/encrypt.go
@@ -161,17 +161,11 @@ func runEncrypt(cmd *cobra.Command, args []string) error {
 		encQuiet = true
 	}
 
-	// Track temp files for cleanup
+	// Track temp files for cleanup. The stdin temp holds raw piped plaintext and
+	// the stdout temp holds the .pcv output; both are securely wiped before unlink.
 	var stdinTempFile string
 	var stdoutTempFile string
-	defer func() {
-		if stdinTempFile != "" {
-			_ = os.Remove(stdinTempFile)
-		}
-		if stdoutTempFile != "" {
-			_ = os.Remove(stdoutTempFile)
-		}
-	}()
+	defer func() { cleanupTempFiles(stdinTempFile, stdoutTempFile) }()
 
 	outputFile := encOutput
 	if outputFile == "" && useStdin {
@@ -442,8 +436,10 @@ func cleanupEncryptError(outputFile string, useStdout, outputPreExisted bool) {
 	if useStdout {
 		return
 	}
+	// outputFile is the user's named .pcv output; a plain unlink is fine here.
 	if !outputPreExisted {
 		_ = os.Remove(outputFile)
 	}
-	_ = os.Remove(outputFile + ".incomplete")
+	// Securely wipe the partially-written .incomplete staging file.
+	_ = wipeTempFile(outputFile + ".incomplete")
 }

--- a/src/internal/cli/password.go
+++ b/src/internal/cli/password.go
@@ -21,6 +21,15 @@ func isTerminal() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
+// captureTerminalState records the current tty mode so the signal handler can
+// restore it if SIGINT arrives during a no-echo password read. A GetState error
+// (e.g. fd is not a tty) stores nothing, leaving restore a no-op.
+func captureTerminalState() {
+	if st, err := term.GetState(int(os.Stdin.Fd())); err == nil {
+		savedTerminalState.Store(st)
+	}
+}
+
 func readPasswordLine(reader *bufio.Reader) (string, error) {
 	pw, err := reader.ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
@@ -47,6 +56,11 @@ func readPasswordSecure(prompt string) (string, error) {
 		return pw, nil
 	}
 
+	// Terminal mode: capture the current tty state so a SIGINT during the
+	// no-echo read can be restored by the signal handler (os.Exit skips
+	// term.ReadPassword's own deferred restore).
+	captureTerminalState()
+
 	// Terminal mode: disable echo
 	pw, err := term.ReadPassword(int(os.Stdin.Fd()))
 	fmt.Fprintln(os.Stderr) // newline after hidden input
@@ -60,6 +74,10 @@ func readPasswordSecure(prompt string) (string, error) {
 // If confirm is true, asks for confirmation (for encryption).
 // If allowEmpty is true, empty password is allowed (useful when keyfiles provide credentials).
 func ReadPasswordInteractive(confirm, allowEmpty bool) (string, error) {
+	// Once the prompt(s) have returned normally, clear the saved tty state so a
+	// later unrelated signal does not re-poke the terminal.
+	defer savedTerminalState.Store(nil)
+
 	password, err := readPasswordSecure("Password: ")
 	if err != nil {
 		return "", err

--- a/src/internal/cli/password_test.go
+++ b/src/internal/cli/password_test.go
@@ -2,8 +2,11 @@ package cli
 
 import (
 	"bufio"
+	"slices"
 	"strings"
 	"testing"
+
+	"golang.org/x/term"
 )
 
 func TestReadPasswordLine(t *testing.T) {
@@ -28,5 +31,64 @@ func TestReadPasswordLine(t *testing.T) {
 				t.Fatalf("readPasswordLine() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestSignalRestoresTerminalState checks that a SIGINT during the interactive
+// password prompt (before any operation reporter is stored) restores the saved
+// terminal mode before the process exits. os.Exit skips term.ReadPassword's
+// deferred restore, so the handler must restore explicitly and do so before
+// exiting, or the shell is left with echo disabled. The call order is asserted
+// because, with a real os.Exit, restoring after exit would never run.
+func TestSignalRestoresTerminalState(t *testing.T) {
+	globalReporter.Store(nil) // reproduces the pre-Store prompt window
+	sentinel := &term.State{}
+	savedTerminalState.Store(sentinel)
+
+	var events []string
+	var restored *term.State
+	origRestore, origExit := restoreTerminalFn, exitFn
+	t.Cleanup(func() {
+		restoreTerminalFn, exitFn = origRestore, origExit
+		savedTerminalState.Store(nil)
+	})
+	restoreTerminalFn = func(s *term.State) {
+		restored = s
+		events = append(events, "restore")
+	}
+	exitFn = func(int) { events = append(events, "exit") }
+
+	handleSignal()
+
+	if restored != sentinel {
+		t.Fatalf("terminal state not restored on signal path: got %p want %p", restored, sentinel)
+	}
+	want := []string{"restore", "exit"}
+	if !slices.Equal(events, want) {
+		t.Fatalf("signal path order = %v, want %v (restore must run before exit)", events, want)
+	}
+}
+
+// TestSignalWithReporterDoesNotExit pins the complementary contract: once an
+// operation reporter is active, SIGINT must cancel the operation rather than
+// exit the process.
+func TestSignalWithReporterDoesNotExit(t *testing.T) {
+	reporter := NewReporter(true)
+	globalReporter.Store(reporter)
+	origExit := exitFn
+	t.Cleanup(func() {
+		exitFn = origExit
+		globalReporter.Store(nil)
+	})
+	exited := false
+	exitFn = func(int) { exited = true }
+
+	handleSignal()
+
+	if exited {
+		t.Fatalf("reporter active: signal path must cancel, not exit")
+	}
+	if !reporter.IsCancelled() {
+		t.Fatalf("reporter active: signal path must cancel the operation")
 	}
 }

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"golang.org/x/term"
 )
 
 // Version is set by main.go
@@ -79,6 +80,43 @@ var rootCmd = &cobra.Command{
 // Global reporter for signal handling (atomic for safe concurrent access)
 var globalReporter atomic.Pointer[Reporter]
 
+// savedTerminalState holds the terminal mode captured at the start of an
+// interactive password prompt. term.ReadPassword puts the tty in no-echo mode
+// and restores it via a deferred ioctl on normal return; but a SIGINT during
+// the prompt drives the signal handler to os.Exit, which skips deferred
+// functions and would leave the shell with echo disabled. The signal handler
+// reads this to restore the tty before exiting. Nil outside a prompt, so the
+// restore is a no-op on every other path.
+var savedTerminalState atomic.Pointer[term.State]
+
+// exitFn and restoreTerminalFn are overridable in tests; the signal path calls
+// os.Exit and a real termios ioctl, neither of which a unit test can exercise.
+var (
+	exitFn            = os.Exit
+	restoreTerminalFn = func(s *term.State) { _ = term.Restore(int(os.Stdin.Fd()), s) }
+)
+
+// handleSignal runs when SIGINT/SIGTERM arrives. If an operation is in flight
+// (reporter stored), it cancels cooperatively. Otherwise (typically during the
+// interactive password prompt, before the reporter is stored) it restores the
+// terminal mode and exits, so the shell is not left with echo disabled.
+func handleSignal() {
+	if r := globalReporter.Load(); r != nil {
+		r.Cancel()
+		fmt.Fprintln(os.Stderr, "\nCancelling operation...")
+		return
+	}
+	restoreTerminalState()
+	exitFn(1)
+}
+
+// restoreTerminalState restores the tty mode captured at prompt start, if any.
+func restoreTerminalState() {
+	if s := savedTerminalState.Load(); s != nil {
+		restoreTerminalFn(s)
+	}
+}
+
 // Execute runs the CLI application.
 // Returns true if CLI mode was activated, false if GUI should run instead.
 func Execute(version string) bool {
@@ -94,12 +132,7 @@ func Execute(version string) bool {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-sigChan
-		if r := globalReporter.Load(); r != nil {
-			r.Cancel()
-			fmt.Fprintln(os.Stderr, "\nCancelling operation...")
-		} else {
-			os.Exit(1)
-		}
+		handleSignal()
 	}()
 
 	if err := rootCmd.Execute(); err != nil {

--- a/src/internal/cli/stream.go
+++ b/src/internal/cli/stream.go
@@ -4,7 +4,27 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"Picocrypt-NG/internal/fileops"
 )
+
+// wipeTempFile zero-overwrites a temp file's bytes before unlinking, so a
+// plaintext fragment from stdin/stdout staging is not left recoverable on disk
+// after the run. It is a package var so tests can verify that cleanup goes
+// through this secure path rather than a bare os.Remove.
+var wipeTempFile = fileops.OverwriteAndRemove
+
+// cleanupTempFiles best-effort securely removes the stdin/stdout staging temps
+// created for a CLI encrypt/decrypt run. Empty paths are skipped (no temp was
+// created for that direction). Errors are intentionally ignored: cleanup is
+// best-effort and must never mask the operation's real result.
+func cleanupTempFiles(paths ...string) {
+	for _, p := range paths {
+		if p != "" {
+			_ = wipeTempFile(p)
+		}
+	}
+}
 
 // IsStdin returns true if the path indicates stdin ("-")
 func IsStdin(path string) bool {
@@ -42,12 +62,16 @@ func BufferStdinToTemp(outputPath string) (string, error) {
 	_, err = io.Copy(tmp, os.Stdin)
 	if err != nil {
 		_ = tmp.Close()
-		_ = os.Remove(tmpPath)
+		// This error path returns "", so the caller cannot clean up the buffered
+		// stdin bytes; securely wipe them here rather than just unlinking.
+		_ = wipeTempFile(tmpPath)
 		return "", fmt.Errorf("buffering stdin: %w", err)
 	}
 
 	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpPath)
+		// The buffered stdin bytes are on disk and the caller cannot reach this
+		// path; securely wipe them rather than just unlinking.
+		_ = wipeTempFile(tmpPath)
 		return "", fmt.Errorf("closing temp file: %w", err)
 	}
 

--- a/src/internal/cli/stream_test.go
+++ b/src/internal/cli/stream_test.go
@@ -5,8 +5,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
+
+	"Picocrypt-NG/internal/fileops"
 )
 
 func TestIsStdin(t *testing.T) {
@@ -275,6 +278,113 @@ func TestStreamFileToStdoutNonexistent(t *testing.T) {
 	err := StreamFileToStdout("/nonexistent/file/path")
 	if err == nil {
 		t.Error("expected error for nonexistent file")
+	}
+}
+
+// TestWipeTempFileDefaultsToSecurePrimitive ensures the production default of the
+// wipeTempFile seam is the zero-overwrite primitive, not a bare os.Remove. The
+// routing tests below swap the seam, so without this check a regression that
+// rebound the default to a non-zeroing remove would still leave them green while
+// silently dropping the overwrite-before-unlink guarantee.
+func TestWipeTempFileDefaultsToSecurePrimitive(t *testing.T) {
+	got := reflect.ValueOf(wipeTempFile).Pointer()
+	want := reflect.ValueOf(fileops.OverwriteAndRemove).Pointer()
+	if got != want {
+		t.Fatal("wipeTempFile default is not fileops.OverwriteAndRemove; temp files may not be zero-overwritten before unlink")
+	}
+}
+
+// TestCleanupTempFilesRoutesThroughSecureWipe verifies that the stdin/stdout
+// staging temps are removed through the secure wipe path rather than a bare
+// os.Remove. Overwrite-before-unlink ordering itself is covered by
+// fileops.TestTempFilesOverwrittenBeforeUnlink; here we only check the routing.
+func TestCleanupTempFilesRoutesThroughSecureWipe(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+	}{
+		{"decrypt-to-stdout plaintext temp", "picocrypt-out-"},
+		{"encrypt-from-stdin plaintext temp", "picocrypt-stdin-"},
+		{"ciphertext staging temp", "picocrypt-cipher-"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tmp := filepath.Join(dir, tc.prefix+"fixture")
+			content := bytes.Repeat([]byte{0xA5}, 300*1024) // > one 64 KiB overwrite chunk
+			if err := os.WriteFile(tmp, content, 0600); err != nil {
+				t.Fatalf("write temp: %v", err)
+			}
+
+			var routed []string
+			prev := wipeTempFile
+			wipeTempFile = func(p string) error {
+				routed = append(routed, p)
+				return prev(p) // delegate to the real primitive
+			}
+			defer func() { wipeTempFile = prev }()
+
+			cleanupTempFiles(tmp)
+
+			if len(routed) != 1 || routed[0] != tmp {
+				t.Fatalf("temp not routed through secure wipe seam (bare os.Remove?): routed=%v want=[%q]", routed, tmp)
+			}
+			if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+				t.Fatalf("temp still exists after cleanup: %v", err)
+			}
+		})
+	}
+}
+
+// TestCleanupTempFilesWipesAllProvidedTemps proves the shared helper handles the
+// real call shape from both runEncrypt and runDecrypt: a stdin staging temp AND
+// a stdout staging temp are both securely wiped in one cleanup pass.
+func TestCleanupTempFilesWipesAllProvidedTemps(t *testing.T) {
+	dir := t.TempDir()
+	stdinTemp := filepath.Join(dir, "picocrypt-stdin-a")
+	stdoutTemp := filepath.Join(dir, "picocrypt-out-b")
+	for _, p := range []string{stdinTemp, stdoutTemp} {
+		if err := os.WriteFile(p, []byte("plaintext fragment"), 0600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	var routed []string
+	prev := wipeTempFile
+	wipeTempFile = func(p string) error {
+		routed = append(routed, p)
+		return prev(p)
+	}
+	defer func() { wipeTempFile = prev }()
+
+	cleanupTempFiles(stdinTemp, stdoutTemp)
+
+	if len(routed) != 2 {
+		t.Fatalf("expected both temps routed through secure wipe, got %v", routed)
+	}
+	for _, p := range []string{stdinTemp, stdoutTemp} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("temp %s still exists after cleanup", p)
+		}
+	}
+}
+
+// TestCleanupTempFilesSkipsEmptyPaths guards the "no temp was created" case:
+// runEncrypt/runDecrypt pass "" when stdin/stdout buffering never ran, and the
+// helper must not invoke the wipe seam (which would error on an empty path).
+func TestCleanupTempFilesSkipsEmptyPaths(t *testing.T) {
+	calls := 0
+	prev := wipeTempFile
+	wipeTempFile = func(p string) error {
+		calls++
+		return nil
+	}
+	defer func() { wipeTempFile = prev }()
+
+	cleanupTempFiles("", "")
+
+	if calls != 0 {
+		t.Fatalf("cleanupTempFiles invoked wipe seam for empty paths: %d calls", calls)
 	}
 }
 

--- a/src/internal/fileops/encrypted_reader_test.go
+++ b/src/internal/fileops/encrypted_reader_test.go
@@ -1,0 +1,53 @@
+package fileops
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+// eofDataReader returns its entire payload together with io.EOF in a single Read,
+// then io.EOF with no data on every subsequent Read. This is a legal io.Reader
+// (Go permits returning n>0 alongside io.EOF) and exercises the encryptedReader
+// path where data arrives simultaneously with EOF.
+type eofDataReader struct {
+	data []byte
+	done bool
+}
+
+func (e *eofDataReader) Read(p []byte) (int, error) {
+	if e.done {
+		return 0, io.EOF
+	}
+	n := copy(p, e.data)
+	e.done = true
+	return n, io.EOF
+}
+
+// TestEncryptedReaderDecryptsDataDeliveredWithEOF: a reader that returns data
+// together with io.EOF must still be decrypted. The old `err == nil && n > 0`
+// guard skipped XORKeyStream when err == io.EOF, leaking raw ciphertext to the
+// caller.
+func TestEncryptedReaderDecryptsDataDeliveredWithEOF(t *testing.T) {
+	c, err := NewTempZipCiphers()
+	if err != nil {
+		t.Fatalf("NewTempZipCiphers: %v", err)
+	}
+	defer c.Close()
+
+	plaintext := []byte("Picocrypt-NG encryptedReader EOF+data regression payload.")
+
+	// Encrypt the known plaintext with the Writer cipher to obtain ciphertext.
+	ciphertext := make([]byte, len(plaintext))
+	c.Writer.XORKeyStream(ciphertext, plaintext)
+
+	er := &encryptedReader{r: &eofDataReader{data: ciphertext}, cipher: c.Reader}
+	got, err := io.ReadAll(er)
+	if err != nil {
+		t.Fatalf("io.ReadAll(encryptedReader): %v", err)
+	}
+
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("encryptedReader did not decrypt data delivered with io.EOF\n got: %q\nwant: %q", got, plaintext)
+	}
+}

--- a/src/internal/fileops/zip.go
+++ b/src/internal/fileops/zip.go
@@ -49,7 +49,7 @@ type encryptedReader struct {
 func (er *encryptedReader) Read(data []byte) (int, error) {
 	src := make([]byte, len(data))
 	n, err := er.r.Read(src)
-	if err == nil && n > 0 {
+	if n > 0 {
 		dst := make([]byte, n)
 		er.cipher.XORKeyStream(dst, src[:n])
 		copy(data, dst)

--- a/src/internal/header/reader.go
+++ b/src/internal/header/reader.go
@@ -320,7 +320,21 @@ func (r *Reader) ReadHeaderRaw() (*ReadHeaderRawResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("decode comment length: %w", err)
 	}
+
+	// SEC-01/D-02: validate the comment-length field before it sizes the
+	// allocation below. This mirrors the guard in ReadHeader: the ^\d{5}$
+	// match caps the value to [0, 99999] and forbids '-', and the explicit
+	// MaxCommentLen bound is defense-in-depth. Without it a crafted/corrupt
+	// length (e.g. a decoded "-0001") reaches make([]byte, 0, commentsLen)
+	// with a negative value and panics — a pre-auth crash, since the length is
+	// trusted here before any header MAC is verified.
+	if !commentLenRE.Match(commentLenDec) {
+		return nil, ErrInvalidCommentLength
+	}
 	commentsLen, _ := strconv.Atoi(string(commentLenDec))
+	if commentsLen < 0 || commentsLen > MaxCommentLen {
+		return nil, ErrInvalidCommentLength
+	}
 	raw.CommentsLen = commentsLen
 
 	// Read comments (track corruption but continue reading)

--- a/src/internal/header/reader_raw_commentlen_test.go
+++ b/src/internal/header/reader_raw_commentlen_test.go
@@ -1,0 +1,81 @@
+package header
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"Picocrypt-NG/internal/encoding"
+)
+
+// rawHeaderWithCommentLenField builds the leading bytes of a volume header — the
+// RS-encoded version field followed by an RS-encoded 5-byte comment-length field
+// whose decoded value is commentLen5 verbatim. It stops after the comment-length
+// field, which is all ReadHeaderRaw needs to reach the comment allocation.
+func rawHeaderWithCommentLenField(t *testing.T, rs *encoding.RSCodecs, commentLen5 string) []byte {
+	t.Helper()
+	if len(commentLen5) != 5 {
+		t.Fatalf("comment-length field must be exactly 5 bytes, got %q", commentLen5)
+	}
+	versionEnc, err := encoding.Encode(rs.RS5, []byte("v2.10"))
+	if err != nil {
+		t.Fatalf("encode version: %v", err)
+	}
+	commentLenEnc, err := encoding.Encode(rs.RS5, []byte(commentLen5))
+	if err != nil {
+		t.Fatalf("encode comment length: %v", err)
+	}
+	return append(append([]byte{}, versionEnc...), commentLenEnc...)
+}
+
+// TestReadHeaderRawRejectsNegativeCommentLength pins the SEC-01/D-02 guard on the
+// guard-less raw path. A crafted comment-length field that RS-decodes to "-0001"
+// makes strconv.Atoi return -1; without a bound, ReadHeaderRaw reaches
+// make([]byte, 0, -1), which panics — a pre-auth crash on attacker-controlled
+// input (the comment length is read and trusted before any MAC is verified).
+// ReadHeader already rejects this; ReadHeaderRaw must do the same, returning a
+// clean ErrInvalidCommentLength instead of panicking.
+func TestReadHeaderRawRejectsNegativeCommentLength(t *testing.T) {
+	rs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("NewRSCodecs: %v", err)
+	}
+
+	input := rawHeaderWithCommentLenField(t, rs, "-0001")
+	reader := NewReader(bytes.NewReader(input), rs)
+
+	var readErr error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("ReadHeaderRaw panicked on negative comment length: %v", r)
+			}
+		}()
+		_, readErr = reader.ReadHeaderRaw()
+	}()
+
+	if readErr == nil {
+		t.Fatal("ReadHeaderRaw accepted a negative comment length; want ErrInvalidCommentLength")
+	}
+	if !errors.Is(readErr, ErrInvalidCommentLength) {
+		t.Fatalf("ReadHeaderRaw error = %v; want ErrInvalidCommentLength", readErr)
+	}
+}
+
+// TestReadHeaderRawRejectsNonNumericCommentLength covers the other unvalidated
+// case: a comment-length field that is not 5 digits. The old code ignored the
+// strconv.Atoi error and silently treated it as length 0, parsing a header whose
+// real structure it could not know. The guard now rejects it up front.
+func TestReadHeaderRawRejectsNonNumericCommentLength(t *testing.T) {
+	rs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("NewRSCodecs: %v", err)
+	}
+
+	input := rawHeaderWithCommentLenField(t, rs, "1a2b3")
+	reader := NewReader(bytes.NewReader(input), rs)
+
+	if _, err := reader.ReadHeaderRaw(); !errors.Is(err, ErrInvalidCommentLength) {
+		t.Fatalf("ReadHeaderRaw error = %v; want ErrInvalidCommentLength", err)
+	}
+}

--- a/src/internal/ui/app.go
+++ b/src/internal/ui/app.go
@@ -250,10 +250,28 @@ func (a *App) Run(startupPaths []string) {
 }
 
 func (a *App) scheduleStartupPaths(startupPaths []string) {
+	// applyOpened drains paths buffered by the macOS open-file bridge and feeds
+	// them through the normal drop handler. It is the notify handler for paths
+	// that arrive while the app is already running (issue #127: warm openURLs
+	// events and late cold-launch events delivered after the initial drain).
+	applyOpened := func() {
+		fyne.Do(func() {
+			opened := drainOpenedPaths()
+			if len(opened) == 0 {
+				return
+			}
+			a.applyStartupPaths(opened)
+		})
+	}
+
 	// Always wire SetOnStarted: even if startupPaths is empty, AppleEvent paths
 	// from a Finder cold launch may have been buffered by the cgo handler before
-	// Go's main() ran (drainOpenedPaths is a no-op on non-darwin via stub).
+	// Go's main() ran (drainOpenedPaths returns nothing on non-darwin).
 	a.fyneApp.Lifecycle().SetOnStarted(func() {
+		// Register the notify handler *before* the initial drain so any path that
+		// arrives during or after startup is applied — closing the race that made
+		// cold launches drop files and warm launches drop everything.
+		setOpenedPathsNotify(applyOpened)
 		fyne.Do(func() {
 			merged := append([]string(nil), startupPaths...)
 			merged = append(merged, drainOpenedPaths()...)

--- a/src/internal/ui/drop_test.go
+++ b/src/internal/ui/drop_test.go
@@ -719,6 +719,59 @@ func TestScheduleStartupPathsAlwaysWiresStartHook(t *testing.T) {
 	}
 }
 
+// TestScheduleStartupPathsAppliesWarmOpenedPaths covers issue #127: a path opened
+// while the app is already running (a warm application:openURLs: event, simulated
+// here by appendOpenedPath after the lifecycle start hook fired) must be drained
+// and applied through the normal drop handler. Before the event-driven wiring,
+// drainOpenedPaths ran exactly once inside the start hook, so any path arriving
+// afterward was silently lost — the app merely came to the foreground.
+func TestScheduleStartupPathsAppliesWarmOpenedPaths(t *testing.T) {
+	if raceEnabled {
+		t.Skip("Fyne v2.7.3 internal cache races under -race; covered on arm64 matrix")
+	}
+
+	// Reset package-global bridge state: other tests fire the start hook and leave
+	// a notify handler registered.
+	setOpenedPathsNotify(nil)
+	drainOpenedPaths()
+	t.Cleanup(func() {
+		setOpenedPathsNotify(nil)
+		drainOpenedPaths()
+	})
+
+	fyneApp := newTestFyneApp(t)
+
+	a := createUIReadyDropTestApp(t, fyneApp)
+	inputFile := filepath.Join(t.TempDir(), "warm-open.txt")
+	if err := os.WriteFile(inputFile, []byte("payload"), 0644); err != nil {
+		t.Fatalf("Create test file: %v", err)
+	}
+
+	fake := newLifecycleCaptureApp(fyne.CurrentApp())
+	a.fyneApp = fake
+
+	a.scheduleStartupPaths(nil)
+	if fake.started == nil {
+		t.Fatal("expected startup hook to be registered")
+	}
+
+	// Fire the start hook with nothing buffered: still no input applied.
+	fake.started()
+	waitForDropProcessing(t, a)
+	if state := snapshotDropState(t, a); state.InputFile != "" {
+		t.Fatalf("InputFile = %q before any opened path; want empty", state.InputFile)
+	}
+
+	// A warm openURLs event arrives after launch.
+	appendOpenedPath(inputFile)
+	fyne.DoAndWait(func() {}) // barrier: let the notify-scheduled fyne.Do run
+	waitForDropProcessing(t, a)
+
+	if state := snapshotDropState(t, a); state.InputFile != inputFile {
+		t.Fatalf("InputFile = %q after warm opened path; want %q", state.InputFile, inputFile)
+	}
+}
+
 // TestKeyfileDropHandling tests keyfile drop in keyfile modal.
 func TestKeyfileDropHandling(t *testing.T) {
 	t.Run("AddUniqueKeyfiles", func(t *testing.T) {

--- a/src/internal/ui/fyne_test_helpers_test.go
+++ b/src/internal/ui/fyne_test_helpers_test.go
@@ -22,19 +22,45 @@ func mustNewState(t *testing.T) *app.State {
 	return s
 }
 
-// TestMain pre-warms Fyne's process-global font-metric cache before any
-// parallel test goroutines start. Fyne v2.7.3's internal/cache/base.go
-// `setAlive` is racy on first writes (verified via -race detector during
-// concurrent test.NewApp + MeasureText calls), and the cache is shared
-// across all test.NewApp instances. Running one MeasureText in TestMain
-// populates the cache serially, so subsequent parallel tests only read.
+// asciiWarmup is every printable-ASCII rune (0x20..0x7e). Measuring it populates
+// one cmapCache bucket per rune&0xFF; since printable ASCII has distinct low
+// bytes, warming it covers every bucket the Latin UI text in these tests can
+// touch, so later measurements only read warmed buckets.
+func asciiWarmup() string {
+	b := make([]byte, 0, 0x7e-0x20+1)
+	for c := byte(0x20); c <= 0x7e; c++ {
+		b = append(b, c)
+	}
+	return string(b)
+}
+
+// TestMain pre-warms Fyne's process-global font Face cache before any test
+// measures text. The Face's cmapCache is a lock-free [256]uint32 keyed by
+// rune&0xFF (go-text typesetting cmap_cache.go) shared across every
+// test.NewApp; a first-write racing a concurrent read trips the -race detector
+// (the CI amd64 matrix). MeasureText and the harfbuzz shaping path used by
+// Entry/RichText both populate it via Face.NominalGlyph, so warming via
+// MeasureText covers both readers.
+//
+// The warmup must COMPLETE before m.Run starts. fyne.DoAndWait only blocks when
+// called off the main goroutine: the test driver's EnsureNotMain runs the func
+// inline when off-main, but on the main goroutine (where TestMain runs) it logs
+// a thread violation and fires the func on a new, un-awaited goroutine — which
+// leaves the warmup racing the first test (the exact G14-vs-G15 stack the
+// -race job reported). Running the warmup from a child goroutine forces the
+// synchronous inline path; <-done then guarantees it finished before any test.
 func TestMain(m *testing.M) {
 	app := test.NewApp()
-	fyne.DoAndWait(func() {
-		// Trigger font metric cache population on the common path.
-		_ = fyne.MeasureText("Picocrypt NG 2.09", 14, fyne.TextStyle{})
-		_ = fyne.MeasureText("Picocrypt NG 2.09", 14, fyne.TextStyle{Bold: true})
-	})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fyne.DoAndWait(func() {
+			ascii := asciiWarmup()
+			_ = fyne.MeasureText(ascii, 14, fyne.TextStyle{})
+			_ = fyne.MeasureText(ascii, 14, fyne.TextStyle{Bold: true})
+		})
+	}()
+	<-done
 	app.Quit()
 	os.Exit(m.Run())
 }

--- a/src/internal/ui/macos_open.go
+++ b/src/internal/ui/macos_open.go
@@ -1,0 +1,63 @@
+// Platform-neutral side of the macOS "open file" bridge.
+//
+// On darwin, AppleEvents (Finder double-click, drag onto the app/dock icon) are
+// delivered to goAppendOpenedPath in macos_open_darwin.go, which forwards each
+// path to appendOpenedPath here. Buffering and delivery live in this file — not
+// the darwin file — so the delivery logic is unit-testable on every CI platform,
+// not only macOS.
+//
+// Delivery is event-driven: appendOpenedPath fires a notify handler registered
+// by the running App via setOpenedPathsNotify. This lets paths that arrive while
+// the app is already running (issue #127: warm application:openURLs: events, and
+// cold-launch events delivered after the first drain) reach the UI instead of
+// sitting in the buffer indefinitely.
+package ui
+
+import "sync"
+
+var (
+	openedPathsMu     sync.Mutex
+	openedPaths       []string
+	openedPathsNotify func()
+)
+
+// appendOpenedPath buffers a path opened via the OS (AppleEvents on darwin) and
+// invokes the registered notify handler, if any, so the path can be drained and
+// applied. The handler is called outside the lock to avoid re-entrancy on
+// openedPathsMu.
+func appendOpenedPath(path string) {
+	if path == "" {
+		return
+	}
+	openedPathsMu.Lock()
+	openedPaths = append(openedPaths, path)
+	notify := openedPathsNotify
+	openedPathsMu.Unlock()
+
+	if notify != nil {
+		notify()
+	}
+}
+
+// setOpenedPathsNotify registers (or clears, when fn is nil) the handler invoked
+// after a path is buffered. Callers should drain once immediately after
+// registering so paths buffered before registration are not missed.
+func setOpenedPathsNotify(fn func()) {
+	openedPathsMu.Lock()
+	openedPathsNotify = fn
+	openedPathsMu.Unlock()
+}
+
+// drainOpenedPaths returns the buffered paths and clears the buffer, or nil when
+// empty. On non-darwin the buffer is always empty (nothing calls appendOpenedPath).
+func drainOpenedPaths() []string {
+	openedPathsMu.Lock()
+	defer openedPathsMu.Unlock()
+	if len(openedPaths) == 0 {
+		return nil
+	}
+	out := make([]string, len(openedPaths))
+	copy(out, openedPaths)
+	openedPaths = openedPaths[:0]
+	return out
+}

--- a/src/internal/ui/macos_open_darwin.go
+++ b/src/internal/ui/macos_open_darwin.go
@@ -8,10 +8,6 @@ package ui
 */
 import "C"
 
-import (
-	"sync"
-)
-
 // The Objective-C side of this bridge lives in macos_open_darwin.m (separate
 // file because the preamble of a //export-using cgo file must contain only
 // declarations, not definitions — putting @implementation here would generate
@@ -19,34 +15,14 @@ import (
 //
 // macos_open_darwin.m uses class_addMethod to inject application:openURLs:
 // into GLFW's existing application delegate at +(void)load time, then calls
-// goAppendOpenedPath below for each opened file URL.
-
-var (
-	openedPathsMu sync.Mutex
-	openedPaths   []string
-)
+// goAppendOpenedPath below for each opened file URL. Buffering, notify, and
+// drain logic lives in the platform-neutral macos_open.go so it is testable on
+// every CI platform.
 
 //export goAppendOpenedPath
 func goAppendOpenedPath(cpath *C.char) {
 	if cpath == nil {
 		return
 	}
-	path := C.GoString(cpath)
-	openedPathsMu.Lock()
-	openedPaths = append(openedPaths, path)
-	openedPathsMu.Unlock()
-}
-
-// drainOpenedPaths returns paths buffered from AppleEvents and clears the buffer.
-// Safe to call from the Fyne main goroutine inside Lifecycle.SetOnStarted.
-func drainOpenedPaths() []string {
-	openedPathsMu.Lock()
-	defer openedPathsMu.Unlock()
-	if len(openedPaths) == 0 {
-		return nil
-	}
-	out := make([]string, len(openedPaths))
-	copy(out, openedPaths)
-	openedPaths = openedPaths[:0]
-	return out
+	appendOpenedPath(C.GoString(cpath))
 }

--- a/src/internal/ui/macos_open_other.go
+++ b/src/internal/ui/macos_open_other.go
@@ -1,5 +1,0 @@
-//go:build !darwin
-
-package ui
-
-func drainOpenedPaths() []string { return nil }

--- a/src/internal/volume/decrypt.go
+++ b/src/internal/volume/decrypt.go
@@ -21,6 +21,10 @@ import (
 
 var unpackArchive = fileops.Unpack
 
+// newPayloadReader is identity in production; tests replace it to inject short
+// reads and check that the io.ReadFull loops reassemble full blocks.
+var newPayloadReader = func(r io.Reader) io.Reader { return r }
+
 // rsEncodedBlockSize is the on-disk byte size of a single Reed-Solomon-encoded
 // 1 MiB payload block: each 128-byte (RS128DataSize) plaintext chunk encodes to
 // 136 bytes (RS128EncodedSize), so a 1 MiB block expands to 1,114,112 bytes.
@@ -483,12 +487,14 @@ func decryptVerifyMACFirstWithDecode(ctx *OperationContext, req *DecryptRequest,
 	}
 	src := make([]byte, srcBufSize)
 
+	reader := newPayloadReader(io.Reader(fin))
+
 	for {
 		if ctx.IsCancelled() {
 			return ctx.CancellationError()
 		}
 
-		n, readErr := fin.Read(src)
+		n, readErr := io.ReadFull(reader, src)
 		if n > 0 {
 			srcData := src[:n]
 			var data []byte
@@ -528,7 +534,7 @@ func decryptVerifyMACFirstWithDecode(ctx *OperationContext, req *DecryptRequest,
 			// MAC across the 60 GiB rekey boundary without any rekeying.
 		}
 
-		if readErr == io.EOF {
+		if readErr == io.EOF || readErr == io.ErrUnexpectedEOF {
 			break
 		}
 		if readErr != nil {
@@ -660,12 +666,14 @@ func decryptPayloadWithFastDecode(ctx *OperationContext, req *DecryptRequest, fa
 	dst := util.GetMiBBuffer()      // Decrypted data is always <= 1 MiB
 	defer util.PutMiBBuffer(dst)
 
+	reader := newPayloadReader(io.Reader(fin))
+
 	for {
 		if ctx.IsCancelled() {
 			return ctx.CancellationError()
 		}
 
-		n, readErr := fin.Read(src)
+		n, readErr := io.ReadFull(reader, src)
 		if n > 0 {
 			srcData := src[:n]
 			var data []byte
@@ -695,7 +703,7 @@ func decryptPayloadWithFastDecode(ctx *OperationContext, req *DecryptRequest, fa
 			} else {
 				done += int64(n)
 			}
-			counter += int64(len(data))
+			counter += int64(util.MiB)
 
 			progress, speed, eta := util.Statify(done, ctx.Total, startTime)
 			ctx.UpdateProgress(progress, fmt.Sprintf("%.2f%%", progress*100))
@@ -714,7 +722,7 @@ func decryptPayloadWithFastDecode(ctx *OperationContext, req *DecryptRequest, fa
 			}
 		}
 
-		if readErr == io.EOF {
+		if readErr == io.EOF || readErr == io.ErrUnexpectedEOF {
 			break
 		}
 		if readErr != nil {

--- a/src/internal/volume/deniability.go
+++ b/src/internal/volume/deniability.go
@@ -18,6 +18,12 @@ import (
 
 var wipeDeniabilityTemp = fileops.OverwriteAndRemove
 
+// newDeniabilityReader is identity in production; tests replace it to inject
+// short reads and verify the io.ReadFull loops pin the rekey boundary to a
+// fixed block count regardless of read chunking. Mirrors newPayloadReader in
+// decrypt.go for the main payload path.
+var newDeniabilityReader = func(r io.Reader) io.Reader { return r }
+
 // AddDeniability wraps a volume with a deniability layer.
 // This encrypts the entire volume with XChaCha20 using a separate key derived from the password.
 //
@@ -106,8 +112,10 @@ func AddDeniability(volumePath, password string, reporter ProgressReporter) erro
 	dst := util.GetMiBBuffer()
 	defer util.PutMiBBuffer(dst)
 
+	reader := newDeniabilityReader(io.Reader(fin))
+
 	for {
-		n, readErr := fin.Read(buf)
+		n, readErr := io.ReadFull(reader, buf)
 		if n > 0 {
 			cipher.XORKeyStream(dst[:n], buf[:n])
 
@@ -117,7 +125,12 @@ func AddDeniability(volumePath, password string, reporter ProgressReporter) erro
 			}
 
 			done += int64(n)
-			counter += int64(n)
+			// Pin the rekey boundary to a fixed block count regardless of read
+			// chunking: io.ReadFull delivers full MiB blocks, so the counter
+			// advances by util.MiB per block. The threshold is a MiB multiple
+			// and only crossable on a full block, so the final partial block's
+			// over-count is irrelevant (the loop breaks at EOF).
+			counter += int64(util.MiB)
 
 			if reporter != nil {
 				reporter.SetProgress(float32(done)/float32(total), "")
@@ -135,7 +148,7 @@ func AddDeniability(volumePath, password string, reporter ProgressReporter) erro
 			}
 		}
 
-		if readErr == io.EOF {
+		if readErr == io.EOF || readErr == io.ErrUnexpectedEOF {
 			break
 		}
 		if readErr != nil {
@@ -252,8 +265,10 @@ func RemoveDeniability(volumePath, password string, reporter ProgressReporter, r
 	dst := util.GetMiBBuffer()
 	defer util.PutMiBBuffer(dst)
 
+	reader := newDeniabilityReader(io.Reader(fin))
+
 	for {
-		n, readErr := fin.Read(buf)
+		n, readErr := io.ReadFull(reader, buf)
 		if n > 0 {
 			cipher.XORKeyStream(dst[:n], buf[:n])
 
@@ -263,7 +278,10 @@ func RemoveDeniability(volumePath, password string, reporter ProgressReporter, r
 			}
 
 			done += int64(n)
-			counter += int64(n)
+			// Pin the rekey boundary to a fixed block count (see AddDeniability):
+			// io.ReadFull delivers full MiB blocks, so the rekey offset is
+			// independent of how the underlying reader chunks its reads.
+			counter += int64(util.MiB)
 
 			if reporter != nil {
 				reporter.SetProgress(float32(done)/float32(total), "")
@@ -281,7 +299,7 @@ func RemoveDeniability(volumePath, password string, reporter ProgressReporter, r
 			}
 		}
 
-		if readErr == io.EOF {
+		if readErr == io.EOF || readErr == io.ErrUnexpectedEOF {
 			break
 		}
 		if readErr != nil {

--- a/src/internal/volume/deniability_short_read_test.go
+++ b/src/internal/volume/deniability_short_read_test.go
@@ -1,0 +1,141 @@
+package volume
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"Picocrypt-NG/internal/crypto"
+	"Picocrypt-NG/internal/util"
+)
+
+// deniabilityShortReadSeam installs newDeniabilityReader to wrap the payload
+// reader in a shortReader, and returns a restore func. max is deliberately
+// smaller than the 1 MiB block so reads never align to block boundaries,
+// forcing the io.ReadFull loops to reassemble full blocks. Mirrors
+// shortReadSeam (which targets the main-payload newPayloadReader seam).
+func deniabilityShortReadSeam(max int) func() {
+	prev := newDeniabilityReader
+	newDeniabilityReader = func(r io.Reader) io.Reader {
+		return &shortReader{r: r, max: max}
+	}
+	return func() { newDeniabilityReader = prev }
+}
+
+// TestDeniabilityAddShortReadsByteIdentical isolates the AddDeniability encrypt
+// loop. The deniability layer is a pure XChaCha20 keystream over the whole
+// volume, so the only chunk-sensitive behaviour is the rekey boundary. Adding
+// deniability to the same input twice — once with full reads, once under a
+// short-read seam — must yield byte-identical output. With the old
+// `counter += int64(n)` + bare Read, a short read advances the rekey offset
+// early, so the two outputs diverge after the first rekey crossing.
+func TestDeniabilityAddShortReadsByteIdentical(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Lower the rekey threshold so a small synthetic volume crosses it.
+	prevThreshold := crypto.RekeyThreshold
+	crypto.RekeyThreshold = 4 * int64(util.MiB)
+	defer func() { crypto.RekeyThreshold = prevThreshold }()
+
+	// 8 MiB > 4 MiB threshold (and > 4 MiB + one short-read's worth of slack),
+	// guaranteeing data past the rekey boundary where a desync would show.
+	payload := randomPlaintext(t, 8*1024*1024)
+
+	// Pin salt+nonce: AddDeniability draws them via crypto.RandomBytes(rand.Reader),
+	// so reseeding rand.Reader before each call gives both runs an identical
+	// header. That leaves the rekey offset as the only thing that can differ.
+	prevRand := rand.Reader
+	defer func() { rand.Reader = prevRand }()
+
+	add := func(name string) []byte {
+		path := filepath.Join(tmp, name)
+		if err := os.WriteFile(path, payload, 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		rand.Reader = newDeterministicReader()
+		if err := AddDeniability(path, "deniability-short-read", nil); err != nil {
+			t.Fatalf("AddDeniability(%s): %v", name, err)
+		}
+		out, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		return out
+	}
+
+	full := add("full.bin") // identity seam (full reads)
+
+	restore := deniabilityShortReadSeam(shortReadMax)
+	defer restore()
+	short := add("short.bin") // short reads
+
+	if !bytes.Equal(full, short) {
+		t.Fatalf("deniability rekey offset is not chunk-independent: full-read and short-read output differ (len full=%d short=%d)", len(full), len(short))
+	}
+}
+
+// TestDeniabilityRemoveShortReadsRoundTrip isolates the RemoveDeniability
+// decrypt loop. A deniable volume written with full reads must decrypt cleanly
+// under a short-read seam and recover the inner .pcv byte-for-byte. With the
+// old bare Read + `counter += int64(n)`, the short-read decrypt rekeys at a
+// different offset than encrypt did, corrupting the inner volume past the rekey
+// boundary so RemoveDeniability's validity check fails outright.
+func TestDeniabilityRemoveShortReadsRoundTrip(t *testing.T) {
+	rs := newRSCodecsT(t)
+	tmp := t.TempDir()
+
+	prevThreshold := crypto.RekeyThreshold
+	crypto.RekeyThreshold = 4 * int64(util.MiB)
+	defer func() { crypto.RekeyThreshold = prevThreshold }()
+
+	// Build a real inner volume: RemoveDeniability verifies the decrypted output
+	// is a valid volume, so a corrupt rekey would surface as a failed check.
+	plaintext := randomPlaintext(t, 8*1024*1024) // inner .pcv ends up > 4 MiB threshold
+	inputPath := filepath.Join(tmp, "in.bin")
+	if err := os.WriteFile(inputPath, plaintext, 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	volPath := filepath.Join(tmp, "in.bin.pcv")
+	encReq := &EncryptRequest{
+		InputFile:   inputPath,
+		OutputFile:  volPath,
+		Password:    "deniability-roundtrip",
+		ReedSolomon: false,
+		Reporter:    &GoldenTestReporter{},
+		RSCodecs:    rs,
+	}
+	if err := Encrypt(context.Background(), encReq); err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	// Snapshot the inner .pcv before deniability wraps it in place.
+	innerVolume, err := os.ReadFile(volPath)
+	if err != nil {
+		t.Fatalf("read inner volume: %v", err)
+	}
+
+	// Add deniability with full reads (the known-good encrypt path).
+	if err := AddDeniability(volPath, "deniability-roundtrip", nil); err != nil {
+		t.Fatalf("AddDeniability: %v", err)
+	}
+
+	// Remove deniability under a short-read seam.
+	restore := deniabilityShortReadSeam(shortReadMax)
+	defer restore()
+	outPath, err := RemoveDeniability(volPath, "deniability-roundtrip", nil, rs)
+	if err != nil {
+		t.Fatalf("RemoveDeniability under short-read seam: %v", err)
+	}
+
+	recovered, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read recovered volume: %v", err)
+	}
+	if !bytes.Equal(recovered, innerVolume) {
+		t.Fatalf("short-read decrypt did not recover the inner volume (len recovered=%d want=%d)", len(recovered), len(innerVolume))
+	}
+}

--- a/src/internal/volume/encrypt.go
+++ b/src/internal/volume/encrypt.go
@@ -337,6 +337,7 @@ func encryptPayload(ctx *OperationContext, req *EncryptRequest) error {
 	if ctx.TempZipInUse && ctx.TempCiphers != nil {
 		reader = fileops.WrapReaderWithCipher(fin, ctx.TempCiphers)
 	}
+	reader = newPayloadReader(reader)
 
 	// Encrypt loop
 	ctx.SetCanCancel(true)
@@ -355,7 +356,7 @@ func encryptPayload(ctx *OperationContext, req *EncryptRequest) error {
 			return ctx.CancellationError()
 		}
 
-		n, readErr := reader.Read(src)
+		n, readErr := io.ReadFull(reader, src)
 		if n > 0 {
 			srcData := src[:n]
 			dstData := dst[:n]
@@ -380,7 +381,7 @@ func encryptPayload(ctx *OperationContext, req *EncryptRequest) error {
 			}
 
 			done += int64(n)
-			counter += int64(n)
+			counter += int64(util.MiB)
 
 			progress, speed, eta := util.Statify(done, ctx.Total, startTime)
 			ctx.UpdateProgress(progress, fmt.Sprintf("%.2f%%", progress*100))
@@ -395,7 +396,7 @@ func encryptPayload(ctx *OperationContext, req *EncryptRequest) error {
 			}
 		}
 
-		if readErr == io.EOF {
+		if readErr == io.EOF || readErr == io.ErrUnexpectedEOF {
 			break
 		}
 		if readErr != nil {

--- a/src/internal/volume/golden_test.go
+++ b/src/internal/volume/golden_test.go
@@ -3,7 +3,6 @@ package volume
 import (
 	"archive/zip"
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +10,7 @@ import (
 	"testing"
 
 	"Picocrypt-NG/internal/encoding"
+	"Picocrypt-NG/internal/header"
 )
 
 // GoldenTestReporter is a minimal reporter for testing
@@ -147,10 +147,10 @@ var goldenCompressedTestCases = []struct {
 }
 
 var goldenKeyfileTestCases = []struct {
-	name          string
-	file          string
-	password      string
-	keyfiles      []string
+	name           string
+	file           string
+	password       string
+	keyfiles       []string
 	keyfileOrdered bool
 }{
 	{
@@ -588,7 +588,7 @@ func TestGoldenKeyfileHeaderFlags(t *testing.T) {
 	}
 
 	testCases := []struct {
-		file          string
+		file           string
 		keyfileOrdered bool
 	}{
 		{file: "pico_test_v2_keyfile_single.txt.pcv", keyfileOrdered: false},
@@ -643,7 +643,9 @@ func TestGoldenV1Detection(t *testing.T) {
 
 	// Read version
 	versionEnc := make([]byte, 15)
-	_, _ = fin.Read(versionEnc)
+	if _, err := io.ReadFull(fin, versionEnc); err != nil {
+		t.Fatalf("Failed to read version header: %v", err)
+	}
 
 	versionDec, err := encoding.Decode(rsCodecs.RS5, versionEnc, false)
 	if err != nil {
@@ -653,7 +655,7 @@ func TestGoldenV1Detection(t *testing.T) {
 	version := string(versionDec)
 	t.Logf("V1 file version: %s", version)
 
-	if version[0:2] != "v1" {
+	if !strings.HasPrefix(version, "v1") {
 		t.Errorf("Expected v1.x version, got: %s", version)
 	}
 }
@@ -680,7 +682,9 @@ func TestGoldenV2Detection(t *testing.T) {
 
 	// Read version
 	versionEnc := make([]byte, 15)
-	_, _ = fin.Read(versionEnc)
+	if _, err := io.ReadFull(fin, versionEnc); err != nil {
+		t.Fatalf("Failed to read version header: %v", err)
+	}
 
 	versionDec, err := encoding.Decode(rsCodecs.RS5, versionEnc, false)
 	if err != nil {
@@ -690,7 +694,7 @@ func TestGoldenV2Detection(t *testing.T) {
 	version := string(versionDec)
 	t.Logf("V2 file version: %s", version)
 
-	if version[0:2] != "v2" {
+	if !strings.HasPrefix(version, "v2") {
 		t.Errorf("Expected v2.x version, got: %s", version)
 	}
 }
@@ -957,184 +961,9 @@ func goldenFixturePaths(testdataPath string, names []string) []string {
 	return paths
 }
 
-// NewHeaderReaderForTest creates a header reader for testing
-// This is a workaround to access header.Reader from the volume package
-func NewHeaderReaderForTest(r *os.File, rs *encoding.RSCodecs) *headerReaderWrapper {
-	return &headerReaderWrapper{r: r, rs: rs}
-}
-
-type headerReaderWrapper struct {
-	r  *os.File
-	rs *encoding.RSCodecs
-}
-
-type headerReadResult struct {
-	Header      *volumeHeader
-	DecodeError error
-}
-
-type volumeHeader struct {
-	Version     string
-	Comments    string
-	Flags       volumeFlags
-	Salt        []byte
-	HKDFSalt    []byte
-	SerpentIV   []byte
-	Nonce       []byte
-	KeyHash     []byte
-	KeyfileHash []byte
-	AuthTag     []byte
-}
-
-type volumeFlags struct {
-	Paranoid       bool
-	UseKeyfiles    bool
-	KeyfileOrdered bool
-	ReedSolomon    bool
-	Padded         bool
-}
-
-func (r *headerReaderWrapper) ReadHeader() (*headerReadResult, error) {
-	result := &headerReadResult{
-		Header: &volumeHeader{},
-	}
-	h := result.Header
-	var decodeErrors []error
-
-	// Read version (15 bytes -> 5 bytes)
-	versionEnc := make([]byte, 15)
-	if _, err := io.ReadFull(r.r, versionEnc); err != nil {
-		return nil, err
-	}
-	versionDec, err := encoding.Decode(r.rs.RS5, versionEnc, false)
-	if err != nil {
-		decodeErrors = append(decodeErrors, err)
-	}
-	h.Version = string(versionDec)
-
-	// Read comment length (15 bytes -> 5 bytes)
-	commentLenEnc := make([]byte, 15)
-	if _, err := io.ReadFull(r.r, commentLenEnc); err != nil {
-		return nil, err
-	}
-	commentLenDec, err := encoding.Decode(r.rs.RS5, commentLenEnc, false)
-	if err != nil {
-		decodeErrors = append(decodeErrors, err)
-	}
-
-	var commentsLen int
-	for _, b := range commentLenDec {
-		if b >= '0' && b <= '9' {
-			commentsLen = commentsLen*10 + int(b-'0')
-		}
-	}
-
-	// Read comments
-	comments := make([]byte, 0, commentsLen)
-	for i := 0; i < commentsLen; i++ {
-		cEnc := make([]byte, 3)
-		if _, err := io.ReadFull(r.r, cEnc); err != nil {
-			return nil, fmt.Errorf("read comment byte %d: %w", i, err)
-		}
-		cDec, err := encoding.Decode(r.rs.RS1, cEnc, false)
-		if err != nil {
-			decodeErrors = append(decodeErrors, err)
-		}
-		comments = append(comments, cDec...)
-	}
-	h.Comments = string(comments)
-
-	// Read flags (15 bytes -> 5 bytes)
-	flagsEnc := make([]byte, 15)
-	if _, err := io.ReadFull(r.r, flagsEnc); err != nil {
-		return nil, fmt.Errorf("read flags: %w", err)
-	}
-	flagsDec, err := encoding.Decode(r.rs.RS5, flagsEnc, false)
-	if err != nil {
-		decodeErrors = append(decodeErrors, err)
-	}
-	if len(flagsDec) >= 5 {
-		h.Flags.Paranoid = flagsDec[0] == 1
-		h.Flags.UseKeyfiles = flagsDec[1] == 1
-		h.Flags.KeyfileOrdered = flagsDec[2] == 1
-		h.Flags.ReedSolomon = flagsDec[3] == 1
-		h.Flags.Padded = flagsDec[4] == 1
-	}
-
-	// Read salt (48 bytes -> 16 bytes)
-	saltEnc := make([]byte, 48)
-	if _, err := io.ReadFull(r.r, saltEnc); err != nil {
-		return nil, fmt.Errorf("read salt: %w", err)
-	}
-	h.Salt, err = encoding.Decode(r.rs.RS16, saltEnc, false)
-	if err != nil {
-		decodeErrors = append(decodeErrors, err)
-	}
-
-	// Read HKDF salt (96 bytes -> 32 bytes)
-	hkdfSaltEnc := make([]byte, 96)
-	if _, err := io.ReadFull(r.r, hkdfSaltEnc); err != nil {
-		return nil, fmt.Errorf("read hkdf salt: %w", err)
-	}
-	h.HKDFSalt, err = encoding.Decode(r.rs.RS32, hkdfSaltEnc, false)
-	if err != nil {
-		decodeErrors = append(decodeErrors, err)
-	}
-
-	// Read Serpent IV (48 bytes -> 16 bytes)
-	serpentIVEnc := make([]byte, 48)
-	if _, err := io.ReadFull(r.r, serpentIVEnc); err != nil {
-		return nil, fmt.Errorf("read serpent iv: %w", err)
-	}
-	h.SerpentIV, err = encoding.Decode(r.rs.RS16, serpentIVEnc, false)
-	if err != nil {
-		decodeErrors = append(decodeErrors, err)
-	}
-
-	// Read nonce (72 bytes -> 24 bytes)
-	nonceEnc := make([]byte, 72)
-	if _, err := io.ReadFull(r.r, nonceEnc); err != nil {
-		return nil, fmt.Errorf("read nonce: %w", err)
-	}
-	h.Nonce, err = encoding.Decode(r.rs.RS24, nonceEnc, false)
-	if err != nil {
-		decodeErrors = append(decodeErrors, err)
-	}
-
-	// Read key hash (192 bytes -> 64 bytes)
-	keyHashEnc := make([]byte, 192)
-	if _, err := io.ReadFull(r.r, keyHashEnc); err != nil {
-		return nil, fmt.Errorf("read key hash: %w", err)
-	}
-	h.KeyHash, err = encoding.Decode(r.rs.RS64, keyHashEnc, false)
-	if err != nil {
-		decodeErrors = append(decodeErrors, err)
-	}
-
-	// Read keyfile hash (96 bytes -> 32 bytes)
-	keyfileHashEnc := make([]byte, 96)
-	if _, err := io.ReadFull(r.r, keyfileHashEnc); err != nil {
-		return nil, fmt.Errorf("read keyfile hash: %w", err)
-	}
-	h.KeyfileHash, err = encoding.Decode(r.rs.RS32, keyfileHashEnc, false)
-	if err != nil {
-		decodeErrors = append(decodeErrors, err)
-	}
-
-	// Read auth tag (192 bytes -> 64 bytes)
-	authTagEnc := make([]byte, 192)
-	if _, err := io.ReadFull(r.r, authTagEnc); err != nil {
-		return nil, fmt.Errorf("read auth tag: %w", err)
-	}
-	h.AuthTag, err = encoding.Decode(r.rs.RS64, authTagEnc, false)
-	if err != nil {
-		decodeErrors = append(decodeErrors, err)
-	}
-
-	// Set combined decode error if any occurred
-	if len(decodeErrors) > 0 {
-		result.DecodeError = decodeErrors[0] // Report first error
-	}
-
-	return result, nil
+// NewHeaderReaderForTest returns the production header reader so golden tests
+// exercise the real, audited parser (with its D-02 comment-length bound and RS
+// field widths) instead of a hand-rolled copy that could silently drift from it.
+func NewHeaderReaderForTest(r io.Reader, rs *encoding.RSCodecs) *header.Reader {
+	return header.NewReader(r, rs)
 }

--- a/src/internal/volume/rekey_counter_test.go
+++ b/src/internal/volume/rekey_counter_test.go
@@ -1,0 +1,110 @@
+package volume
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	mrand "math/rand/v2"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"Picocrypt-NG/internal/crypto"
+	"Picocrypt-NG/internal/util"
+)
+
+// deterministicReader is a seeded, repeatable byte source that pins the volume's
+// random salt/nonce/IV so two Encrypt calls produce an identical header. That
+// leaves the payload keystream (and thus the rekey offset) as the only thing that
+// can differ between the full-read and short-read runs.
+type deterministicReader struct{ rng *mrand.ChaCha8 }
+
+func newDeterministicReader() *deterministicReader {
+	var seed [32]byte
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+	return &deterministicReader{rng: mrand.NewChaCha8(seed)}
+}
+
+func (d *deterministicReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = byte(d.rng.Uint64())
+	}
+	return len(p), nil
+}
+
+// TestRekeyCounterChunkIndependence checks that the rekey offset is driven by the
+// plaintext block count, not by how the underlying reader chunks its reads. The
+// counter += util.MiB change is equivalent to counter += int64(n) only because
+// io.ReadFull feeds full blocks, so this is a guard against future regressions
+// rather than a standalone failing test; byte-compat with existing volumes is
+// pinned by TestVerifyFirstRekeyAbove60GiB and the golden vectors.
+//
+// It lowers crypto.RekeyThreshold so a small synthetic volume crosses several
+// rekey boundaries, then encrypts the same plaintext twice: once with full reads
+// (identity seam) and once under a short-read seam. The two .pcv files must be
+// byte-identical.
+func TestRekeyCounterChunkIndependence(t *testing.T) {
+	rs := newRSCodecsT(t)
+	tmp := t.TempDir()
+
+	// Lower the rekey threshold BEFORE Encrypt: NewCounter copies RekeyThreshold
+	// at context construction, so it must be set prior to NewEncryptContext.
+	prevThreshold := crypto.RekeyThreshold
+	crypto.RekeyThreshold = 4 * int64(util.MiB)
+	defer func() { crypto.RekeyThreshold = prevThreshold }()
+
+	plaintext := randomPlaintext(t, 8*1024*1024) // 8 MiB -> crosses the 4 MiB rekey boundary
+	inputPath := filepath.Join(tmp, "in.bin")
+	if err := os.WriteFile(inputPath, plaintext, 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	// Pin the volume's random salt/nonce/IV: reset rand.Reader to a freshly
+	// seeded deterministic source before each Encrypt so both volumes share an
+	// identical header. With identical key/nonce/IV and plaintext, the only thing
+	// that can differ between the two .pcv files is the payload keystream, i.e.
+	// whether the rekey offset depends on read chunking. Single-file, no-compress
+	// encryption draws randomness solely via crypto.RandomBytes.
+	prevRand := rand.Reader
+	defer func() { rand.Reader = prevRand }()
+
+	encrypt := func(out string) {
+		rand.Reader = newDeterministicReader()
+		req := &EncryptRequest{
+			InputFile:   inputPath,
+			OutputFile:  out,
+			Password:    "rekey-counter-lock",
+			ReedSolomon: false,
+			Reporter:    &GoldenTestReporter{},
+			RSCodecs:    rs,
+		}
+		if err := Encrypt(context.Background(), req); err != nil {
+			t.Fatalf("Encrypt(%s): %v", out, err)
+		}
+	}
+
+	fullPath := filepath.Join(tmp, "full.pcv")
+	encrypt(fullPath) // identity seam (full reads)
+
+	// defer the restore so a t.Fatalf inside encrypt() can't leave the seam
+	// installed for the rest of the package's volume tests.
+	restore := shortReadSeam(shortReadMax)
+	defer restore()
+	shortPath := filepath.Join(tmp, "short.pcv")
+	encrypt(shortPath) // short reads
+
+	full, err := os.ReadFile(fullPath)
+	if err != nil {
+		t.Fatalf("read full volume: %v", err)
+	}
+	short, err := os.ReadFile(shortPath)
+	if err != nil {
+		t.Fatalf("read short volume: %v", err)
+	}
+
+	if !bytes.Equal(full, short) {
+		t.Fatalf("rekey offset is not chunk-independent: full-read and short-read .pcv differ (len full=%d short=%d)", len(full), len(short))
+	}
+}

--- a/src/internal/volume/rs_short_read_test.go
+++ b/src/internal/volume/rs_short_read_test.go
@@ -1,0 +1,219 @@
+package volume
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"Picocrypt-NG/internal/encoding"
+)
+
+// shortReader caps every Read to at most max bytes before delegating to the
+// underlying reader. It returns genuine short reads (n < len(p)) while still
+// surfacing the underlying EOF, so the io.ReadFull loops in the encrypt and
+// decrypt payload paths have to reassemble full blocks.
+type shortReader struct {
+	r   io.Reader
+	max int
+}
+
+func (s *shortReader) Read(p []byte) (int, error) {
+	if len(p) > s.max {
+		p = p[:s.max]
+	}
+	return s.r.Read(p)
+}
+
+// shortReadSeam installs newPayloadReader to wrap the payload reader in a
+// shortReader, and returns a restore func. max is deliberately smaller than
+// both 1 MiB and rsEncodedBlockSize so reads never align to RS block
+// boundaries.
+func shortReadSeam(max int) func() {
+	prev := newPayloadReader
+	newPayloadReader = func(r io.Reader) io.Reader {
+		return &shortReader{r: r, max: max}
+	}
+	return func() { newPayloadReader = prev }
+}
+
+const shortReadMax = 100 * 1024 // < 1 MiB and < rsEncodedBlockSize
+
+func newRSCodecsT(t *testing.T) *encoding.RSCodecs {
+	t.Helper()
+	rs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("NewRSCodecs: %v", err)
+	}
+	return rs
+}
+
+func randomPlaintext(t *testing.T, n int) []byte {
+	t.Helper()
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	return b
+}
+
+// TestDecryptShortReadsRSBlockAligned covers the decrypt pass loop
+// (decryptPayloadWithFastDecode). The volume is written with full reads (identity
+// seam); decryption then runs under a short-read seam. With a bare fin.Read the
+// loop hands a non-block-aligned chunk to decodeWithRSFast, mis-decoding the RS
+// blocks and yielding ErrCorruptData / ErrAuthFailed. io.ReadFull reassembles
+// full RS blocks regardless of read chunking.
+func TestDecryptShortReadsRSBlockAligned(t *testing.T) {
+	rs := newRSCodecsT(t)
+	tmp := t.TempDir()
+
+	plaintext := randomPlaintext(t, 2*1024*1024+12345) // >= 2 MiB, not block-aligned
+	inputPath := filepath.Join(tmp, "in.bin")
+	if err := os.WriteFile(inputPath, plaintext, 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	encPath := filepath.Join(tmp, "in.bin.pcv")
+	decPath := filepath.Join(tmp, "out.bin")
+
+	encReq := &EncryptRequest{
+		InputFile:   inputPath,
+		OutputFile:  encPath,
+		Password:    "short-read-decrypt",
+		ReedSolomon: true,
+		Reporter:    &GoldenTestReporter{},
+		RSCodecs:    rs,
+	}
+	if err := Encrypt(context.Background(), encReq); err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	restore := shortReadSeam(shortReadMax)
+	defer restore()
+
+	decReq := &DecryptRequest{
+		InputFile:  encPath,
+		OutputFile: decPath,
+		Password:   "short-read-decrypt",
+		Reporter:   &GoldenTestReporter{},
+		RSCodecs:   rs,
+	}
+	if err := Decrypt(context.Background(), decReq); err != nil {
+		t.Fatalf("Decrypt under short-read seam: %v", err)
+	}
+
+	got, err := os.ReadFile(decPath)
+	if err != nil {
+		t.Fatalf("read decrypted: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("decrypted plaintext mismatch (len got=%d want=%d)", len(got), len(plaintext))
+	}
+}
+
+// TestEncryptShortReadsRoundTrip covers the encrypt loop (encryptPayload).
+// Encryption runs under a short-read seam; the resulting volume must decrypt
+// cleanly under a normal (identity-seam) Decrypt. With a bare reader.Read the
+// partial-block path in encodeWithRS pads a non-final block, so a normal decrypt
+// cannot reproduce the plaintext.
+func TestEncryptShortReadsRoundTrip(t *testing.T) {
+	rs := newRSCodecsT(t)
+	tmp := t.TempDir()
+
+	plaintext := randomPlaintext(t, 2*1024*1024+9999) // >= 2 MiB
+	inputPath := filepath.Join(tmp, "in.bin")
+	if err := os.WriteFile(inputPath, plaintext, 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	encPath := filepath.Join(tmp, "in.bin.pcv")
+	decPath := filepath.Join(tmp, "out.bin")
+
+	restore := shortReadSeam(shortReadMax)
+	encReq := &EncryptRequest{
+		InputFile:   inputPath,
+		OutputFile:  encPath,
+		Password:    "short-read-encrypt",
+		ReedSolomon: true,
+		Reporter:    &GoldenTestReporter{},
+		RSCodecs:    rs,
+	}
+	if err := Encrypt(context.Background(), encReq); err != nil {
+		restore()
+		t.Fatalf("Encrypt under short-read seam: %v", err)
+	}
+	restore() // decrypt with identity (full reads)
+
+	decReq := &DecryptRequest{
+		InputFile:  encPath,
+		OutputFile: decPath,
+		Password:   "short-read-encrypt",
+		Reporter:   &GoldenTestReporter{},
+		RSCodecs:   rs,
+	}
+	if err := Decrypt(context.Background(), decReq); err != nil {
+		t.Fatalf("Decrypt (normal) of short-read-encrypted volume: %v", err)
+	}
+
+	got, err := os.ReadFile(decPath)
+	if err != nil {
+		t.Fatalf("read decrypted: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("roundtrip plaintext mismatch (len got=%d want=%d)", len(got), len(plaintext))
+	}
+}
+
+// TestVerifyFirstShortReadsRSBlockAligned covers the verify-first loop
+// (decryptVerifyMACFirstWithDecode). The volume is written with full reads;
+// Decrypt runs with VerifyFirst:true under a short-read seam. With a bare
+// fin.Read the verify pass MACs non-block-aligned RS chunks, producing a false
+// ErrAuthFailed.
+func TestVerifyFirstShortReadsRSBlockAligned(t *testing.T) {
+	rs := newRSCodecsT(t)
+	tmp := t.TempDir()
+
+	plaintext := randomPlaintext(t, 2*1024*1024+4242) // >= 2 MiB
+	inputPath := filepath.Join(tmp, "in.bin")
+	if err := os.WriteFile(inputPath, plaintext, 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	encPath := filepath.Join(tmp, "in.bin.pcv")
+	decPath := filepath.Join(tmp, "out.bin")
+
+	encReq := &EncryptRequest{
+		InputFile:   inputPath,
+		OutputFile:  encPath,
+		Password:    "short-read-verifyfirst",
+		ReedSolomon: true,
+		Reporter:    &GoldenTestReporter{},
+		RSCodecs:    rs,
+	}
+	if err := Encrypt(context.Background(), encReq); err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	restore := shortReadSeam(shortReadMax)
+	defer restore()
+
+	decReq := &DecryptRequest{
+		InputFile:   encPath,
+		OutputFile:  decPath,
+		Password:    "short-read-verifyfirst",
+		VerifyFirst: true,
+		Reporter:    &GoldenTestReporter{},
+		RSCodecs:    rs,
+	}
+	if err := Decrypt(context.Background(), decReq); err != nil {
+		t.Fatalf("Decrypt VerifyFirst under short-read seam: %v", err)
+	}
+
+	got, err := os.ReadFile(decPath)
+	if err != nil {
+		t.Fatalf("read decrypted: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("verify-first decrypted plaintext mismatch (len got=%d want=%d)", len(got), len(plaintext))
+	}
+}

--- a/src/mobile/progress.go
+++ b/src/mobile/progress.go
@@ -19,15 +19,15 @@ type ProgressState struct {
 
 // progressMap stores progress state for all active operations
 type progressMap struct {
-	mu   sync.RWMutex
-	ops  map[string]*ProgressState
-	ctxs map[string]context.Context
+	mu      sync.RWMutex
+	ops     map[string]*ProgressState
+	ctxs    map[string]context.Context
 	cancels map[string]context.CancelFunc
 }
 
 var globalProgressMap = &progressMap{
-	ops:  make(map[string]*ProgressState),
-	ctxs:  make(map[string]context.Context),
+	ops:     make(map[string]*ProgressState),
+	ctxs:    make(map[string]context.Context),
 	cancels: make(map[string]context.CancelFunc),
 }
 
@@ -40,10 +40,10 @@ func newOperationID() string {
 func startOperation() (string, context.Context, context.CancelFunc) {
 	id := newOperationID()
 	ctx, cancel := context.WithCancel(context.Background())
-	
+
 	globalProgressMap.mu.Lock()
 	defer globalProgressMap.mu.Unlock()
-	
+
 	globalProgressMap.ops[id] = &ProgressState{
 		ID:       id,
 		Status:   "Starting...",
@@ -54,7 +54,7 @@ func startOperation() (string, context.Context, context.CancelFunc) {
 	}
 	globalProgressMap.ctxs[id] = ctx
 	globalProgressMap.cancels[id] = cancel
-	
+
 	return id, ctx, cancel
 }
 
@@ -62,7 +62,7 @@ func startOperation() (string, context.Context, context.CancelFunc) {
 func updateProgress(id string, status string, progress float32, info string) {
 	globalProgressMap.mu.Lock()
 	defer globalProgressMap.mu.Unlock()
-	
+
 	if op, exists := globalProgressMap.ops[id]; exists {
 		op.Status = status
 		op.Progress = progress
@@ -74,7 +74,7 @@ func updateProgress(id string, status string, progress float32, info string) {
 func completeOperation(id string, err error) {
 	globalProgressMap.mu.Lock()
 	defer globalProgressMap.mu.Unlock()
-	
+
 	if op, exists := globalProgressMap.ops[id]; exists {
 		if op.Status == "Cancelled" {
 			op.Done = true
@@ -100,7 +100,7 @@ func getProgress(id string) (*ProgressState, error) {
 	if !exists {
 		return nil, fmt.Errorf("operation %s not found", id)
 	}
-	
+
 	// Return a copy to avoid race conditions
 	return &ProgressState{
 		ID:       op.ID,
@@ -116,18 +116,18 @@ func getProgress(id string) (*ProgressState, error) {
 func cancelOperation(id string) error {
 	globalProgressMap.mu.Lock()
 	defer globalProgressMap.mu.Unlock()
-	
+
 	cancel, exists := globalProgressMap.cancels[id]
 	if !exists {
 		return fmt.Errorf("operation %s not found", id)
 	}
-	
+
 	cancel()
 	if op, exists := globalProgressMap.ops[id]; exists {
 		op.Status = "Cancelled"
 		op.Done = true
 	}
-	
+
 	return nil
 }
 
@@ -135,7 +135,7 @@ func cancelOperation(id string) error {
 func getContext(id string) (context.Context, bool) {
 	globalProgressMap.mu.RLock()
 	defer globalProgressMap.mu.RUnlock()
-	
+
 	ctx, exists := globalProgressMap.ctxs[id]
 	return ctx, exists
 }
@@ -144,7 +144,7 @@ func getContext(id string) (context.Context, bool) {
 func cleanupOperation(id string) {
 	globalProgressMap.mu.Lock()
 	defer globalProgressMap.mu.Unlock()
-	
+
 	delete(globalProgressMap.ops, id)
 	delete(globalProgressMap.ctxs, id)
 	delete(globalProgressMap.cancels, id)


### PR DESCRIPTION
## Summary

Batch of correctness and security hardening fixes across the GUI, CLI, WASM, and crypto core, plus the headline macOS file-opening fix for #127. All changes preserve `.pcv` interoperability and the frozen encrypt-then-MAC ordering — no crypto behavior changes, only correctness and robustness.

`26 files changed, 1272 insertions(+), 296 deletions(-)`

## Headline fix — macOS file opening (Fixes #127)

**Root cause.** AppleEvent-delivered paths (Finder double-click, drag onto the app icon) were drained exactly once inside `Lifecycle.SetOnStarted`. Anything delivered at any other moment was buffered and never applied — warm-launch opens were silently lost (the app just came to the foreground), and cold-launch events racing the one-shot drain produced an incorrect file count.

**Fix.** Delivery is now event-driven. The buffer, a notify seam, and the drain move to a platform-neutral `macos_open.go` (unit-testable on all CI runners, not just darwin). `appendOpenedPath` fires a notify handler that the running `App` registers inside `SetOnStarted` *before* the initial drain, closing the race for both cold and warm launches. Multi-URL bursts coalesce into a single drop. The darwin cgo file keeps only the `//export` forwarder; the redundant non-darwin stub is removed.

**Tests.** Added `TestScheduleStartupPathsAppliesWarmOpenedPaths` (proven red without the notify wiring, green with it). Existing startup-path tests still pass.

> Note: the darwin cgo compile/link and on-device AppleEvent timing are covered by the `build-macos` CI job; final on-device confirmation is recommended before release.

## Other fixes in this batch

**Crypto / volume (AUDIT-CRITICAL):**
- `fix(volume)`: pin the rekey boundary to a fixed MiB via `io.ReadFull`, including the plausible-deniability path — prevents short reads from desynchronizing the rekey counter.
- `fix(header)`: bound `ReadHeaderRaw` comment length before allocation — closes a pre-auth over-allocation DoS driven by a crafted comment-length field.
- `test(volume)`: golden tests now exercise the real header parser instead of a hand-rolled stand-in.

**CLI:**
- `fix(cli)`: restore terminal echo on `SIGINT` during the password prompt (no more invisible terminal after Ctrl-C).
- `fix(cli)`: securely wipe stdin/stdout plaintext temp files before unlink.

**WASM:**
- `fix(wasm)`: validate JS arguments and recover from panics in the entrypoint.

**fileops:**
- `fix(fileops)`: correctly decrypt data delivered by `encryptedReader` together with `EOF`.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./...` — all packages pass (incl. `internal/ui`, `internal/volume`, `internal/wasm`)
- `govulncheck` — no vulnerabilities
- `gofmt` clean; `-tags cli` builds clean

## Compatibility

No change to volume format, header layout, or cipher ordering. 2.08/2.09 `.pcv` interop is preserved in both directions.

Fixes #127
