### PR TITLE
fix: macos: do not force document icon

### DIFF
--- a/dist/macos/Info.plist
+++ b/dist/macos/Info.plist
@@ -42,8 +42,6 @@
             <array>
                 <string>io.github.picocryptng.pcv</string>
             </array>
-            <key>CFBundleTypeIconFile</key>
-            <string>icon.icns</string>
         </dict>
     </array>
 
@@ -55,8 +53,6 @@
             <string>io.github.picocryptng.pcv</string>
             <key>UTTypeDescription</key>
             <string>Picocrypt-NG encrypted volume</string>
-            <key>UTTypeIconFile</key>
-            <string>icon.icns</string>
             <key>UTTypeConformsTo</key>
             <array>
                 <string>public.data</string>


### PR DESCRIPTION
System-generated document icon looks better:
<img width="238" height="107" alt="image" src="https://github.com/user-attachments/assets/2a85a767-7785-41dc-beb3-1c86d4597e18" />
and supports dark mode automatically on macOS 26:
<img width="687" height="440" alt="image" src="https://github.com/user-attachments/assets/bdaf1152-87c9-40de-967a-02b29df77cf3" />
App icon forced onto documents looks out of place:
<img width="226" height="119" alt="image" src="https://github.com/user-attachments/assets/ced878d8-96de-453f-8669-c7a82c66d398" />
