### PR TITLE
fix(ui): deliver macOS multi-file icon opens as one drop (#127)

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -4,7 +4,7 @@ run:
   timeout: 5m
   build-tags:
     - cli
-  modules-download-mode: vendor
+  modules-download-mode: readonly
   tests: false
 
 linters:
@@ -29,6 +29,34 @@ linters:
       - path: internal/ui/
         linters:
           - typecheck
+      # gosec G115 false positives — mirrors root .golangci.yml policy:
+      # fd/syscall/size/color conversions bounded well below 2^63.
+      - path: internal/fileops/
+        linters:
+          - gosec
+        text: G115
+      - path: internal/cli/
+        linters:
+          - gosec
+        text: G115
+      - path: internal/header/
+        linters:
+          - gosec
+        text: G115
+      # G302: log file is intentionally readable by monitoring tools
+      # (documented at internal/log/log.go EnableFileLogging).
+      - path: internal/log/
+        linters:
+          - gosec
+        text: G302
+      # Platform false positive: appendOpenedPath/flushOpenedPaths and the
+      # openedPathsNotify handler are called only from macos_open_darwin.go
+      # (//go:build darwin), which the linux lint host never compiles, so the
+      # unused linter cannot see their callers. The symbols are live on macOS
+      # and are exercised by drop_test.go.
+      - path: internal/ui/macos_open\.go
+        linters:
+          - unused
   settings:
     gosec:
       excludes:

--- a/src/internal/cli/encrypt_dir_test.go
+++ b/src/internal/cli/encrypt_dir_test.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEncryptDirectoryProducesZip is the CLI-side regression for issue #130.
+//
+// The desktop UI labels a dropped folder "Zip and Encrypt" and names the output
+// "<name>.zip.pcv"; the headless CLI takes the symmetric path (a directory input
+// is recorded in OnlyFolders, see encrypt.go IsDir branch). A folder holding a
+// single file used to skip zipping because the decision only looked at file
+// count, so decryption produced a ".zip"-named file whose bytes were the raw
+// inner file and which no unzip tool could extract.
+//
+// This exercises the real `encrypt`/`decrypt` commands end to end so the wiring
+// (IsDir -> OnlyFolders -> volume zip decision) is covered on every CI platform,
+// not just through the volume package directly. It must fail before the fix.
+func TestEncryptDirectoryProducesZip(t *testing.T) {
+	resetEncryptFlagsForDirTest()
+	resetDecryptFlagsForDirTest()
+	t.Cleanup(resetEncryptFlagsForDirTest)
+	t.Cleanup(resetDecryptFlagsForDirTest)
+
+	tmpDir := t.TempDir()
+
+	// A folder ("test_dir") containing exactly one file, mirroring the issue.
+	folder := filepath.Join(tmpDir, "test_dir")
+	if err := os.MkdirAll(folder, 0755); err != nil {
+		t.Fatalf("create folder: %v", err)
+	}
+	innerContent := []byte("hello world\n")
+	innerPath := filepath.Join(folder, "hello.txt")
+	if err := os.WriteFile(innerPath, innerContent, 0644); err != nil {
+		t.Fatalf("write inner file: %v", err)
+	}
+
+	encryptedPath := filepath.Join(tmpDir, "encrypted.zip.pcv")
+	decryptedPath := filepath.Join(tmpDir, "decrypted.zip")
+
+	// Encrypt the directory through the real CLI command.
+	encInput = []string{folder}
+	encOutput = encryptedPath
+	encPassword = "pw"
+	encQuiet = true
+	encYes = true
+	if err := encryptCmd.RunE(encryptCmd, []string{}); err != nil {
+		t.Fatalf("encrypt directory: %v", err)
+	}
+
+	// Decrypt WITHOUT auto-unzip: the on-disk output must itself be a valid zip.
+	decInput = encryptedPath
+	decOutput = decryptedPath
+	decPassword = "pw"
+	decQuiet = true
+	decYes = true
+	if err := decryptCmd.RunE(decryptCmd, []string{}); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+
+	// The decrypted output must be a real zip archive containing test_dir/hello.txt.
+	zr, err := zip.OpenReader(decryptedPath)
+	if err != nil {
+		t.Fatalf("decrypted output is not a valid zip archive (issue #130): %v", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	if len(zr.File) != 1 {
+		t.Fatalf("expected 1 zip entry, got %d", len(zr.File))
+	}
+	entry := zr.File[0]
+	if entry.Name != "test_dir/hello.txt" {
+		t.Fatalf("expected entry name %q, got %q", "test_dir/hello.txt", entry.Name)
+	}
+
+	rc, err := entry.Open()
+	if err != nil {
+		t.Fatalf("open zip entry: %v", err)
+	}
+	got, err := io.ReadAll(rc)
+	_ = rc.Close()
+	if err != nil {
+		t.Fatalf("read zip entry: %v", err)
+	}
+	if string(got) != string(innerContent) {
+		t.Fatalf("zip entry content = %q, want %q", got, innerContent)
+	}
+}
+
+// resetEncryptFlagsForDirTest clears the package-level encrypt flags this test
+// touches so leftover state from other tests (or this one) cannot bleed in.
+func resetEncryptFlagsForDirTest() {
+	encInput = nil
+	encOutput = ""
+	encPassword = ""
+	encKeyfiles = nil
+	encParanoid = false
+	encReedSolomon = false
+	encDeniability = false
+	encCompress = false
+	encSplit = false
+	encSplitSize = 0
+	encSplitUnit = "MiB"
+	encQuiet = false
+	encYes = false
+	encFollowSymlinks = false
+}
+
+// resetDecryptFlagsForDirTest clears the package-level decrypt flags this test
+// touches so leftover state cannot bleed in.
+func resetDecryptFlagsForDirTest() {
+	decInput = ""
+	decOutput = ""
+	decPassword = ""
+	decKeyfiles = nil
+	decForce = false
+	decVerifyFirst = false
+	decAutoUnzip = false
+	decSameLevel = false
+	decRecombine = false
+	decDeniability = false
+	decQuiet = false
+	decYes = false
+}

--- a/src/internal/ui/drop_test.go
+++ b/src/internal/ui/drop_test.go
@@ -762,13 +762,60 @@ func TestScheduleStartupPathsAppliesWarmOpenedPaths(t *testing.T) {
 		t.Fatalf("InputFile = %q before any opened path; want empty", state.InputFile)
 	}
 
-	// A warm openURLs event arrives after launch.
+	// A warm openURLs event arrives after launch: the bridge appends the
+	// path(s) for the event, then flushes once, which fires the notify handler.
 	appendOpenedPath(inputFile)
+	flushOpenedPaths()
 	fyne.DoAndWait(func() {}) // barrier: let the notify-scheduled fyne.Do run
 	waitForDropProcessing(t, a)
 
 	if state := snapshotDropState(t, a); state.InputFile != inputFile {
 		t.Fatalf("InputFile = %q after warm opened path; want %q", state.InputFile, inputFile)
+	}
+}
+
+// TestOpenedPathsBatchDeliversWholeGestureAsOneDrop covers the #127 follow-up:
+// dragging several files onto the app/dock icon is delivered by AppKit as a
+// single application:openURLs: event, and the bridge must surface it as ONE drop
+// carrying every path. The previous code notified after every appended path, so
+// a three-file gesture produced three single-path drops — each replacing the
+// prior selection or hitting onDrop's scanning guard, losing files. The darwin
+// bridge now appends all paths and flushes once; this asserts that contract at
+// the platform-neutral layer so it guards the regression on every CI platform,
+// including the amd64 -race job (it touches no Fyne rendering, so it is not
+// -race-skipped).
+func TestOpenedPathsBatchDeliversWholeGestureAsOneDrop(t *testing.T) {
+	// Reset package-global bridge state other tests may have left behind.
+	setOpenedPathsNotify(nil)
+	drainOpenedPaths()
+	t.Cleanup(func() {
+		setOpenedPathsNotify(nil)
+		drainOpenedPaths()
+	})
+
+	var batches [][]string
+	setOpenedPathsNotify(func() {
+		batches = append(batches, drainOpenedPaths())
+	})
+
+	// One openURLs: event carrying three files: append each, then flush once.
+	paths := []string{"/tmp/a.txt", "/tmp/b.txt", "/tmp/c.txt"}
+	for _, p := range paths {
+		appendOpenedPath(p)
+	}
+	flushOpenedPaths()
+
+	if len(batches) != 1 {
+		t.Fatalf("notify fired %d time(s) for one openURLs gesture; want exactly 1 (per-path notifying loses files, #127)", len(batches))
+	}
+	got := batches[0]
+	if len(got) != len(paths) {
+		t.Fatalf("drained %d path(s); want all %d delivered in one drop: got %v", len(got), len(paths), got)
+	}
+	for i := range paths {
+		if got[i] != paths[i] {
+			t.Fatalf("path[%d] = %q; want %q (order and completeness must be preserved)", i, got[i], paths[i])
+		}
 	}
 }
 

--- a/src/internal/ui/macos_open.go
+++ b/src/internal/ui/macos_open.go
@@ -2,15 +2,25 @@
 //
 // On darwin, AppleEvents (Finder double-click, drag onto the app/dock icon) are
 // delivered to goAppendOpenedPath in macos_open_darwin.go, which forwards each
-// path to appendOpenedPath here. Buffering and delivery live in this file — not
-// the darwin file — so the delivery logic is unit-testable on every CI platform,
-// not only macOS.
+// path to appendOpenedPath here and then calls flushOpenedPaths exactly once per
+// application:openURLs: event. Buffering and delivery live in this file — not the
+// darwin file — so the delivery logic is unit-testable on every CI platform, not
+// only macOS.
 //
-// Delivery is event-driven: appendOpenedPath fires a notify handler registered
-// by the running App via setOpenedPathsNotify. This lets paths that arrive while
-// the app is already running (issue #127: warm application:openURLs: events, and
-// cold-launch events delivered after the first drain) reach the UI instead of
-// sitting in the buffer indefinitely.
+// Delivery is event-driven and batched. AppKit hands an entire multi-file open
+// gesture to application:openURLs: as a single [URL] array — one delegate call,
+// per Apple's NSApplicationDelegate contract — so the bridge buffers every path
+// in that array and fires the notify handler once, via flushOpenedPaths, after
+// the whole array has been appended. That guarantees one drain -> one onDrop
+// carrying the entire selection. The previous behaviour notified after every
+// single path, which shredded one gesture into N single-path onDrop calls: each
+// replaced the prior selection or was discarded by onDrop's scanning guard,
+// losing files (issue #127).
+//
+// The notify handler is registered by the running App via setOpenedPathsNotify.
+// This also lets paths that arrive while the app is already running (issue #127:
+// warm openURLs events, and cold-launch events delivered after the first drain)
+// reach the UI instead of sitting in the buffer indefinitely.
 package ui
 
 import "sync"
@@ -21,16 +31,27 @@ var (
 	openedPathsNotify func()
 )
 
-// appendOpenedPath buffers a path opened via the OS (AppleEvents on darwin) and
-// invokes the registered notify handler, if any, so the path can be drained and
-// applied. The handler is called outside the lock to avoid re-entrancy on
-// openedPathsMu.
+// appendOpenedPath buffers a path opened via the OS (AppleEvents on darwin). It
+// deliberately does not notify: a single openURLs: event delivers several paths,
+// so the darwin bridge appends them all and then calls flushOpenedPaths once,
+// ensuring the whole gesture reaches the UI as one drop rather than one per path.
 func appendOpenedPath(path string) {
 	if path == "" {
 		return
 	}
 	openedPathsMu.Lock()
 	openedPaths = append(openedPaths, path)
+	openedPathsMu.Unlock()
+}
+
+// flushOpenedPaths invokes the registered notify handler once, after a batch of
+// appendOpenedPath calls, so the buffered paths are drained and applied together.
+// It is a no-op when no handler is registered yet (a cold launch whose openURLs
+// event arrives before the App wires its handler) — those paths are picked up by
+// the initial drain performed right after setOpenedPathsNotify registers. The
+// handler is invoked outside the lock to avoid re-entrancy on openedPathsMu.
+func flushOpenedPaths() {
+	openedPathsMu.Lock()
 	notify := openedPathsNotify
 	openedPathsMu.Unlock()
 
@@ -40,8 +61,8 @@ func appendOpenedPath(path string) {
 }
 
 // setOpenedPathsNotify registers (or clears, when fn is nil) the handler invoked
-// after a path is buffered. Callers should drain once immediately after
-// registering so paths buffered before registration are not missed.
+// by flushOpenedPaths. Callers should drain once immediately after registering so
+// paths buffered before registration are not missed.
 func setOpenedPathsNotify(fn func()) {
 	openedPathsMu.Lock()
 	openedPathsNotify = fn

--- a/src/internal/ui/macos_open.go
+++ b/src/internal/ui/macos_open.go
@@ -21,6 +21,7 @@
 // This also lets paths that arrive while the app is already running (issue #127:
 // warm openURLs events, and cold-launch events delivered after the first drain)
 // reach the UI instead of sitting in the buffer indefinitely.
+
 package ui
 
 import "sync"

--- a/src/internal/ui/macos_open_darwin.go
+++ b/src/internal/ui/macos_open_darwin.go
@@ -14,10 +14,11 @@ import "C"
 // duplicate ObjC symbols at link time).
 //
 // macos_open_darwin.m uses class_addMethod to inject application:openURLs:
-// into GLFW's existing application delegate at +(void)load time, then calls
-// goAppendOpenedPath below for each opened file URL. Buffering, notify, and
-// drain logic lives in the platform-neutral macos_open.go so it is testable on
-// every CI platform.
+// into GLFW's existing application delegate at +(void)load time. For each
+// openURLs: event it calls goAppendOpenedPath below once per file URL, then
+// goFlushOpenedPaths once after the loop so the whole gesture is delivered as a
+// single drop. Buffering, flush, and drain logic lives in the platform-neutral
+// macos_open.go so it is testable on every CI platform.
 
 //export goAppendOpenedPath
 func goAppendOpenedPath(cpath *C.char) {
@@ -25,4 +26,9 @@ func goAppendOpenedPath(cpath *C.char) {
 		return
 	}
 	appendOpenedPath(C.GoString(cpath))
+}
+
+//export goFlushOpenedPaths
+func goFlushOpenedPaths() {
+	flushOpenedPaths()
 }

--- a/src/internal/ui/macos_open_darwin.m
+++ b/src/internal/ui/macos_open_darwin.m
@@ -11,7 +11,8 @@
 // (Go file naming convention applies to .m, .c, .s, etc.).
 //
 // We #include the cgo-generated _cgo_export.h to pick up the auto-declared
-// signature `void goAppendOpenedPath(char *cpath)` — no manual extern needed.
+// signatures `void goAppendOpenedPath(char *cpath)` and `void
+// goFlushOpenedPaths(void)` — no manual extern needed.
 
 #import <Cocoa/Cocoa.h>
 #import <objc/runtime.h>
@@ -57,6 +58,11 @@
 }
 
 - (void)pcngApplication:(NSApplication *)sender openURLs:(NSArray<NSURL *> *)urls {
+    // AppKit delivers an entire multi-file open gesture (e.g. several files
+    // dragged onto the app/dock icon) as one openURLs: call. Buffer every file
+    // URL, then flush once, so the whole selection reaches the UI as a single
+    // drop. Flushing per URL instead lost files (issue #127): each single-path
+    // drop replaced the previous one or was dropped by onDrop's scanning guard.
     for (NSURL *url in urls) {
         if (![url isFileURL]) continue;
         const char *path = [[url path] UTF8String];
@@ -67,6 +73,7 @@
             goAppendOpenedPath((char *)path);
         }
     }
+    goFlushOpenedPaths();
 }
 
 @end

--- a/src/internal/volume/context.go
+++ b/src/internal/volume/context.go
@@ -219,30 +219,30 @@ func (ctx *OperationContext) SetCanCancel(can bool) {
 
 // IsCancelled checks if the operation has been cancelled.
 // Returns true if either the context is done or the reporter indicates cancellation.
-func (opCtx *OperationContext) IsCancelled() bool {
+func (ctx *OperationContext) IsCancelled() bool {
 	// Check context cancellation first (standard Go pattern)
-	if opCtx.Ctx != nil {
+	if ctx.Ctx != nil {
 		select {
-		case <-opCtx.Ctx.Done():
+		case <-ctx.Ctx.Done():
 			return true
 		default:
 		}
 	}
 
 	// Also check reporter-based cancellation (for UI cancel button)
-	if opCtx.Reporter != nil {
-		return opCtx.Reporter.IsCancelled()
+	if ctx.Reporter != nil {
+		return ctx.Reporter.IsCancelled()
 	}
 	return false
 }
 
 // CancellationError returns the appropriate error when cancelled.
 // Returns context error if context is done, otherwise returns ErrCancelled.
-func (opCtx *OperationContext) CancellationError() error {
-	if opCtx.Ctx != nil {
+func (ctx *OperationContext) CancellationError() error {
+	if ctx.Ctx != nil {
 		select {
-		case <-opCtx.Ctx.Done():
-			return opCtx.Ctx.Err()
+		case <-ctx.Ctx.Done():
+			return ctx.Ctx.Err()
 		default:
 		}
 	}

--- a/src/internal/volume/encrypt.go
+++ b/src/internal/volume/encrypt.go
@@ -92,8 +92,13 @@ func preprocessInputFiles(req *EncryptRequest) []string {
 func encryptPreprocess(ctx *OperationContext, req *EncryptRequest) error {
 	inputFiles := preprocessInputFiles(req)
 
-	// If multiple files, or single file with compression requested, create a zip
-	if len(inputFiles) > 1 || (len(inputFiles) == 1 && req.Compress) {
+	// Create a zip when the selection is anything other than a single bare file:
+	// multiple files, a single file with compression requested, or any folder
+	// selection (even one containing a single file). A dropped folder is labelled
+	// "Zip and Encrypt" by the UI and named "<name>.zip.pcv", so it must decrypt to
+	// a real zip that preserves the folder structure — see issue #130. OnlyFolders
+	// is the signal that a folder (not a bare file) was selected.
+	if len(inputFiles) > 1 || (len(inputFiles) == 1 && (req.Compress || len(req.OnlyFolders) > 0)) {
 		ctx.SetStatus("Compressing files...")
 
 		// Create temp zip ciphers for encrypting the temporary file

--- a/src/internal/volume/roundtrip_test.go
+++ b/src/internal/volume/roundtrip_test.go
@@ -1339,6 +1339,92 @@ func TestRoundTripMultiFile(t *testing.T) {
 	t.Log("Round-trip multi-file: SUCCESS")
 }
 
+// TestRoundTripSingleFileFolderProducesZip is a regression test for issue #130:
+// "Zip and Encrypt" of a folder containing a single file must still produce a zip
+// archive. The GUI labels a dropped folder "Zip and Encrypt" and names the output
+// "<name>.zip.pcv", so decryption must yield a real zip — not the raw inner file.
+// Before the fix, a folder with exactly one file (compress off) skipped zipping
+// because the decision only looked at file count, so decryption produced a
+// ".zip"-named file whose bytes were the raw inner file and which no unzip tool
+// (nor Auto unzip) could extract.
+func TestRoundTripSingleFileFolderProducesZip(t *testing.T) {
+	rsCodecs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("Failed to create RS codecs: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+
+	// A folder ("test_dir") containing exactly one file, mirroring the issue.
+	folder := filepath.Join(tmpDir, "test_dir")
+	if err := os.MkdirAll(folder, 0755); err != nil {
+		t.Fatalf("Failed to create folder: %v", err)
+	}
+	innerContent := []byte("hello world\n")
+	innerPath := filepath.Join(folder, "hello.txt")
+	if err := os.WriteFile(innerPath, innerContent, 0644); err != nil {
+		t.Fatalf("Failed to write inner file: %v", err)
+	}
+
+	encryptedPath := filepath.Join(tmpDir, "encrypted.zip.pcv")
+	decryptedPath := filepath.Join(tmpDir, "encrypted.zip")
+
+	reporter := &GoldenTestReporter{}
+
+	// Folder selection: one input file, folder recorded in OnlyFolders, compress off.
+	encReq := &EncryptRequest{
+		InputFiles:  []string{innerPath},
+		OnlyFolders: []string{folder},
+		OutputFile:  encryptedPath,
+		Password:    "pw",
+		Reporter:    reporter,
+		RSCodecs:    rsCodecs,
+	}
+	if err := Encrypt(context.Background(), encReq); err != nil {
+		t.Fatalf("Encrypt failed: %v", err)
+	}
+
+	// Decrypt WITHOUT auto-unzip: the on-disk output must itself be a valid zip.
+	decReq := &DecryptRequest{
+		InputFile:  encryptedPath,
+		OutputFile: decryptedPath,
+		Password:   "pw",
+		Reporter:   reporter,
+		RSCodecs:   rsCodecs,
+	}
+	if err := Decrypt(context.Background(), decReq); err != nil {
+		t.Fatalf("Decrypt failed: %v", err)
+	}
+
+	// The decrypted output must be a real zip archive containing test_dir/hello.txt.
+	zr, err := zip.OpenReader(decryptedPath)
+	if err != nil {
+		t.Fatalf("decrypted output is not a valid zip archive (issue #130): %v", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	if len(zr.File) != 1 {
+		t.Fatalf("expected 1 zip entry, got %d", len(zr.File))
+	}
+	entry := zr.File[0]
+	if entry.Name != "test_dir/hello.txt" {
+		t.Fatalf("expected entry name %q, got %q", "test_dir/hello.txt", entry.Name)
+	}
+
+	rc, err := entry.Open()
+	if err != nil {
+		t.Fatalf("Failed to open zip entry: %v", err)
+	}
+	got, err := io.ReadAll(rc)
+	_ = rc.Close()
+	if err != nil {
+		t.Fatalf("Failed to read zip entry: %v", err)
+	}
+	if string(got) != string(innerContent) {
+		t.Fatalf("zip entry content mismatch: got %q want %q", got, innerContent)
+	}
+}
+
 // TestRoundTripSplitWithDeniability tests split + deniability combination
 func TestRoundTripSplitWithDeniability(t *testing.T) {
 	rsCodecs, err := encoding.NewRSCodecs()

--- a/src/internal/wasm/encrypt.go
+++ b/src/internal/wasm/encrypt.go
@@ -164,7 +164,6 @@ func EncryptVolume(plaintext []byte, password string) ([]byte, int) {
 		}
 	}()
 	zeroWASMSensitiveBuffer(wasmZeroingHeaderSubkey, subkeyHeader)
-	subkeyHeader = nil
 	hdr.KeyfileHash = keyfileHash
 
 	// Read remaining subkeys
@@ -181,7 +180,6 @@ func EncryptVolume(plaintext []byte, password string) ([]byte, int) {
 	// Create MAC (normal mode = BLAKE2b)
 	mac, err := crypto.NewMAC(macSubkey, false)
 	zeroWASMSensitiveBuffer(wasmZeroingMACSubkey, macSubkey)
-	macSubkey = nil
 	if err != nil {
 		return nil, ErrRandomFailure
 	}
@@ -197,7 +195,6 @@ func EncryptVolume(plaintext []byte, password string) ([]byte, int) {
 		false, // not paranoid
 	)
 	zeroWASMSensitiveBuffer(wasmZeroingSerpentKey, serpentKey)
-	serpentKey = nil
 	if err != nil {
 		return nil, ErrRandomFailure
 	}

--- a/src/mobile/android.go
+++ b/src/mobile/android.go
@@ -1,3 +1,5 @@
+// Package mobile is the gomobile bridge between the Go crypto core and the
+// Android (Kotlin/Compose) host application.
 package mobile
 
 import (


### PR DESCRIPTION
## Summary

Fixes the remaining half of #127: dragging **multiple files onto the macOS app/dock icon** dropped some of them ("file count is incorrect / misses files sometimes"). The warm-start half of #127 was already fixed in 2.10 (`fb4de86`); this PR addresses the multi-file icon-open path.

## Root cause

AppKit delivers a multi-file icon drag as a **single** `application:openURLs:` event carrying one `[URL]` array (per Apple's `NSApplicationDelegate` contract). The bridge, however, appended each path and fired the notify handler **after every path** — so one gesture was shredded into N single-path `onDrop` calls. Each `onDrop` either *replaced* the prior selection (`drop.go` reset semantics) or was discarded by the `IsScanning` guard, losing files. One URL = one drop worked; many URLs raced and lost.

## Fix

Split delivery into **buffer + flush**:
- `appendOpenedPath` now only buffers.
- New `flushOpenedPaths` (exported to ObjC as `goFlushOpenedPaths`) fires the notify handler **once**, after the `openURLs:` handler has appended the whole array.

One gesture now drains to one `onDrop` carrying every path. Deterministic — no timer, no debounce, no extra goroutine.

## Tests

Adds `TestOpenedPathsBatchDeliversWholeGestureAsOneDrop`, asserting the contract at the platform-neutral layer so it runs on every CI platform (including the amd64 `-race` job). Verified red against the old per-path notify behaviour (notify fired 4×), green after the fix (exactly 1).

## Verification

`go build ./...`, `go vet ./...`, gofmt, `go test ./...` (18 packages), `internal/ui -race`, `-tags cli` build, darwin neutral typecheck, `govulncheck ./internal/ui/...` — all clean.

**Not verifiable in CI without a device:** final on-device AppKit confirmation belongs to `build-macos` CI and the original reporter. The Go-layer contract (one gesture → one drop) is fully covered by the unit test.

Fixes #127
