### PR TITLE
fix: macos: declare any file as openable

### DIFF
--- a/dist/macos/Info.plist
+++ b/dist/macos/Info.plist
@@ -43,6 +43,18 @@
                 <string>io.github.picocryptng.pcv</string>
             </array>
         </dict>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>*</string>
+            </array>
+            <key>CFBundleTypeName</key>
+            <string>Any File</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>None</string>
+        </dict>
     </array>
 
     <!-- UTI declaration (FA-MAC-02; D-04, D-05, D-06) -->
@@ -62,6 +74,7 @@
                 <key>public.filename-extension</key>
                 <array>
                     <string>pcv</string>
+                    <string>PCV</string>
                 </array>
                 <key>public.mime-type</key>
                 <array>


### PR DESCRIPTION
this makes generic file drag & drop noto app icon more reliable