### PR TITLE
Fix flaky Android OperationViewModel unit tests

### DIFF
--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationViewModelTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationViewModelTest.kt
@@ -2,7 +2,10 @@ package io.github.picocrypt_ng.picocrypt_ng
 
 import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -44,6 +47,11 @@ class OperationViewModelTest {
     
     @After
     fun tearDown() {
+        if (::viewModel.isInitialized) {
+            runTest(mainDispatcherRule.testDispatcher) {
+                viewModel.viewModelScope.coroutineContext[Job]?.cancelAndJoin()
+            }
+        }
         resetOperationState()
     }
     

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationViewModelTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationViewModelTest.kt
@@ -68,32 +68,32 @@ class OperationViewModelTest {
     }
     
     @Test
-    fun `startEncrypt launches operation`() = runTest(mainDispatcherRule.testDispatcher) {
+    fun `startEncrypt handles validation failure without leaking work`() = runTest(mainDispatcherRule.testDispatcher) {
         val formData = TestDataBuilders.createEncryptFormData(
+            copiedFilePath = "",
             password = "test",
             confirmPassword = "test"
         )
-        
-        // This will fail validation or require GoBridge, but we test the method call
+
         viewModel.startEncrypt(mockContext, formData)
-        
+
         advanceUntilIdle()
-        
-        // Operation may or may not start depending on validation/GoBridge availability
-        // But the method should not throw
+
+        assertNull("Invalid encrypt input should not start an operation", viewModel.operationState.value)
     }
-    
+
     @Test
-    fun `startDecrypt launches operation`() = runTest(mainDispatcherRule.testDispatcher) {
+    fun `startDecrypt handles validation failure without leaking work`() = runTest(mainDispatcherRule.testDispatcher) {
         val formData = TestDataBuilders.createDecryptFormData(
+            copiedFilePath = "",
             password = "test"
         )
-        
+
         viewModel.startDecrypt(mockContext, formData)
-        
+
         advanceUntilIdle()
-        
-        // Method should not throw
+
+        assertNull("Invalid decrypt input should not start an operation", viewModel.operationState.value)
     }
     
     @Test

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/testutils/MainDispatcherRule.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/testutils/MainDispatcherRule.kt
@@ -3,6 +3,7 @@ package io.github.picocrypt_ng.picocrypt_ng.testutils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
@@ -11,7 +12,7 @@ import org.junit.runner.Description
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainDispatcherRule(
-    private val dispatcherFactory: () -> TestDispatcher = { StandardTestDispatcher() },
+    private val dispatcherFactory: () -> TestDispatcher = { StandardTestDispatcher(TestCoroutineScheduler()) },
 ) : TestWatcher() {
     private var _testDispatcher: TestDispatcher? = null
     val testDispatcher: TestDispatcher


### PR DESCRIPTION
## Summary
- make `MainDispatcherRule` create its test dispatcher from an explicit `TestCoroutineScheduler`
- cancel and join `OperationViewModel`'s `viewModelScope` during test teardown before `Dispatchers.Main` is reset
- keep the `OperationViewModel` start-operation unit tests on the validation-failure path, so they do not accidentally enter real file-copy / GoBridge work with a relaxed mock `Context`
- keep the fix in Android unit-test code only; production behavior is unchanged

## Root cause
The original `build-android` workflow failed in `OperationViewModelTest` because `viewModelScope` work could switch to real `Dispatchers.IO` and outlive the test. A later continuation then tried to resume after `Dispatchers.Main` was reset, which makes the JVM unit-test runner hit the unmocked Android `Looper`.

After that coroutine leak was fixed, the PR CI exposed a second test-isolation issue: the start-operation tests used default test form data with a non-empty copied-file path, so the test could reach real `FileCopyService` / GoBridge setup while using a relaxed mock `Context`, causing the `File.java:364` NPE. Those tests only assert that invalid input is handled without starting an operation, so the safe fix is to pass an empty copied-file path and assert `operationState` stays null.

## Verification
- RED before first fix: `JAVA_HOME=/usr/lib/jvm/java-17-openjdk ANDROID_HOME=/home/chris/Android/Sdk ANDROID_SDK_ROOT=/home/chris/Android/Sdk ANDROID_NDK_HOME=/home/chris/Android/Sdk/ndk/29.0.14206865 ./gradlew :app:testDebugUnitTest --tests 'io.github.picocrypt_ng.picocrypt_ng.OperationViewModelTest' --rerun-tasks --stacktrace` failed with `UncaughtExceptionsBeforeTest` / `Looper not mocked`
- CI regression before second fix: PR run `27068972845`, job `79894689640`, failed with `OperationViewModelTest > startEncrypt launches operation` and `File.java:364`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk PATH=/usr/lib/jvm/java-17-openjdk/bin:$PATH ANDROID_HOME=/home/chris/Android/Sdk ANDROID_SDK_ROOT=/home/chris/Android/Sdk ANDROID_NDK_HOME=/home/chris/Android/Sdk/ndk/29.0.14206865 ./gradlew :app:testDebugUnitTest --tests 'io.github.picocrypt_ng.picocrypt_ng.OperationViewModelTest' --rerun-tasks --stacktrace`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk PATH=/usr/lib/jvm/java-17-openjdk/bin:$PATH ANDROID_HOME=/home/chris/Android/Sdk ANDROID_SDK_ROOT=/home/chris/Android/Sdk ANDROID_NDK_HOME=/home/chris/Android/Sdk/ndk/29.0.14206865 ./build-gomobile.sh && JAVA_HOME=/usr/lib/jvm/java-17-openjdk PATH=/usr/lib/jvm/java-17-openjdk/bin:$PATH ANDROID_HOME=/home/chris/Android/Sdk ANDROID_SDK_ROOT=/home/chris/Android/Sdk ANDROID_NDK_HOME=/home/chris/Android/Sdk/ndk/29.0.14206865 ./gradlew test --rerun-tasks --stacktrace`
- `git ls-files '*.go' | xargs gofmt -l` produced no output
- `LC_ALL=C.UTF-8 GOFLAGS=-mod=readonly go test ./... -count=1 -timeout=15m`
- `LC_ALL=C.UTF-8 GOFLAGS=-mod=readonly go vet ./...`
- `LC_ALL=C.UTF-8 GOFLAGS=-mod=readonly gopls check cmd/picocrypt/main.go internal/ui/macos_open.go internal/ui/app.go internal/crypto/rekey.go internal/header/auth.go internal/keyfile/processor.go mobile/android.go`
- `LC_ALL=C.UTF-8 GOFLAGS=-mod=readonly golangci-lint run ./...`
- `LC_ALL=C.UTF-8 GOFLAGS=-mod=readonly gosec -exclude-dir=testdata ./...`
