### PR TITLE
feat: Android volume interop + verify-first/FGS, Linux AppImage, test/CI hardening

### DIFF
--- a/.github/workflows/android-instrumented.yml
+++ b/.github/workflows/android-instrumented.yml
@@ -120,7 +120,7 @@ jobs:
         # Single-line: the runner executes each script line in its own `sh -c`,
         # so multi-line `cd`/`if`/`fi` constructs do not persist across lines.
         working-directory: android
-        script: TEST_CLASSES="io.github.picocrypt_ng.picocrypt_ng.ui.components.PasswordCardTest,io.github.picocrypt_ng.picocrypt_ng.ui.components.ProgressCardTest"; { [ "${{ inputs.test_scope }}" = "extended" ] && TEST_CLASSES="$TEST_CLASSES,io.github.picocrypt_ng.picocrypt_ng.OperationManagerIntegrationTest"; } || true; ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class="$TEST_CLASSES"
+        script: TEST_CLASSES="io.github.picocrypt_ng.picocrypt_ng.ui.components.PasswordCardTest,io.github.picocrypt_ng.picocrypt_ng.ui.components.ProgressCardTest,io.github.picocrypt_ng.picocrypt_ng.ui.components.DecryptOptionsCardTest"; { [ "${{ inputs.test_scope }}" = "extended" ] && TEST_CLASSES="$TEST_CLASSES,io.github.picocrypt_ng.picocrypt_ng.OperationManagerIntegrationTest"; } || true; ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class="$TEST_CLASSES"
 
     - name: Upload instrumented test report
       if: always()

--- a/.github/workflows/android-instrumented.yml
+++ b/.github/workflows/android-instrumented.yml
@@ -117,7 +117,10 @@ jobs:
         api-level: 36
         arch: x86_64
         disable-animations: true
-        emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none
+        # -memory 6144: the Argon2id KDF allocates 1 GiB per operation
+        # (src/internal/crypto/kdf.go); the runner's default ~2.5 GiB emulator OOMs
+        # (lowmemorykiller kills the test process) mid crypto roundtrip.
+        emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -memory 6144 -cores 4 -camera-back none -camera-front none
         # Single-line: the runner executes each script line in its own `sh -c`,
         # so multi-line `cd`/`if`/`fi` constructs do not persist across lines.
         working-directory: android

--- a/.github/workflows/android-instrumented.yml
+++ b/.github/workflows/android-instrumented.yml
@@ -113,7 +113,8 @@ jobs:
     - name: Run focused instrumented tests
       uses: ReactiveCircus/android-emulator-runner@0a638108440efd5c7f980e6ba145dbcdd8f32009 # v2.37.0
       with:
-        api-level: 34
+        # API 36 (= targetSdk), not 34: needed for API 35+ FGS timeout / onTimeout.
+        api-level: 36
         arch: x86_64
         disable-animations: true
         emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,0 +1,152 @@
+name: build-appimage
+
+permissions:
+  contents: read
+
+on:
+  push:
+    paths:
+      - "VERSION"
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    # ubuntu-22.04 (glibc 2.35) is the portability floor. AppImage was dropped once
+    # "for better portability" (Changelog v1.34); building on the newest runner's glibc
+    # forward-binds symbols that fail on older distros and would reproduce that. GL and
+    # GPU-driver libraries are intentionally NOT bundled (linuxdeploy excludelist) -- they
+    # are provided by the host, which is what keeps the AppImage portable (incl. Nvidia).
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: stable
+        cache-dependency-path: src/go.sum
+
+    - name: Install packages
+      run: |
+        sudo apt update
+        sudo apt install -y gcc pkg-config libgl1-mesa-dev xorg-dev libgtk-3-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libxxf86vm-dev libgl1 desktop-file-utils librsvg2-bin wget
+
+    - name: Build GUI
+      run: |
+        cd src
+        GOARCH=amd64 GOAMD64=v1 CGO_ENABLED=1 go build -v -ldflags="-s -w" -o Picocrypt-NG ./cmd/picocrypt
+
+    - name: Fetch and verify AppImage tooling
+      run: |
+        # Pinned by sha256 and verified (fail loud), like UPX in build-linux. These are
+        # linuxdeploy/appimagetool "continuous" builds; if upstream republishes them this
+        # check fails and the pin must be refreshed -- intentional, not silent drift.
+        wget -O linuxdeploy https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+        echo "514d4ffe2a2f757369b41863a4f63fbbb222c429652803ebc081cb16ba21ac25  linuxdeploy" | sha256sum --check --strict --status
+        wget -O appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+        echo "a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0  appimagetool" | sha256sum --check --strict --status
+        chmod +x linuxdeploy appimagetool
+        # linuxdeploy invokes appimagetool from PATH during --output appimage.
+        sudo mv appimagetool /usr/local/bin/appimagetool
+
+    - name: Build AppImage
+      env:
+        # GitHub runners lack FUSE; run the tools (and later the result) extracted.
+        APPIMAGE_EXTRACT_AND_RUN: "1"
+        # The Go binary is already stripped (-s -w) and the bundled system libs gain
+        # little from stripping; skipping it removes a fragile step (linuxdeploy's strip
+        # aborts on libraries using newer ELF sections, e.g. .relr.dyn) for ~2-3 MB.
+        NO_STRIP: "true"
+      run: |
+        VERSION=$(cat VERSION)
+        mkdir -p stage AppDir/usr/share/metainfo
+
+        # Desktop entry: point Exec at the bundled binary's basename.
+        cp dist/linux/io.github.picocrypt_ng.Picocrypt-NG.desktop stage/
+        sed -i 's|^Exec=.*|Exec=Picocrypt-NG %f|' stage/io.github.picocrypt_ng.Picocrypt-NG.desktop
+
+        # App icon (must match the desktop Icon= key) rendered from the same SVG as the .deb.
+        rsvg-convert --format png --width 256 --height 256 \
+          --output stage/io.github.picocrypt_ng.Picocrypt-NG.png images/key.svg
+
+        # AppStream metadata so AppImage-aware tooling can show app info / update sources.
+        cp dist/linux/io.github.picocrypt_ng.Picocrypt-NG.metainfo.xml AppDir/usr/share/metainfo/
+
+        # Deterministic output filename (independent of the binary's internal version).
+        export OUTPUT="Picocrypt-NG-${VERSION}-x86_64.AppImage"
+        export VERSION
+        ./linuxdeploy \
+          --appdir AppDir \
+          --executable src/Picocrypt-NG \
+          --desktop-file stage/io.github.picocrypt_ng.Picocrypt-NG.desktop \
+          --icon-file stage/io.github.picocrypt_ng.Picocrypt-NG.png \
+          --output appimage
+        test -f "$OUTPUT"
+
+    - name: Smoke test AppImage
+      env:
+        APPIMAGE_EXTRACT_AND_RUN: "1"
+      run: |
+        VERSION=$(cat VERSION)
+        APP="Picocrypt-NG-${VERSION}-x86_64.AppImage"
+        # --version drives the embedded CLI (cli.Execute) and exits before Fyne/OpenGL
+        # init, so this needs no display. It still loads every DT_NEEDED shared library at
+        # startup, so a broken/incomplete bundle fails here instead of shipping silently.
+        out=$("./$APP" --version)
+        echo "$out"
+        echo "$out" | grep -qi picocrypt
+
+    - name: Prepare to upload artifacts
+      run: |
+        VERSION=$(cat VERSION)
+        mkdir -p out
+        mv "Picocrypt-NG-${VERSION}-x86_64.AppImage" out/
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: build-appimage-amd64
+        # AppImage is already squashfs-compressed; re-zipping it gains nothing.
+        path: out/*
+        if-no-files-found: error
+        compression-level: 0
+
+  release:
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v8
+      with:
+        name: build-appimage-amd64
+        path: artifacts
+
+    - name: Get version tag and checksum
+      run: |
+        VERSION=$(cat VERSION)
+        APP="Picocrypt-NG-${VERSION}-x86_64.AppImage"
+        {
+          echo "VERSION=$VERSION"
+          echo "APPIMAGE_NAME=$APP"
+          echo "CHECKSUM_APPIMAGE=$(sha256sum "artifacts/$APP" | cut -d ' ' -f1)"
+        } >> "$GITHUB_ENV"
+
+    - name: Release
+      uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae
+      with:
+        files: artifacts/${{ env.APPIMAGE_NAME }}
+        tag_name: ${{ env.VERSION }}
+        append_body: true
+        body: |
+          **Linux (AppImage, amd64):**
+          `sha256(${{ env.APPIMAGE_NAME }})  ${{ env.CHECKSUM_APPIMAGE }}`

--- a/.github/workflows/pr-test-build-android.yml
+++ b/.github/workflows/pr-test-build-android.yml
@@ -111,7 +111,10 @@ jobs:
         api-level: 36
         arch: x86_64
         disable-animations: true
-        emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none
+        # -memory 6144: the Argon2id KDF allocates 1 GiB per operation
+        # (src/internal/crypto/kdf.go); the runner's default ~2.5 GiB emulator OOMs
+        # (lowmemorykiller kills the test process) mid crypto roundtrip.
+        emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -memory 6144 -cores 4 -camera-back none -camera-front none
         working-directory: android
         script: ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=io.github.picocrypt_ng.picocrypt_ng.OperationManagerIntegrationTest
 

--- a/.github/workflows/pr-test-build-android.yml
+++ b/.github/workflows/pr-test-build-android.yml
@@ -97,6 +97,32 @@ jobs:
       working-directory: android
       run: ./gradlew :app:assembleDebugAndroidTest
 
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
+    - name: Run instrumented crypto roundtrip
+      uses: ReactiveCircus/android-emulator-runner@0a638108440efd5c7f980e6ba145dbcdd8f32009 # v2.37.0
+      with:
+        api-level: 34
+        arch: x86_64
+        disable-animations: true
+        emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none
+        working-directory: android
+        script: ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=io.github.picocrypt_ng.picocrypt_ng.OperationManagerIntegrationTest
+
+    - name: Upload instrumented test report
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: pr-instrumented-test-report
+        path: |
+          android/app/build/reports/androidTests/connected/
+          android/app/build/outputs/androidTest-results/connected/
+        if-no-files-found: warn
+
     - name: Prepare artifacts
       run: |
         mkdir -p out

--- a/.github/workflows/pr-test-build-android.yml
+++ b/.github/workflows/pr-test-build-android.yml
@@ -106,7 +106,9 @@ jobs:
     - name: Run instrumented crypto roundtrip
       uses: ReactiveCircus/android-emulator-runner@0a638108440efd5c7f980e6ba145dbcdd8f32009 # v2.37.0
       with:
-        api-level: 34
+        # API 36 (= targetSdk), not 34: API 35+ FGS dataSync timeout and
+        # Service.onTimeout are only reachable here, so API 34 is a false green.
+        api-level: 36
         arch: x86_64
         disable-animations: true
         emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+# v2.14
+<ul>
+	<li>✓ <strong>Android: open multi-file and compressed volumes</strong>: a <code>.pcv</code> made from several files or with compression on the desktop now decrypts and saves as a <code>.zip</code> on Android instead of failing to export; open it with any file manager (auto-unzip stays off, like the CLI)</li>
+	<li>✓ <strong>Android: split volumes</strong>: selecting a <code>.pcv.0</code> chunk now tells you to recombine the parts on a computer first, instead of failing with a misleading error or re-encrypting the chunk</li>
+	<li>✓ <strong>Android: verify-first decrypt</strong>: optional integrity check before any output is written (under Decryption Options), independent of force-decrypt</li>
+	<li>✓ <strong>Android: background start</strong>: starting an encrypt or decrypt while the app is in the background no longer crashes; the operation keeps running and progress still updates</li>
+</ul>
+
 # v2.13
 <ul>
 	<li>✓ <strong>macOS iCloud file opening</strong>: late Finder/AppKit batches of one open gesture now extend the already-applied iCloud selection instead of replacing it; manual drops keep priority over gesture stragglers</li>

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 	<li>✓ <strong>Android: split volumes</strong>: selecting a <code>.pcv.0</code> chunk now tells you to recombine the parts on a computer first, instead of failing with a misleading error or re-encrypting the chunk</li>
 	<li>✓ <strong>Android: verify-first decrypt</strong>: optional integrity check before any output is written (under Decryption Options), independent of force-decrypt</li>
 	<li>✓ <strong>Android: background start</strong>: starting an encrypt or decrypt while the app is in the background no longer crashes; the operation keeps running and progress still updates</li>
+	<li>✓ <strong>Linux: AppImage package</strong>: a portable, unsandboxed single-file build that bundles its GTK/X11 dependencies and uses the host's OpenGL driver, for distros where the .deb or raw binary don't fit</li>
 </ul>
 
 # v2.13

--- a/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerIntegrationTest.kt
+++ b/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerIntegrationTest.kt
@@ -3,8 +3,11 @@ package io.github.picocrypt_ng.picocrypt_ng
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
@@ -119,57 +122,59 @@ class OperationManagerIntegrationTest {
     }
     
     @Test
-    fun startEncrypt_creates_operation_state_on_success() = runTest {
-        // Create a test file
-        val internalDir = File(context.filesDir, "picocrypt_files")
-        internalDir.mkdirs()
-        val testFile = File(internalDir, "input_file.txt")
-        testFile.writeText("test content")
-        
-        val formData = encryptFormData(
-            copiedFilePath = testFile.absolutePath,
-            password = "testpassword",
-            confirmPassword = "testpassword"
+    fun encrypt_then_decrypt_recovers_the_original_bytes() = runBlocking {
+        // The point of an ON-DEVICE gate: prove that real bytes survive
+        // encrypt -> gomobile/JNI bridge -> native crypto -> decrypt on an actual device.
+        // `go test` already covers the crypto math but never crosses the bridge, so this is
+        // the only place that proves the bridge + AAR + KDF/cipher actually round-trip.
+        // runBlocking (not runTest) so the wait runs in real wall-clock time.
+        val original = (
+            "Picocrypt-NG on-device roundtrip — éçü 0123456789 " +
+                "the quick brown fox jumps over the lazy dog"
+            ).toByteArray(Charsets.UTF_8)
+        val internalDir = File(context.filesDir, "picocrypt_files").apply { mkdirs() }
+        val plaintext = File(internalDir, "roundtrip_input.txt")
+        plaintext.writeBytes(original)
+
+        // Encrypt.
+        val encStart = OperationManager.startEncrypt(
+            context,
+            encryptFormData(copiedFilePath = plaintext.absolutePath)
         )
-        
-        val result = OperationManager.startEncrypt(context, formData)
-
-        assertTrue("Encrypt should start successfully: ${result.exceptionOrNull()}", result.isSuccess)
-        val operationID = result.getOrThrow()
-
-        val operationState = OperationManager.currentOperation.first()
-        assertNotNull("Operation state should be set", operationState)
-        assertEquals("Operation ID should match", operationID, operationState?.id)
-        assertEquals("Operation type should be ENCRYPT", OperationType.ENCRYPT, operationState?.type)
-        assertEquals("Input file should match", testFile.absolutePath, operationState?.inputFile)
-        assertNotNull("Output file should be set", operationState?.outputFile)
-        assertTrue("Output file should end with .pcv", operationState?.outputFile?.endsWith(".pcv") == true)
-    }
-    
-    @Test
-    fun startDecrypt_creates_operation_state_on_success() = runTest {
-        val password = "testpassword"
-        val encryptedFile = createEncryptedVolume(
-            sourceText = "test encrypted content",
-            password = password
+        assertTrue("encrypt should start: ${encStart.exceptionOrNull()}", encStart.isSuccess)
+        val encState = waitForOperationToFinish()
+        assertNull("encrypt must not finish with an error", encState.error)
+        val encryptedFile = File(encState.outputFile)
+        assertTrue("encrypted volume must exist", encryptedFile.exists())
+        assertFalse(
+            "ciphertext must differ from plaintext (data was actually encrypted)",
+            encryptedFile.readBytes().contentEquals(original)
         )
+        OperationManager.clearOperation(context, shouldCleanupFiles = false)
 
-        val formData = decryptFormData(
-            copiedFilePath = encryptedFile.absolutePath,
-            password = password
+        // Re-stage the ciphertext as a decrypt INPUT, mirroring the real app: a picked
+        // .pcv is copied to input_file.<ext>. startDecrypt's pre-clean wipes output_file.*
+        // (never input_file.*), so feeding the raw encrypt output back in would delete it.
+        val decryptInput = File(internalDir, "input_file.pcv")
+        encryptedFile.copyTo(decryptInput, overwrite = true)
+
+        // Decrypt the volume we just produced.
+        val decStart = OperationManager.startDecrypt(
+            context,
+            decryptFormData(copiedFilePath = decryptInput.absolutePath)
         )
+        assertTrue("decrypt should start: ${decStart.exceptionOrNull()}", decStart.isSuccess)
+        val decState = waitForOperationToFinish()
+        assertNull("decrypt must not finish with an error", decState.error)
+        val decryptedFile = File(decState.outputFile)
+        assertTrue("decrypted output must exist", decryptedFile.exists())
 
-        val result = OperationManager.startDecrypt(context, formData)
-
-        assertTrue("Decrypt should start successfully: ${result.exceptionOrNull()}", result.isSuccess)
-        val operationID = result.getOrThrow()
-
-        val operationState = OperationManager.currentOperation.first()
-        assertNotNull("Operation state should be set", operationState)
-        assertEquals("Operation ID should match", operationID, operationState?.id)
-        assertEquals("Operation type should be DECRYPT", OperationType.DECRYPT, operationState?.type)
-        assertEquals("Input file should match", encryptedFile.absolutePath, operationState?.inputFile)
-        assertNotNull("Output file should be set", operationState?.outputFile)
+        // The assertion that actually matters: the bytes came back intact.
+        assertArrayEquals(
+            "decrypted bytes must equal the original plaintext",
+            original,
+            decryptedFile.readBytes()
+        )
     }
     
     @Test
@@ -279,40 +284,18 @@ class OperationManagerIntegrationTest {
         assertNull("Should be null after clearing", operationState)
     }
 
-    private suspend fun createEncryptedVolume(sourceText: String, password: String): File {
-        val internalDir = File(context.filesDir, "picocrypt_files")
-        internalDir.mkdirs()
-        val inputFile = File(internalDir, "integration_input.txt")
-        inputFile.writeText(sourceText)
-
-        val result = OperationManager.startEncrypt(
-            context,
-            encryptFormData(
-                copiedFilePath = inputFile.absolutePath,
-                password = password,
-                confirmPassword = password
-            )
-        )
-        assertTrue("Encrypt setup should start successfully: ${result.exceptionOrNull()}", result.isSuccess)
-
-        val completed = waitForOperationToFinish()
-        assertTrue("Encrypt setup operation should complete successfully", completed.done)
-        assertNull("Encrypt setup should not finish with error", completed.error)
-
-        val encryptedFile = File(completed.outputFile)
-        OperationManager.clearOperation(context, shouldCleanupFiles = false)
-
-        assertTrue("Encrypted file should exist for decrypt test", encryptedFile.exists())
-        return encryptedFile
-    }
-
-    private suspend fun waitForOperationToFinish(maxPolls: Int = 200): OperationState {
+    // Polls the async Go operation to completion in REAL wall-clock time. The gomobile
+    // bridge is start-then-poll by design, so polling is unavoidable; the budget is large
+    // enough (~60s for an Argon2id KDF that takes seconds) that only a genuine bug -- not a
+    // slow emulator -- can trip it. delay() is forced onto a real dispatcher so a
+    // virtual-time test scheduler cannot collapse it to zero.
+    private suspend fun waitForOperationToFinish(maxPolls: Int = 600): OperationState {
         repeat(maxPolls) {
             val state = OperationManager.pollProgress()
             if (state != null && state.done) {
                 return state
             }
-            delay(50)
+            withContext(Dispatchers.IO) { delay(100) }
         }
         throw AssertionError("Timed out waiting for operation to finish")
     }

--- a/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/DecryptOptionsCardTest.kt
+++ b/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/DecryptOptionsCardTest.kt
@@ -1,0 +1,45 @@
+package io.github.picocrypt_ng.picocrypt_ng.ui.components
+
+import android.app.Application
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.picocrypt_ng.picocrypt_ng.MainViewModel
+import io.github.picocrypt_ng.picocrypt_ng.R
+import io.github.picocrypt_ng.picocrypt_ng.testutils.TestDataBuilders
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DecryptOptionsCardTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val application: Application
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun verifyFirstCheckboxTogglesFormState() {
+        val viewModel = MainViewModel(application, SavedStateHandle())
+        viewModel.updateFormData(TestDataBuilders.createDecryptFormData())
+
+        composeTestRule.setContent {
+            DecryptOptionsCard(viewModel = viewModel)
+        }
+
+        // ExpandableCard starts collapsed — expand it (count starts at 0), then toggle.
+        composeTestRule.onNodeWithText(application.getString(R.string.decrypt_options, 0)).performClick()
+        composeTestRule.onNodeWithText(application.getString(R.string.verify_first)).performClick()
+
+        assertTrue(
+            "Tapping 'verify first' must flip the verifyFirst form state",
+            viewModel.formState.value.verifyFirst
+        )
+    }
+}

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/AppError.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/AppError.kt
@@ -130,6 +130,16 @@ sealed class AppError(
          * Passwords don't match (for encryption).
          */
         object PasswordsMismatch : ValidationError("Passwords do not match")
+
+        /**
+         * A numbered split-volume chunk (e.g. secret.pcv.0) was selected. Android cannot
+         * recombine chunks (single-file picker, no sibling access), so the operation is
+         * rejected with guidance to recombine on a desktop first.
+         */
+        object SplitVolumeNotSupported : ValidationError(
+            "Split volumes aren't supported on Android. Recombine the chunks on your " +
+                "computer first, then transfer the single .pcv file."
+        )
     }
     
     companion object {

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FormData.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FormData.kt
@@ -25,6 +25,7 @@ data class FormData(
     val reedSolomon: Boolean,
     val paranoid: Boolean,
     val deniability: Boolean,
+    val verifyFirst: Boolean = false,
     val keyfileFilenames: List<KeyfileInfo>, // Keyfile info with internal path and display name
     val keyfileOrdered: Boolean,
     val decryptionInfo: DecryptionInfo? = null
@@ -74,6 +75,7 @@ data class FormData(
         if (reedSolomon != other.reedSolomon) return false
         if (paranoid != other.paranoid) return false
         if (deniability != other.deniability) return false
+        if (verifyFirst != other.verifyFirst) return false
         if (keyfileFilenames != other.keyfileFilenames) return false
         if (keyfileOrdered != other.keyfileOrdered) return false
         if (decryptionInfo != other.decryptionInfo) return false
@@ -90,6 +92,7 @@ data class FormData(
         result = 31 * result + reedSolomon.hashCode()
         result = 31 * result + paranoid.hashCode()
         result = 31 * result + deniability.hashCode()
+        result = 31 * result + verifyFirst.hashCode()
         result = 31 * result + keyfileFilenames.hashCode()
         result = 31 * result + keyfileOrdered.hashCode()
         result = 31 * result + (decryptionInfo?.hashCode() ?: 0)

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FormData.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FormData.kt
@@ -38,6 +38,16 @@ data class FormData(
         get() = passwordInput.contentEquals(confirmPasswordInput)
     val isPasswordValid: Boolean
         get() = passwordInput.isNotEmpty() && ((isEncrypt && isPasswordsMatch) || isDecrypt)
+
+    /**
+     * True when the selected file is a numbered split-volume chunk (e.g. secret.pcv.0).
+     * Mirrors Go fileops.IsSplitChunkPath. Android cannot recombine chunks (single-file
+     * picker, no sibling access), so such files are rejected loudly rather than run --
+     * a chunk does not end in .pcv, so without this it would be treated as an encrypt
+     * target and double-encrypted.
+     */
+    val isSplitVolumeChunk: Boolean
+        get() = isSplitVolumeChunkName(selectedFilename)
     
     /**
      * Clears password fields by zeroing the character arrays.
@@ -112,5 +122,19 @@ data class FormData(
         }
     
     val isFormValid: Boolean
-        get() = selectedFilename.isNotEmpty() && isPasswordValid && !areKeyfilesRequiredButMissing
+        get() = selectedFilename.isNotEmpty() && isPasswordValid &&
+            !areKeyfilesRequiredButMissing && !isSplitVolumeChunk
+
+    companion object {
+        // Mirrors Go fileops.splitChunkRE: (?i)\.pcv\.[0-9]+$ matched on the base name.
+        private val SPLIT_CHUNK_REGEX = Regex("""(?i)\.pcv\.[0-9]+$""")
+
+        /**
+         * Reports whether [filename] names a numbered split-volume chunk (e.g.
+         * secret.pcv.0). Kept in sync with Go fileops.IsSplitChunkPath so detection is
+         * identical on both sides of the bridge.
+         */
+        fun isSplitVolumeChunkName(filename: String): Boolean =
+            SPLIT_CHUNK_REGEX.containsMatchIn(filename.substringAfterLast('/'))
+    }
 }

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/GoBridge.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/GoBridge.kt
@@ -137,20 +137,7 @@ object GoBridge {
     ): Result<Unit> {
         return try {
             // Build JSON request (password is passed separately as bytes, never in JSON)
-            val requestJson = JSONObject().apply {
-                put("operationID", operationID)
-                put("inputFile", inputFile)
-                put("outputFile", outputFile)
-                put("comments", options.comments)
-                put("keyfiles", JSONArray().apply {
-                    options.keyfiles.forEach { put(it) }
-                })
-                put("paranoid", options.paranoid)
-                put("reedSolomon", options.reedSolomon)
-                put("deniability", options.deniability)
-                put("compress", options.compress)
-                put("keyfileOrdered", options.keyfileOrdered)
-            }.toString()
+            val requestJson = buildEncryptRequestJson(operationID, inputFile, outputFile, options)
 
             // Note: gomobile copies the array across JNI; that transient bridge copy is not reachable for zeroing (intrinsic to the binding).
             val errorMsg = Mobile.startEncrypt(requestJson, password)
@@ -190,20 +177,7 @@ object GoBridge {
     ): Result<Unit> {
         return try {
             // Build JSON request (password is passed separately as bytes, never in JSON)
-            val requestJson = JSONObject().apply {
-                put("operationID", operationID)
-                put("inputFile", inputFile)
-                put("outputFile", outputFile)
-                put("keyfiles", JSONArray().apply {
-                    options.keyfiles.forEach { put(it) }
-                })
-                put("forceDecrypt", options.forceDecrypt)
-                put("verifyFirst", options.verifyFirst)
-                put("autoUnzip", options.autoUnzip)
-                put("sameLevel", options.sameLevel)
-                put("recombine", options.recombine)
-                put("deniability", options.deniability)
-            }.toString()
+            val requestJson = buildDecryptRequestJson(operationID, inputFile, outputFile, options)
 
             // Note: gomobile copies the array across JNI; that transient bridge copy is not reachable for zeroing (intrinsic to the binding).
             val errorMsg = Mobile.startDecrypt(requestJson, password)
@@ -285,21 +259,75 @@ object GoBridge {
     fun getDecryptionInfo(filePath: String): Result<DecryptionInfo> {
         return try {
             val jsonString = Mobile.getDecryptionInfo(filePath)
-            val json = JSONObject(jsonString)
-            
-            Result.success(DecryptionInfo(
-                keyfilesRequired = json.getBoolean("keyfilesRequired"),
-                keyfileOrdered = json.getBoolean("keyfileOrdered"),
-                reedSolomon = json.getBoolean("reedSolomon"),
-                deniability = json.getBoolean("deniability"),
-                paranoid = json.getBoolean("paranoid"),
-                comments = json.getString("comments"),
-                readable = json.getBoolean("readable")
-            ))
+            Result.success(parseDecryptionInfo(jsonString))
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             Result.failure(AppError.fromException(e))
         }
+    }
+
+    /**
+     * Builds the encryption request JSON sent to Mobile.startEncrypt. The password is
+     * intentionally NEVER included here -- it is passed to Mobile as raw bytes and zeroed.
+     * Extracted so unit tests verify the REAL serialization instead of re-deriving it.
+     */
+    internal fun buildEncryptRequestJson(
+        operationID: String,
+        inputFile: String,
+        outputFile: String,
+        options: EncryptOptions
+    ): String = JSONObject().apply {
+        put("operationID", operationID)
+        put("inputFile", inputFile)
+        put("outputFile", outputFile)
+        put("comments", options.comments)
+        put("keyfiles", JSONArray().apply { options.keyfiles.forEach { put(it) } })
+        put("paranoid", options.paranoid)
+        put("reedSolomon", options.reedSolomon)
+        put("deniability", options.deniability)
+        put("compress", options.compress)
+        put("keyfileOrdered", options.keyfileOrdered)
+    }.toString()
+
+    /**
+     * Builds the decryption request JSON sent to Mobile.startDecrypt. As with encryption,
+     * the password is never serialized. Extracted for the same testability reason.
+     */
+    internal fun buildDecryptRequestJson(
+        operationID: String,
+        inputFile: String,
+        outputFile: String,
+        options: DecryptOptions
+    ): String = JSONObject().apply {
+        put("operationID", operationID)
+        put("inputFile", inputFile)
+        put("outputFile", outputFile)
+        put("keyfiles", JSONArray().apply { options.keyfiles.forEach { put(it) } })
+        put("forceDecrypt", options.forceDecrypt)
+        put("verifyFirst", options.verifyFirst)
+        put("autoUnzip", options.autoUnzip)
+        put("sameLevel", options.sameLevel)
+        put("recombine", options.recombine)
+        put("deniability", options.deniability)
+    }.toString()
+
+    /**
+     * Parses the decryption-metadata JSON returned by Mobile.getDecryptionInfo. Uses
+     * getBoolean/getString, which THROW on a missing field rather than silently
+     * defaulting (a missing keyfilesRequired must never be read as false). Extracted so
+     * the parser is unit-tested directly.
+     */
+    internal fun parseDecryptionInfo(jsonString: String): DecryptionInfo {
+        val json = JSONObject(jsonString)
+        return DecryptionInfo(
+            keyfilesRequired = json.getBoolean("keyfilesRequired"),
+            keyfileOrdered = json.getBoolean("keyfileOrdered"),
+            reedSolomon = json.getBoolean("reedSolomon"),
+            deniability = json.getBoolean("deniability"),
+            paranoid = json.getBoolean("paranoid"),
+            comments = json.getString("comments"),
+            readable = json.getBoolean("readable")
+        )
     }
 }

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/MainActivity.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/MainActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import io.github.picocrypt_ng.picocrypt_ng.ui.components.AdvancedCard
 import io.github.picocrypt_ng.picocrypt_ng.ui.components.CommentsCard
+import io.github.picocrypt_ng.picocrypt_ng.ui.components.DecryptOptionsCard
 import io.github.picocrypt_ng.picocrypt_ng.ui.components.DecryptionInfoCard
 import io.github.picocrypt_ng.picocrypt_ng.ui.components.ErrorDialog
 import io.github.picocrypt_ng.picocrypt_ng.ui.components.FileCard
@@ -173,6 +174,9 @@ fun MainLayout() {
     val isAdvancedCardVisible = remember(formData) {
         formData.isEncrypt
     }
+    val isDecryptOptionsCardVisible = remember(formData) {
+        formData.isDecrypt
+    }
     val isKeyfileCardVisible = remember(formData) {
         if (!(formData.isEncrypt || formData.isDecrypt)) {
             false
@@ -197,6 +201,7 @@ fun MainLayout() {
         if (isDecryptionInfoCardVisible) add { DecryptionInfoCard(mainViewModel) }
         if (isPasswordCardVisible) add { PasswordCard(mainViewModel) }
         if (isAdvancedCardVisible) add { AdvancedCard(mainViewModel) }
+        if (isDecryptOptionsCardVisible) add { DecryptOptionsCard(mainViewModel) }
         if (isKeyfileCardVisible) add { KeyfileCard(mainViewModel) }
         if (isWorkButtonVisible) add { WorkButton(mainViewModel, operationViewModel) }
     }

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/MainViewModel.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/MainViewModel.kt
@@ -31,6 +31,7 @@ class MainViewModel(
         reedSolomon = false, // Always default, no persistence
         paranoid = false, // Always default, no persistence
         deniability = false, // Always default, no persistence
+        verifyFirst = false, // Always default, no persistence
         keyfileFilenames = emptyList(), // Always default, no persistence
         keyfileOrdered = false, // Always default, no persistence
         decryptionInfo = null // Never save decryption info (transient)
@@ -169,6 +170,7 @@ class MainViewModel(
             reedSolomon = false,
             paranoid = false,
             deniability = false,
+            verifyFirst = false,
             keyfileFilenames = emptyList(),
             keyfileOrdered = false,
             decryptionInfo = null

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationForegroundService.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationForegroundService.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
@@ -84,6 +85,7 @@ class OperationForegroundService : Service() {
      * (6h / 24h on Android 15+). Cancel the operation and stop promptly to avoid a crash.
      */
     @OptIn(DelicateCoroutinesApi::class)
+    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
     override fun onTimeout(startId: Int, fgsType: Int) {
         // Cancel on a process-lifetime scope: stopSelf() below cancels `scope`, so a cancel
         // launched on `scope` could be cancelled before it signals the native Go operation.

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationManager.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationManager.kt
@@ -107,7 +107,7 @@ object OperationManager {
         val options = DecryptOptions(
             keyfiles = formData.keyfileFilenames.map { it.internalPath },
             forceDecrypt = false,
-            verifyFirst = false,
+            verifyFirst = formData.verifyFirst,
             autoUnzip = true, // Auto-unzip decrypted files
             sameLevel = false,
             recombine = false, // Split volumes are not supported in the Android app
@@ -304,7 +304,7 @@ object OperationManager {
         val options = DecryptOptions(
             keyfiles = formData.keyfileFilenames.map { it.internalPath },
             forceDecrypt = true, // Enable force decrypt
-            verifyFirst = false,
+            verifyFirst = formData.verifyFirst,
             autoUnzip = true,
             sameLevel = false,
             recombine = false,

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationManager.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationManager.kt
@@ -26,7 +26,14 @@ object OperationManager {
         if (formData.copiedFilePath.isEmpty()) {
             return@withContext Result.failure(AppError.ValidationError.NoFileSelected)
         }
-        
+
+        // A numbered split-volume chunk (secret.pcv.0) does not end in .pcv, so it lands
+        // on the encrypt path and would be DOUBLE-ENCRYPTED. Android cannot recombine
+        // (single-file picker), so reject it loudly before any work.
+        if (formData.isSplitVolumeChunk) {
+            return@withContext Result.failure(AppError.ValidationError.SplitVolumeNotSupported)
+        }
+
         if (!formData.isPasswordValid) {
             val error = if (formData.isEncrypt && !formData.isPasswordsMatch) {
                 AppError.ValidationError.PasswordsMismatch
@@ -35,10 +42,10 @@ object OperationManager {
             }
             return@withContext Result.failure(error)
         }
-        
+
         // Clean up old files before starting new operation to prevent contamination
         FileCopyService.cleanupOperationFilesBeforeStart(context)
-        
+
         // Generate output file path using FileCopyService
         val outputFilePath = FileCopyService.getOutputFilePath(context, formData.copiedFilePath, isEncrypt = true)
 
@@ -90,14 +97,21 @@ object OperationManager {
         if (formData.copiedFilePath.isEmpty()) {
             return@withContext Result.failure(AppError.ValidationError.NoFileSelected)
         }
-        
+
+        // A desktop split volume (secret.pcv.0) cannot be decrypted on Android without
+        // recombining its sibling chunks, which the single-file picker cannot supply.
+        // Fail loud instead of running the Go op on one chunk (a confusing corrupt error).
+        if (formData.isSplitVolumeChunk) {
+            return@withContext Result.failure(AppError.ValidationError.SplitVolumeNotSupported)
+        }
+
         if (!formData.isPasswordValid) {
             return@withContext Result.failure(AppError.ValidationError.InvalidPassword)
         }
-        
+
         // Clean up old files before starting new operation to prevent contamination
         FileCopyService.cleanupOperationFilesBeforeStart(context)
-        
+
         // Generate output file path using FileCopyService
         val outputFilePath = FileCopyService.getOutputFilePath(context, formData.copiedFilePath, isEncrypt = false)
 

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationManager.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationManager.kt
@@ -108,7 +108,12 @@ object OperationManager {
             keyfiles = formData.keyfileFilenames.map { it.internalPath },
             forceDecrypt = false,
             verifyFirst = formData.verifyFirst,
-            autoUnzip = true, // Auto-unzip decrypted files
+            // INTEROP: Go auto-unzip extracts to a subdirectory and DELETES the zip
+            // (decrypt.go:816,847). Android exports a single fixed output path, so an
+            // unzipped output orphans the export -> SaveFailed. Keep OFF until a SAF
+            // tree-export exists; the intact .zip stays exportable. Matches the CLI
+            // --auto-unzip default (decrypt.go:94).
+            autoUnzip = false,
             sameLevel = false,
             recombine = false, // Split volumes are not supported in the Android app
             deniability = formData.decryptionInfo?.deniability ?: false
@@ -305,7 +310,7 @@ object OperationManager {
             keyfiles = formData.keyfileFilenames.map { it.internalPath },
             forceDecrypt = true, // Enable force decrypt
             verifyFirst = formData.verifyFirst,
-            autoUnzip = true,
+            autoUnzip = false, // See startDecrypt: off until SAF tree-export exists.
             sameLevel = false,
             recombine = false,
             deniability = formData.decryptionInfo?.deniability ?: false

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationViewModel.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationViewModel.kt
@@ -18,7 +18,22 @@ class OperationViewModel : ViewModel() {
     private var pollingJob: Job? = null
     private var backgroundPollingJob: Job? = null
     private var isForeground = true
-    
+
+    /**
+     * Starts the foreground service, swallowing a background-start failure. On Android
+     * 12+ ForegroundServiceStartNotAllowedException (an IllegalStateException subclass)
+     * is thrown if the app left the foreground during the suspending op-start. The Go
+     * operation is already running; callers still poll so progress and completion
+     * surface — just without the ongoing notification.
+     */
+    internal fun startForegroundServiceSafely(context: Context) {
+        try {
+            OperationForegroundService.start(context.applicationContext)
+        } catch (e: IllegalStateException) {
+            // Background-start not allowed; intentionally ignored (see KDoc).
+        }
+    }
+
     /**
      * Starts an encryption operation and begins polling progress.
      */
@@ -26,7 +41,7 @@ class OperationViewModel : ViewModel() {
         viewModelScope.launch {
             val result = OperationManager.startEncrypt(context, formData)
             result.onSuccess {
-                OperationForegroundService.start(context.applicationContext)
+                startForegroundServiceSafely(context)
                 startPolling()
             }
         }
@@ -39,7 +54,7 @@ class OperationViewModel : ViewModel() {
         viewModelScope.launch {
             val result = OperationManager.startDecrypt(context, formData)
             result.onSuccess {
-                OperationForegroundService.start(context.applicationContext)
+                startForegroundServiceSafely(context)
                 startPolling()
             }
         }
@@ -75,7 +90,7 @@ class OperationViewModel : ViewModel() {
             stopPolling()
             val result = OperationManager.retryOperation(context, formData)
             result.onSuccess {
-                OperationForegroundService.start(context.applicationContext)
+                startForegroundServiceSafely(context)
                 startPolling()
             }
         }
@@ -89,7 +104,7 @@ class OperationViewModel : ViewModel() {
             stopPolling()
             val result = OperationManager.retryDecryptWithForce()
             result.onSuccess {
-                OperationForegroundService.start(context.applicationContext)
+                startForegroundServiceSafely(context)
                 startPolling()
             }
         }

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/DecryptOptionsCard.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/DecryptOptionsCard.kt
@@ -1,0 +1,33 @@
+package io.github.picocrypt_ng.picocrypt_ng.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import io.github.picocrypt_ng.picocrypt_ng.MainViewModel
+import io.github.picocrypt_ng.picocrypt_ng.R
+
+/**
+ * Decrypt-only options card. Mirrors AdvancedCard (encrypt) but for decrypt-time
+ * options. Currently exposes verify-first (integrity-verify-before-write); reuses the
+ * ExpandableCard / LabeledCheckbox helpers defined in AdvancedCard.kt.
+ */
+@Composable
+fun DecryptOptionsCard(viewModel: MainViewModel, modifier: Modifier = Modifier) {
+    val formData by viewModel.formState.collectAsState()
+    if (!formData.isDecrypt) {
+        return
+    }
+    val count = (if (formData.verifyFirst) 1 else 0)
+    ExpandableCard(title = stringResource(R.string.decrypt_options, count), modifier = modifier) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            LabeledCheckbox(stringResource(R.string.verify_first), formData.verifyFirst) {
+                viewModel.updateFormData(formData.copy(verifyFirst = it))
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/FileCard.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/FileCard.kt
@@ -159,7 +159,14 @@ fun ChooseFile(viewModel: MainViewModel) {
                 }
             }
             selectedFileName = fileName
-            selectedUri = it // Trigger LaunchedEffect
+            if (FormData.isSplitVolumeChunkName(fileName)) {
+                // Split-volume chunk (secret.pcv.0): Android cannot recombine sibling
+                // chunks. Surface the reason loudly and skip copy/detect -- otherwise it
+                // would be treated as an encrypt target and double-encrypted.
+                viewModel.setError(AppError.ValidationError.SplitVolumeNotSupported)
+            } else {
+                selectedUri = it // Trigger LaunchedEffect (copy + detect)
+            }
         }
     }
     

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -41,7 +41,11 @@
     <string name="paranoid">Paranoid</string>
     <string name="deniability">Deniability</string>
     <string name="expand_or_collapse">Expand or collapse</string>
-    
+
+    <!-- Decrypt Options Card -->
+    <string name="decrypt_options">Decryption Options (%1$d)</string>
+    <string name="verify_first">Verify integrity first</string>
+
     <!-- Decryption Info Card -->
     <string name="encryption_settings">Encryption Settings</string>
     <string name="keyfiles_section">Keyfiles</string>

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/FormDataTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/FormDataTest.kt
@@ -280,6 +280,41 @@ class FormDataTest {
         assertEquals(formData1.hashCode(), formData2.hashCode())
         assertNotEquals(formData1.hashCode(), formData3.hashCode())
     }
+
+    @Test
+    fun `isSplitVolumeChunk detects numbered pcv chunks`() {
+        // Must mirror Go fileops.IsSplitChunkPath: (?i)\.pcv\.[0-9]+$ on the base name.
+        // Desktop split volumes (secret.pcv.0, .1, ...) need recombining; Android can't
+        // (single-file picker, no sibling chunks), so they must be detected and rejected.
+        val cases = listOf(
+            "archive.zip.pcv.0" to true,
+            "archive.zip.pcv.12" to true,
+            "ARCHIVE.ZIP.PCV.0" to true,   // case-insensitive, like the Go regex
+            "secret.pcv.0" to true,
+            "backup.pcv.tmp1" to false,    // suffix not all digits
+            "notes.pcv.v2" to false,
+            "secret.pcv" to false,         // a normal (single) volume
+            "photo.jpg" to false,
+            "" to false
+        )
+        for ((name, want) in cases) {
+            val formData = TestDataBuilders.createDecryptFormData(selectedFilename = name)
+            assertEquals("isSplitVolumeChunk for '$name'", want, formData.isSplitVolumeChunk)
+        }
+    }
+
+    @Test
+    fun `isFormValid is false for a split volume chunk`() {
+        // A split chunk must never be a runnable operation: it does not end in .pcv, so
+        // isEncrypt is true and it would be double-encrypted. The work button gates on
+        // isFormValid, so a chunk must make the form invalid even with a valid password.
+        val formData = TestDataBuilders.createDecryptFormData(
+            selectedFilename = "secret.pcv.0",
+            password = "testpassword"
+        )
+        assertTrue("precondition: chunk is classified as split", formData.isSplitVolumeChunk)
+        assertFalse("a split chunk must invalidate the form", formData.isFormValid)
+    }
 }
 
 

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/GoBridgeTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/GoBridgeTest.kt
@@ -1,25 +1,26 @@
 package io.github.picocrypt_ng.picocrypt_ng
 
 import org.junit.Assert.*
+import org.junit.Assume.assumeTrue
 import org.junit.Test
+import org.json.JSONException
 import org.json.JSONObject
-import org.json.JSONArray
 
 /**
- * Unit tests for GoBridge class.
- * 
- * Note: GoBridge uses mobile.Mobile which is a generated class from Go mobile bindings.
- * Full integration testing requires the Go mobile AAR to be built and should be done
- * in instrumented tests. These unit tests focus on error handling and conversion logic.
- * 
- * Some tests may fail if Go mobile bindings are not available - this is expected in
- * unit test environments where the AAR may not be built.
+ * Unit tests for GoBridge.
+ *
+ * Two kinds of tests live here:
+ *  - Pure-logic tests (request-JSON building, response parsing, password zeroing, option
+ *    defaults) run on the plain JVM and assert the REAL production code paths -- they fail
+ *    if the production serialization/parsing changes.
+ *  - Tests that need the gomobile native bridge (mobile.Mobile) cannot run on the JVM.
+ *    They SKIP LOUDLY via assumeTrue(isGoMobileAvailable()) instead of silently passing
+ *    (JUnit reports them as ignored, not green). Their real coverage is the on-device
+ *    OperationManagerIntegrationTest crypto roundtrip.
  */
 class GoBridgeTest {
-    
-    /**
-     * Checks if Go mobile bindings are available.
-     */
+
+    /** True only when the gomobile AAR (mobile.Mobile) is loadable in this runtime. */
     private fun isGoMobileAvailable(): Boolean {
         return try {
             Class.forName("mobile.Mobile")
@@ -32,343 +33,220 @@ class GoBridgeTest {
             false
         }
     }
-    
-    @Test
-    fun `startOperation returns operation ID on success`() {
-        // This test requires the Go mobile bindings to be available
-        // In a real scenario, this would be an instrumented test
-        // For unit tests, we verify the Result wrapping or handle missing bindings
-        try {
-            val result = GoBridge.startOperation()
-            assertNotNull("Result should not be null", result)
-            result.onSuccess { operationId ->
-                assertTrue("Operation ID should not be empty", operationId.isNotEmpty())
-            }
-        } catch (e: UnsatisfiedLinkError) {
-            // Go mobile bindings not available - this is expected in unit tests
-            // Skip this test when bindings aren't available
-        } catch (e: NoClassDefFoundError) {
-            // Go mobile bindings not available - this is expected in unit tests
-            // Skip this test when bindings aren't available
-        }
-    }
+
+    // --- Request JSON building: asserts the REAL production builders ------------------
+    // These call GoBridge.build*RequestJson (the exact code startEncrypt/startDecrypt
+    // send to Go), so they fail if a field is dropped, renamed, or retyped. No AAR needed.
 
     @Test
-    fun `startOperation returns failure (no fabricated ID) on exception`() {
-        // The fabricated-ID fallback was removed: a Go binding failure must surface
-        // as Result.failure, never a fake "op_..." ID that the Go map does not hold.
-        // We can't force Mobile to throw without mocking, but we verify the method
-        // never throws (except for missing bindings) and, if it fails, wraps an AppError.
-        try {
-            val result = GoBridge.startOperation()
-            assertNotNull(result)
-            result.onFailure { error ->
-                assertTrue("Error should be AppError", error is AppError)
-            }
-        } catch (e: UnsatisfiedLinkError) {
-            // Go mobile bindings not available - this is expected in unit tests
-        } catch (e: NoClassDefFoundError) {
-            // Go mobile bindings not available - this is expected in unit tests
-        } catch (e: Exception) {
-            fail("startOperation should not throw exceptions (except missing bindings), but got: ${e.message}")
-        }
-    }
-    
-    @Test
-    fun `detectOperation returns error on exception`() {
-        // Test with invalid file path that should cause an exception
-        try {
-            val result = GoBridge.detectOperation("")
-            
-            // Result should be either success or failure, but not throw
-            assertNotNull("Result should not be null", result)
-            
-            // If it fails, should be a proper AppError
-            result.onFailure { error ->
-                assertTrue("Error should be AppError", error is AppError)
-                assertTrue("Error should be GenericOperation", error is AppError.OperationError.GenericOperation)
-            }
-        } catch (e: UnsatisfiedLinkError) {
-            // Go mobile bindings not available - this is expected in unit tests
-        } catch (e: NoClassDefFoundError) {
-            // Go mobile bindings not available - this is expected in unit tests
-        }
-    }
-    
-    @Test
-    fun `startEncrypt JSON structure is correct`() {
-        // This test doesn't require Go mobile bindings - it just tests JSON structure
-        // Test that the JSON structure built by startEncrypt is correct
-        // We can't easily test the full flow without Mobile, but we can verify
-        // the JSON building logic by examining what would be created
-        
-        // Skip if Go mobile bindings cause class loading issues
-        if (!isGoMobileAvailable()) {
-            return
-        }
-        
-        val operationID = "test_op_123"
-        val inputFile = "/path/to/input.txt"
-        val outputFile = "/path/to/output.pcv"
-        val options = EncryptOptions(
-            comments = "Test comments",
-            paranoid = true,
-            reedSolomon = true,
-            deniability = false,
-            compress = false,
-            keyfiles = listOf("keyfile1", "keyfile2"),
-            keyfileOrdered = true
+    fun `buildEncryptRequestJson serializes every option and never the password`() {
+        val json = JSONObject(
+            GoBridge.buildEncryptRequestJson(
+                operationID = "test_op_123",
+                inputFile = "/path/to/input.txt",
+                outputFile = "/path/to/output.pcv",
+                options = EncryptOptions(
+                    comments = "Test comments",
+                    paranoid = true,
+                    reedSolomon = true,
+                    deniability = false,
+                    compress = true,
+                    keyfiles = listOf("keyfile1", "keyfile2"),
+                    keyfileOrdered = true
+                )
+            )
         )
 
-        // Build the expected JSON structure (password is passed as bytes, never in JSON)
-        val expectedJson = JSONObject().apply {
-            put("operationID", operationID)
-            put("inputFile", inputFile)
-            put("outputFile", outputFile)
-            put("comments", options.comments)
-            put("keyfiles", JSONArray().apply {
-                options.keyfiles.forEach { put(it) }
-            })
-            put("paranoid", options.paranoid)
-            put("reedSolomon", options.reedSolomon)
-            put("deniability", options.deniability)
-            put("compress", options.compress)
-            put("keyfileOrdered", options.keyfileOrdered)
-        }
+        assertEquals("test_op_123", json.getString("operationID"))
+        assertEquals("/path/to/input.txt", json.getString("inputFile"))
+        assertEquals("/path/to/output.pcv", json.getString("outputFile"))
+        assertEquals("Test comments", json.getString("comments"))
+        assertTrue(json.getBoolean("paranoid"))
+        assertTrue(json.getBoolean("reedSolomon"))
+        assertFalse(json.getBoolean("deniability"))
+        assertTrue(json.getBoolean("compress"))
+        assertTrue(json.getBoolean("keyfileOrdered"))
 
-        // Verify JSON structure
-        assertEquals(operationID, expectedJson.getString("operationID"))
-        assertEquals(inputFile, expectedJson.getString("inputFile"))
-        assertEquals(outputFile, expectedJson.getString("outputFile"))
-        assertFalse("password must never appear in the JSON", expectedJson.has("password"))
-        assertEquals(options.comments, expectedJson.getString("comments"))
-        assertEquals(options.paranoid, expectedJson.getBoolean("paranoid"))
-        assertEquals(options.reedSolomon, expectedJson.getBoolean("reedSolomon"))
-        assertEquals(options.deniability, expectedJson.getBoolean("deniability"))
-        assertEquals(options.compress, expectedJson.getBoolean("compress"))
-        assertEquals(options.keyfileOrdered, expectedJson.getBoolean("keyfileOrdered"))
-        
-        val keyfilesArray = expectedJson.getJSONArray("keyfiles")
-        assertEquals(2, keyfilesArray.length())
-        assertEquals("keyfile1", keyfilesArray.getString(0))
-        assertEquals("keyfile2", keyfilesArray.getString(1))
+        val keyfiles = json.getJSONArray("keyfiles")
+        assertEquals(2, keyfiles.length())
+        assertEquals("keyfile1", keyfiles.getString(0))
+        assertEquals("keyfile2", keyfiles.getString(1))
+
+        // SECURITY: the password is handed to Mobile as raw bytes, never serialized.
+        assertFalse("password must never appear in the JSON", json.has("password"))
     }
-    
+
     @Test
-    fun `startDecrypt JSON structure is correct`() {
-        val operationID = "test_op_123"
-        val inputFile = "/path/to/input.pcv"
-        val outputFile = "/path/to/output.txt"
-        val options = DecryptOptions(
-            keyfiles = listOf("keyfile1"),
-            forceDecrypt = true,
-            verifyFirst = false,
-            autoUnzip = true,
-            sameLevel = false,
-            recombine = false,
-            deniability = false
+    fun `buildDecryptRequestJson serializes every option and never the password`() {
+        val json = JSONObject(
+            GoBridge.buildDecryptRequestJson(
+                operationID = "test_op_123",
+                inputFile = "/path/to/input.pcv",
+                outputFile = "/path/to/output.txt",
+                options = DecryptOptions(
+                    keyfiles = listOf("keyfile1"),
+                    forceDecrypt = true,
+                    verifyFirst = true,
+                    autoUnzip = false,
+                    sameLevel = true,
+                    recombine = false,
+                    deniability = true
+                )
+            )
         )
 
-        // Build the expected JSON structure (password is passed as bytes, never in JSON)
-        val expectedJson = JSONObject().apply {
-            put("operationID", operationID)
-            put("inputFile", inputFile)
-            put("outputFile", outputFile)
-            put("keyfiles", JSONArray().apply {
-                options.keyfiles.forEach { put(it) }
-            })
-            put("forceDecrypt", options.forceDecrypt)
-            put("verifyFirst", options.verifyFirst)
-            put("autoUnzip", options.autoUnzip)
-            put("sameLevel", options.sameLevel)
-            put("recombine", options.recombine)
-            put("deniability", options.deniability)
-        }
+        assertEquals("test_op_123", json.getString("operationID"))
+        assertEquals("/path/to/input.pcv", json.getString("inputFile"))
+        assertEquals("/path/to/output.txt", json.getString("outputFile"))
+        assertTrue(json.getBoolean("forceDecrypt"))
+        assertTrue(json.getBoolean("verifyFirst"))
+        assertFalse(json.getBoolean("autoUnzip"))
+        assertTrue(json.getBoolean("sameLevel"))
+        assertFalse(json.getBoolean("recombine"))
+        assertTrue(json.getBoolean("deniability"))
 
-        // Verify JSON structure
-        assertEquals(operationID, expectedJson.getString("operationID"))
-        assertEquals(inputFile, expectedJson.getString("inputFile"))
-        assertEquals(outputFile, expectedJson.getString("outputFile"))
-        assertFalse("password must never appear in the JSON", expectedJson.has("password"))
-        assertEquals(options.forceDecrypt, expectedJson.getBoolean("forceDecrypt"))
-        assertEquals(options.verifyFirst, expectedJson.getBoolean("verifyFirst"))
-        assertEquals(options.autoUnzip, expectedJson.getBoolean("autoUnzip"))
-        assertEquals(options.sameLevel, expectedJson.getBoolean("sameLevel"))
-        assertEquals(options.recombine, expectedJson.getBoolean("recombine"))
-        assertEquals(options.deniability, expectedJson.getBoolean("deniability"))
+        val keyfiles = json.getJSONArray("keyfiles")
+        assertEquals(1, keyfiles.length())
+        assertEquals("keyfile1", keyfiles.getString(0))
+
+        assertFalse("password must never appear in the JSON", json.has("password"))
     }
-    
-    @Test
-    fun `startEncrypt converts empty error message to success`() {
-        // When Mobile.startEncrypt returns empty string, it should be success
-        // This is tested by the actual implementation logic
-        // We verify the error handling path works correctly
-        val password = "test".toByteArray(Charsets.UTF_8)
-        val options = EncryptOptions()
 
-        try {
-            // This will fail if Mobile throws, but we're testing the error conversion logic
-            val result = GoBridge.startEncrypt(
-                "op_123",
-                "/input",
-                "/output",
-                password,
-                options
-            )
-            
-            // Result should not throw, and if it fails, should be a proper AppError
-            result.onFailure { error ->
-                assertTrue("Error should be AppError", error is AppError)
+    // --- Response parsing: asserts the REAL production parser -------------------------
+
+    @Test
+    fun `parseDecryptionInfo maps every header field`() {
+        val info = GoBridge.parseDecryptionInfo(
+            """
+            {
+                "keyfilesRequired": true,
+                "keyfileOrdered": true,
+                "reedSolomon": true,
+                "deniability": false,
+                "paranoid": true,
+                "comments": "Test comments",
+                "readable": true
             }
-        } catch (e: UnsatisfiedLinkError) {
-            // Go mobile bindings not available - this is expected in unit tests
-        } catch (e: NoClassDefFoundError) {
-            // Go mobile bindings not available - this is expected in unit tests
-        }
+            """.trimIndent()
+        )
+
+        assertTrue(info.keyfilesRequired)
+        assertTrue(info.keyfileOrdered)
+        assertTrue(info.reedSolomon)
+        assertFalse(info.deniability)
+        assertTrue(info.paranoid)
+        assertEquals("Test comments", info.comments)
+        assertTrue(info.readable)
     }
-    
+
     @Test
-    fun `startDecrypt converts empty error message to success`() {
-        val password = "test".toByteArray(Charsets.UTF_8)
-        val options = DecryptOptions()
-
-        try {
-            val result = GoBridge.startDecrypt(
-                "op_123",
-                "/input.pcv",
-                "/output",
-                password,
-                options
-            )
-
-            result.onFailure { error ->
-                assertTrue("Error should be AppError", error is AppError)
+    fun `parseDecryptionInfo throws on a missing required field`() {
+        // SECURITY: a malformed header response must fail loud, not silently default
+        // (e.g. defaulting keyfilesRequired=false would let the UI skip the keyfile
+        // prompt). The production parser uses getBoolean, which throws on a missing key.
+        val missingKeyfilesRequired = """
+            {
+                "keyfileOrdered": false,
+                "reedSolomon": false,
+                "deniability": false,
+                "paranoid": false,
+                "comments": "",
+                "readable": true
             }
-        } catch (e: UnsatisfiedLinkError) {
-            // Go mobile bindings not available - this is expected in unit tests
-        } catch (e: NoClassDefFoundError) {
-            // Go mobile bindings not available - this is expected in unit tests
+        """.trimIndent()
+
+        assertThrows(JSONException::class.java) {
+            GoBridge.parseDecryptionInfo(missingKeyfilesRequired)
         }
     }
 
+    // --- Password zeroing: security contract that holds even when the call fails ------
+    // GoBridge.start{Encrypt,Decrypt} zero the caller's password in a finally block. On
+    // the JVM the native Mobile call throws, but finally still runs, so these verify the
+    // wipe WITHOUT the AAR (and on-device, where Mobile returns, the finally still runs).
+
     @Test
-    fun `startEncrypt zeroes the password ByteArray`() {
-        if (!isGoMobileAvailable()) return
-        val id = GoBridge.startOperation().getOrElse { return }
+    fun `startEncrypt zeroes the password even when the bridge call fails`() {
         val password = "hunter2".toByteArray(Charsets.UTF_8)
-        GoBridge.startEncrypt(id, "/no/such/input", "/tmp/out.pcv", password, EncryptOptions())
+        try {
+            GoBridge.startEncrypt("op_missing", "/no/such/in", "/tmp/out.pcv", password, EncryptOptions())
+        } catch (t: Throwable) {
+            // Native bridge unavailable on the JVM; the finally block has already run.
+        }
         assertTrue("password bytes must be zeroed", password.all { it == 0.toByte() })
     }
-    
+
     @Test
-    fun `getDecryptionInfo parses JSON correctly`() {
-        // Test JSON parsing logic
-        // This test doesn't require Go mobile bindings - it just tests JSON parsing
-        
-        // Skip if Go mobile bindings cause class loading issues
-        if (!isGoMobileAvailable()) {
-            return
+    fun `startDecrypt zeroes the password even when the bridge call fails`() {
+        val password = "hunter2".toByteArray(Charsets.UTF_8)
+        try {
+            GoBridge.startDecrypt("op_missing", "/no/such/in.pcv", "/tmp/out", password, DecryptOptions())
+        } catch (t: Throwable) {
+            // Native bridge unavailable on the JVM; the finally block has already run.
         }
-        
-        val jsonString = """
-        {
-            "keyfilesRequired": true,
-            "keyfileOrdered": true,
-            "reedSolomon": true,
-            "deniability": false,
-            "paranoid": true,
-            "comments": "Test comments",
-            "readable": true
-        }
-        """.trimIndent()
-        
-        val json = JSONObject(jsonString)
-        val decryptionInfo = DecryptionInfo(
-            keyfilesRequired = json.getBoolean("keyfilesRequired"),
-            keyfileOrdered = json.getBoolean("keyfileOrdered"),
-            reedSolomon = json.getBoolean("reedSolomon"),
-            deniability = json.getBoolean("deniability"),
-            paranoid = json.getBoolean("paranoid"),
-            comments = json.getString("comments"),
-            readable = json.getBoolean("readable")
-        )
-        
-        assertEquals(true, decryptionInfo.keyfilesRequired)
-        assertEquals(true, decryptionInfo.keyfileOrdered)
-        assertEquals(true, decryptionInfo.reedSolomon)
-        assertEquals(false, decryptionInfo.deniability)
-        assertEquals(true, decryptionInfo.paranoid)
-        assertEquals("Test comments", decryptionInfo.comments)
-        assertEquals(true, decryptionInfo.readable)
+        assertTrue("password bytes must be zeroed", password.all { it == 0.toByte() })
     }
-    
-    @Test
-    fun `getDecryptionInfo handles missing fields with defaults`() {
-        // Test that missing fields are handled (though the actual implementation
-        // would throw JSONException, we verify the structure)
-        val minimalJson = """
-        {
-            "keyfilesRequired": false,
-            "keyfileOrdered": false,
-            "reedSolomon": false,
-            "deniability": false,
-            "paranoid": false,
-            "comments": "",
-            "readable": true
-        }
-        """.trimIndent()
-        
-        val json = JSONObject(minimalJson)
-        val decryptionInfo = DecryptionInfo(
-            keyfilesRequired = json.getBoolean("keyfilesRequired"),
-            keyfileOrdered = json.getBoolean("keyfileOrdered"),
-            reedSolomon = json.getBoolean("reedSolomon"),
-            deniability = json.getBoolean("deniability"),
-            paranoid = json.getBoolean("paranoid"),
-            comments = json.getString("comments"),
-            readable = json.getBoolean("readable")
-        )
-        
-        assertNotNull(decryptionInfo)
-    }
-    
+
+    // --- Option/struct defaults: guard against accidental default changes -------------
+
     @Test
     fun `EncryptOptions has correct defaults`() {
         val options = EncryptOptions()
         assertEquals("", options.comments)
-        assertEquals(false, options.paranoid)
-        assertEquals(false, options.reedSolomon)
-        assertEquals(false, options.deniability)
-        assertEquals(false, options.compress)
+        assertFalse(options.paranoid)
+        assertFalse(options.reedSolomon)
+        assertFalse(options.deniability)
+        assertFalse(options.compress)
         assertEquals(emptyList<String>(), options.keyfiles)
-        assertEquals(false, options.keyfileOrdered)
+        assertFalse(options.keyfileOrdered)
     }
-    
+
     @Test
     fun `DecryptOptions has correct defaults`() {
+        // autoUnzip MUST default false: Go auto-unzip orphans Android's single-file
+        // export (see OperationManager). A regression here re-introduces SaveFailed.
         val options = DecryptOptions()
         assertEquals(emptyList<String>(), options.keyfiles)
-        assertEquals(false, options.forceDecrypt)
-        assertEquals(false, options.verifyFirst)
-        assertEquals(false, options.autoUnzip)
-        assertEquals(false, options.sameLevel)
-        assertEquals(false, options.recombine)
-        assertEquals(false, options.deniability)
+        assertFalse(options.forceDecrypt)
+        assertFalse(options.verifyFirst)
+        assertFalse(options.autoUnzip)
+        assertFalse(options.sameLevel)
+        assertFalse(options.recombine)
+        assertFalse(options.deniability)
     }
-    
+
     @Test
-    fun `ProgressState structure is correct`() {
+    fun `ProgressState has correct defaults`() {
         val progressState = ProgressState(
             status = "Processing",
             progress = 0.5f,
             info = "Encrypting file...",
             done = false
         )
-        
         assertEquals("Processing", progressState.status)
         assertEquals(0.5f, progressState.progress, 0.001f)
         assertEquals("Encrypting file...", progressState.info)
-        assertEquals(false, progressState.done)
+        assertFalse(progressState.done)
+        assertEquals("code defaults to empty until an error is classified", "", progressState.code)
+    }
+
+    // --- Bridge-only contracts: skip loudly on the JVM (covered on-device) ------------
+
+    @Test
+    fun `startOperation returns a non-empty operation ID`() {
+        assumeTrue("requires the gomobile AAR (mobile.Mobile)", isGoMobileAvailable())
+        val result = GoBridge.startOperation()
+        assertTrue("startOperation should succeed with the AAR present", result.isSuccess)
+        result.onSuccess { assertTrue("operation ID must not be empty", it.isNotEmpty()) }
+    }
+
+    @Test
+    fun `detectOperation wraps a binding failure as an AppError`() {
+        assumeTrue("requires the gomobile AAR (mobile.Mobile)", isGoMobileAvailable())
+        // Empty path -> Go reports an error -> bridge must wrap it as a typed AppError.
+        val result = GoBridge.detectOperation("")
+        result.onFailure {
+            assertTrue("must be a GenericOperation AppError", it is AppError.OperationError.GenericOperation)
+        }
     }
 }
-

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerTest.kt
@@ -671,5 +671,58 @@ class OperationManagerTest {
             tmpDir.deleteRecursively()
         }
     }
+
+    @Test
+    fun `startEncrypt fails loud on a split-volume chunk`() = runTest {
+        // A .pcv.N chunk does NOT end in .pcv, so FormData.isEncrypt is true -- the work
+        // button would DOUBLE-ENCRYPT it. Android cannot recombine (single-file picker),
+        // so the operation must fail loud BEFORE reaching the Go bridge.
+        mockkObject(GoBridge)
+        try {
+            val formData = TestDataBuilders.createEncryptFormData(
+                selectedFilename = "secret.pcv.0",
+                copiedFilePath = "/data/test/input_file"
+            )
+            val result = OperationManager.startEncrypt(mockContext, formData)
+
+            assertTrue("Split chunk must fail", result.isFailure)
+            result.onFailure {
+                assertTrue(
+                    "Error should be SplitVolumeNotSupported",
+                    it is AppError.ValidationError.SplitVolumeNotSupported
+                )
+            }
+            // Must short-circuit before any Go work.
+            verify(exactly = 0) { GoBridge.startOperation() }
+        } finally {
+            unmockkObject(GoBridge)
+        }
+    }
+
+    @Test
+    fun `startDecrypt fails loud on a split-volume chunk`() = runTest {
+        // A desktop split volume selected on Android (secret.pcv.0) cannot be decrypted
+        // without recombining its sibling chunks, which Android has no way to supply.
+        // Fail loud instead of running the Go op on one chunk (confusing corrupt error).
+        mockkObject(GoBridge)
+        try {
+            val formData = TestDataBuilders.createDecryptFormData(
+                selectedFilename = "secret.pcv.0",
+                copiedFilePath = "/data/test/input_file"
+            )
+            val result = OperationManager.startDecrypt(mockContext, formData)
+
+            assertTrue("Split chunk must fail", result.isFailure)
+            result.onFailure {
+                assertTrue(
+                    "Error should be SplitVolumeNotSupported",
+                    it is AppError.ValidationError.SplitVolumeNotSupported
+                )
+            }
+            verify(exactly = 0) { GoBridge.startOperation() }
+        } finally {
+            unmockkObject(GoBridge)
+        }
+    }
 }
 

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerTest.kt
@@ -595,5 +595,81 @@ class OperationManagerTest {
             tmpDir.deleteRecursively()
         }
     }
+
+    @Test
+    fun `startDecrypt does not auto-unzip so zip volumes stay exportable`() = runTest {
+        // INTEROP (core value): a desktop volume made from multiple files / compression
+        // decrypts to a .zip. Go's auto-unzip extracts to a SUBDIRECTORY and DELETES the
+        // zip (decrypt.go:816,847); Android then exports a single fixed output path, so
+        // the export reads a now-missing/directory path -> SaveFailed. Until a SAF
+        // tree-export exists, Android must NOT auto-unzip: the intact .zip stays the one
+        // exportable output (matches the CLI --auto-unzip default of false, decrypt.go:94).
+        // Capture the DecryptOptions handed to the Go bridge and prove autoUnzip is off.
+        val tmpDir = createTempDirectory(prefix = "opmgr_autounzip").toFile()
+        every { mockContext.filesDir } returns tmpDir
+
+        mockkObject(GoBridge)
+        try {
+            every { GoBridge.startOperation() } returns Result.success("op_unzip")
+            val optionsSlot = slot<DecryptOptions>()
+            every {
+                GoBridge.startDecrypt(any(), any(), any(), any(), capture(optionsSlot))
+            } returns Result.success(Unit)
+
+            val result = OperationManager.startDecrypt(
+                mockContext,
+                TestDataBuilders.createDecryptFormData()
+            )
+
+            assertTrue("startDecrypt should succeed", result.isSuccess)
+            assertTrue("DecryptOptions must be captured", optionsSlot.isCaptured)
+            assertFalse(
+                "auto-unzip must be OFF on Android (no SAF tree-export; the zip volume must stay exportable)",
+                optionsSlot.captured.autoUnzip
+            )
+        } finally {
+            unmockkObject(GoBridge)
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `retryDecryptWithForce does not auto-unzip`() = runTest {
+        // Same interop invariant as startDecrypt, on the force-decrypt retry path
+        // (retryDecryptWithForce builds its own DecryptOptions). The slot captures the
+        // last GoBridge.startDecrypt call -- the retry -- which must set forceDecrypt
+        // (proving it is the retry) and keep autoUnzip off.
+        val tmpDir = createTempDirectory(prefix = "opmgr_autounzip_force").toFile()
+        every { mockContext.filesDir } returns tmpDir
+
+        mockkObject(GoBridge)
+        try {
+            every { GoBridge.startOperation() } returns Result.success("op_unzip_force")
+            val optionsSlot = slot<DecryptOptions>()
+            every {
+                GoBridge.startDecrypt(any(), any(), any(), any(), capture(optionsSlot))
+            } returns Result.success(Unit)
+
+            assertTrue(
+                "startDecrypt setup should succeed",
+                OperationManager.startDecrypt(
+                    mockContext,
+                    TestDataBuilders.createDecryptFormData()
+                ).isSuccess
+            )
+            val retry = OperationManager.retryDecryptWithForce()
+
+            assertTrue("retryDecryptWithForce should succeed", retry.isSuccess)
+            assertTrue("DecryptOptions must be captured", optionsSlot.isCaptured)
+            assertTrue("retry path must set forceDecrypt", optionsSlot.captured.forceDecrypt)
+            assertFalse(
+                "auto-unzip must be OFF on the force-retry path too",
+                optionsSlot.captured.autoUnzip
+            )
+        } finally {
+            unmockkObject(GoBridge)
+            tmpDir.deleteRecursively()
+        }
+    }
 }
 

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerTest.kt
@@ -481,10 +481,44 @@ class OperationManagerTest {
 
     @Test
     fun `retryDecryptWithForce returns error when operation is not decrypt`() = runTest {
-        // We can't easily set up an encrypt operation, but we can test the logic
-        // that checks operation type
-        // This would require setting up an operation state, which is difficult without GoBridge
-        // So we'll test this in instrumented tests
+        // The guard at OperationManager.retryDecryptWithForce rejects a non-DECRYPT
+        // operation (operation.type != DECRYPT -> GenericOperation("Can only retry
+        // decryption operations")). It short-circuits BEFORE any decrypt-side GoBridge
+        // call, so the Go AAR is not needed — establish an ENCRYPT op through the public
+        // seam (GoBridge mocked) and assert the rejection. startEncrypt resolves an
+        // output path under context.filesDir; back it with a real temp dir.
+        val tmpDir = createTempDirectory(prefix = "opmgr_notdecrypt").toFile()
+        every { mockContext.filesDir } returns tmpDir
+
+        mockkObject(GoBridge)
+        try {
+            every { GoBridge.startOperation() } returns Result.success("op_enc")
+            every { GoBridge.startEncrypt(any(), any(), any(), any(), any()) } returns Result.success(Unit)
+
+            val started = OperationManager.startEncrypt(
+                mockContext,
+                TestDataBuilders.createEncryptFormData()
+            )
+            assertTrue("startEncrypt should succeed", started.isSuccess)
+            assertEquals(OperationType.ENCRYPT, OperationManager.currentOperation.value?.type)
+
+            val result = OperationManager.retryDecryptWithForce()
+
+            assertTrue("Force-decrypt retry on an encrypt op must fail", result.isFailure)
+            result.onFailure { error ->
+                assertTrue(
+                    "Error should be GenericOperation",
+                    error is AppError.OperationError.GenericOperation
+                )
+                assertTrue(
+                    "Message should explain only decryption can be retried",
+                    (error.message ?: "").contains("Can only retry decryption", ignoreCase = true)
+                )
+            }
+        } finally {
+            unmockkObject(GoBridge)
+            tmpDir.deleteRecursively()
+        }
     }
     
     @Test

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerTest.kt
@@ -13,6 +13,7 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
+import io.mockk.slot
 import kotlin.io.path.createTempDirectory
 
 /**
@@ -524,6 +525,41 @@ class OperationManagerTest {
     fun `OperationType enum values are correct`() {
         assertEquals("ENCRYPT", OperationType.ENCRYPT.name)
         assertEquals("DECRYPT", OperationType.DECRYPT.name)
+    }
+
+    @Test
+    fun `startDecrypt passes verifyFirst from formData into DecryptOptions`() = runTest {
+        // verifyFirst is a security option (integrity-verify-before-write). It is wired
+        // through the Go bridge (GoBridge.DecryptOptions.verifyFirst -> android.go) but
+        // OperationManager historically hardcoded it false. Capture the DecryptOptions
+        // handed to GoBridge.startDecrypt and prove the form value flows through.
+        // GoBridge is the Go mobile AAR (absent on the JVM classpath), so mock it;
+        // startDecrypt resolves an output path under context.filesDir, so back it with
+        // a real temp dir (the relaxed mock returns null otherwise).
+        val tmpDir = createTempDirectory(prefix = "opmgr_verifyfirst").toFile()
+        every { mockContext.filesDir } returns tmpDir
+
+        mockkObject(GoBridge)
+        try {
+            every { GoBridge.startOperation() } returns Result.success("op_vf")
+            val optionsSlot = slot<DecryptOptions>()
+            every {
+                GoBridge.startDecrypt(any(), any(), any(), any(), capture(optionsSlot))
+            } returns Result.success(Unit)
+
+            val formData = TestDataBuilders.createDecryptFormData().copy(verifyFirst = true)
+            val result = OperationManager.startDecrypt(mockContext, formData)
+
+            assertTrue("startDecrypt should succeed", result.isSuccess)
+            assertTrue("DecryptOptions must be captured", optionsSlot.isCaptured)
+            assertTrue(
+                "verifyFirst must flow from formData into the Go bridge call",
+                optionsSlot.captured.verifyFirst
+            )
+        } finally {
+            unmockkObject(GoBridge)
+            tmpDir.deleteRecursively()
+        }
     }
 }
 

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationViewModelTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationViewModelTest.kt
@@ -18,6 +18,10 @@ import org.junit.Test
 import io.github.picocrypt_ng.picocrypt_ng.testutils.MainDispatcherRule
 import io.github.picocrypt_ng.picocrypt_ng.testutils.TestDataBuilders
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.every
+import io.mockk.verify
 
 /**
  * Unit tests for OperationViewModel.
@@ -162,6 +166,27 @@ class OperationViewModelTest {
         // but we verify the StateFlow is connected
         val managerState = OperationManager.currentOperation.first()
         assertEquals(managerState, operationState)
+    }
+
+    @Test
+    fun `startForegroundServiceSafely swallows a background-start IllegalStateException`() {
+        // On Android 12+ starting a foreground service from the background throws
+        // ForegroundServiceStartNotAllowedException (an IllegalStateException subclass).
+        // Because the service start happens AFTER the suspending op-start, the app may
+        // have backgrounded in that window. The Go operation is already running, so we
+        // must keep going (poll for progress) rather than crash the coroutine.
+        mockkObject(OperationForegroundService.Companion)
+        try {
+            every { OperationForegroundService.start(any()) } throws
+                IllegalStateException("ForegroundServiceStartNotAllowedException")
+
+            // Must not rethrow.
+            viewModel.startForegroundServiceSafely(mockContext)
+
+            verify { OperationForegroundService.start(any()) }
+        } finally {
+            unmockkObject(OperationForegroundService.Companion)
+        }
     }
 
     private fun resetOperationState() {

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -42,6 +42,7 @@ func TestReleaseActionsPinnedToFullSHA(t *testing.T) {
 		{name: "build-macos", path: ".github/workflows/build-macos.yml", job: "release"},
 		{name: "build-windows", path: ".github/workflows/build-windows.yml", job: "release"},
 		{name: "build-snapcraft", path: ".github/workflows/build-snapcraft.yml", job: "release"},
+		{name: "build-appimage", path: ".github/workflows/build-appimage.yml", job: "release"},
 	}
 
 	for _, tc := range testCases {
@@ -79,6 +80,42 @@ func TestBuildPermissionsStayLeastPrivilege(t *testing.T) {
 	mustPermission(t, buildSnapcraft.Permissions, "contents", "read")
 	mustEffectivePermission(t, buildSnapcraft, mustJob(t, buildSnapcraft, "build-snapcraft"), "contents", "read")
 	mustEffectivePermission(t, buildSnapcraft, mustJob(t, buildSnapcraft, "release"), "contents", "write")
+
+	buildAppImage := mustReadWorkflowDoc(t, ".github/workflows/build-appimage.yml")
+	mustPermission(t, buildAppImage.Permissions, "contents", "read")
+	mustEffectivePermission(t, buildAppImage, mustJob(t, buildAppImage, "build"), "contents", "read")
+	mustEffectivePermission(t, buildAppImage, mustJob(t, buildAppImage, "release"), "contents", "write")
+}
+
+func TestAppImageWorkflowIsPortableSmokeTestedAndPinned(t *testing.T) {
+	const path = ".github/workflows/build-appimage.yml"
+	workflow := mustReadWorkflowDoc(t, path)
+	content := mustReadWorkflow(t, path)
+
+	build := mustJob(t, workflow, "build")
+
+	// Portability floor. AppImage was dropped once "for better portability"
+	// (Changelog v1.34); building on the newest runner's glibc reproduces that, so the
+	// build job pins the oldest supported runner (ubuntu-22.04, glibc 2.35).
+	mustContain(t, content, "runs-on: ubuntu-22.04")
+
+	// Supply chain: the AppImage tooling is fetched at build time, so it must be
+	// sha256-pinned AND verified (fail loud), like UPX in build-linux. Asserts that a
+	// pin exists and is checked -- not the exact digest -- so a tool bump does not churn
+	// this test.
+	mustContain(t, content, "linuxdeploy")
+	mustContain(t, content, "appimagetool")
+	mustMatch(t, content, `[0-9a-f]{64}`)
+	mustContain(t, content, "sha256sum")
+	mustContain(t, content, "--check")
+
+	// The produced AppImage must be smoke-tested, or a broken bundle (a shared library
+	// that fails to resolve) ships silently. --version drives the embedded CLI
+	// (cli.Execute), which exits before Fyne/OpenGL init, so it proves every bundled and
+	// host-provided library resolves at process start without needing a display.
+	smoke := mustStepNamed(t, build, "Smoke test AppImage")
+	mustContain(t, smoke.Run, "--version")
+	mustContain(t, smoke.Run, ".AppImage")
 }
 
 func TestMacOSReleaseWorkflowInjectsRootVersionIntoBundleMetadata(t *testing.T) {

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -200,6 +200,15 @@ func TestAndroidPRWorkflowRunsCryptoRoundtripOnDevice(t *testing.T) {
 	mustContain(t, content, "connectedDebugAndroidTest")
 	mustContain(t, content, "-Pandroid.testInstrumentationRunnerArguments.class")
 	mustContain(t, content, "OperationManagerIntegrationTest")
+
+	// The emulator must run API 36 (matching targetSdk), not 34: API 35+ behavior --
+	// the foreground-service dataSync timeout and Service.onTimeout(API 35+) -- is only
+	// reachable there, so gating on API 34 is a false green for that path.
+	prJob := mustJob(t, mustReadWorkflowDoc(t, ".github/workflows/pr-test-build-android.yml"), "pr-test-build-android")
+	prEmulator := mustHaveStepUsingPrefix(t, prJob, "ReactiveCircus/android-emulator-runner@")
+	if got := prEmulator.With["api-level"]; got != 36 {
+		t.Fatalf("PR emulator api-level = %v, want 36 (>= targetSdk for FGS/onTimeout coverage)", got)
+	}
 }
 
 func TestAndroidReleaseWorkflowKeepsSigningSecretsOutOfBuildJob(t *testing.T) {
@@ -235,6 +244,13 @@ func TestAndroidInstrumentedWorkflowIsManualAndPinned(t *testing.T) {
 	mustNotContain(t, content, "connectedDebugAndroidTest \\")
 	mustContain(t, content, "TEST_CLASSES=")
 	mustContain(t, content, "./gradlew connectedDebugAndroidTest")
+
+	// Same API-36 requirement as the PR gate (FGS/onTimeout reachability).
+	instrJob := mustJob(t, mustReadWorkflowDoc(t, ".github/workflows/android-instrumented.yml"), "android-instrumented")
+	instrEmulator := mustHaveStepUsingPrefix(t, instrJob, "ReactiveCircus/android-emulator-runner@")
+	if got := instrEmulator.With["api-level"]; got != 36 {
+		t.Fatalf("instrumented emulator api-level = %v, want 36", got)
+	}
 }
 
 func TestWindowsLegacyPRWorkflowIsCLIOnly(t *testing.T) {

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -188,14 +188,18 @@ func TestSnapcraftWorkflowSmokeTestsInstalledSnap(t *testing.T) {
 	mustContain(t, smokeStep.Run, "snap run picocrypt-ng --version")
 }
 
-func TestAndroidPRWorkflowStaysFastAndCompileFocused(t *testing.T) {
+func TestAndroidPRWorkflowRunsCryptoRoundtripOnDevice(t *testing.T) {
 	content := mustReadWorkflow(t, ".github/workflows/pr-test-build-android.yml")
 	mustContain(t, content, "Run Unit Tests")
 	mustContain(t, content, "./gradlew test")
 	mustContain(t, content, ":app:compileDebugAndroidTestKotlin")
 	mustContain(t, content, ":app:assembleDebugAndroidTest")
-	mustNotContain(t, content, "ReactiveCircus/android-emulator-runner@")
-	mustNotContain(t, content, "connectedDebugAndroidTest")
+	// The PR gate now runs the real on-device Go encrypt/decrypt roundtrip so a crypto
+	// regression on Android cannot merge green. Keep the emulator action SHA-pinned.
+	mustMatch(t, content, `ReactiveCircus/android-emulator-runner@[0-9a-f]{40}`)
+	mustContain(t, content, "connectedDebugAndroidTest")
+	mustContain(t, content, "-Pandroid.testInstrumentationRunnerArguments.class")
+	mustContain(t, content, "OperationManagerIntegrationTest")
 }
 
 func TestAndroidReleaseWorkflowKeepsSigningSecretsOutOfBuildJob(t *testing.T) {


### PR DESCRIPTION
Finishes the Android cleanup branched off `main` and adds Linux AppImage packaging. No changes to the Go crypto core, the `.pcv` format, the gomobile bridge JSON, or `go.mod` — the golden-vector and roundtrip invariants are untouched.

### Android interop fixes (the important ones)
- **Zip-based volumes now decrypt and export.** A `.pcv` made on the desktop from several files or with compression unzips to a directory in Go, which deleted the file the Android export step reads — so the export failed with `SaveFailed`. Auto-unzip is now off on Android (the intact `.zip` is saved; extract it with a file manager), matching the CLI `--auto-unzip` default. Re-enabling it needs a SAF tree-export, deferred.
- **Split volumes fail honestly.** A chunk like `secret.pcv.0` can't be recombined on Android (single-file picker, no sibling access) and doesn't end in `.pcv`, so it was landing on the encrypt path and getting double-encrypted. It's now detected (same rule as Go's `IsSplitChunkPath`) and rejected with a message to recombine on a computer first.

### Android features / robustness (earlier on this branch)
- Verify-first decrypt option (integrity check before any output is written), independent of force-decrypt.
- Foreground service no longer crashes when an operation starts while the app is in the background.

### Linux: AppImage packaging (issue #141)
Re-adds an AppImage build, addressing the exact reason it was dropped in v1.34 ("for better portability"):
- Built on `ubuntu-22.04` (glibc 2.35 floor); GL/GPU-driver libraries are intentionally **not** bundled (linuxdeploy excludelist) and come from the host, so it runs across distros incl. Nvidia.
- Portable and **unsandboxed** — the niche the existing channels don't cover (Snap/Flatpak sandbox fights a "touch any file" tool; the raw binary needs system GTK/GL).
- linuxdeploy + appimagetool are sha256-pinned and verified (fail loud), like UPX.
- Headless `--version` smoke test proves every bundled/host library resolves at startup. Verified locally end-to-end (~13 MB; libGL/EGL/drm correctly not bundled).
- `workflowpolicy` locks the portability floor, the pin+verify, and the smoke step.

### Tests / CI
- GoBridge tests now check real behavior (extracted `build{Encrypt,Decrypt}RequestJson` / `parseDecryptionInfo`; fail if a field is dropped/renamed). Password zeroing is verified even when the native call fails. AAR-only tests skip loudly instead of swallowing `UnsatisfiedLinkError`; three always-skip duplicates removed.
- Instrumented emulator moved from API 34 to API 36 (matching `targetSdk`) so API 35+ behavior (FGS dataSync timeout, `onTimeout`) is reachable; a `workflowpolicy` test pins it. PR gate stays narrow.

### Deferred (not in this PR)
Full auto-unzip with SAF tree-export, split recombine, multi-file/folder input, compress, same-level — these need Android's multi-file SAF surface and are a separate cycle. AppImage arm64 is also a later add (amd64 first).

### Verification
- `go test ./...`, `go vet ./...`, `govulncheck ./...` clean; `workflowpolicy` green.
- `./gradlew :app:testDebugUnitTest :app:assembleDebug :app:compileDebugAndroidTestKotlin` green (JDK 17): 118 unit tests, 0 failures, 2 skipped (AAR-only).
- AppImage workflow: `actionlint` clean + full local build & smoke test pass. Note: GitHub only triggers `workflow_dispatch` from the default branch, so the AppImage job first runs in CI after merge (or on the next `VERSION` bump).
