### PR TITLE
feat(appimage): sign release + AppImageUpdate delta updates (zsync)

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -55,6 +55,20 @@ jobs:
         # linuxdeploy invokes appimagetool from PATH during --output appimage.
         sudo mv appimagetool /usr/local/bin/appimagetool
 
+    - name: Import GPG signing key
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.APPIMAGE_GPG_PRIVATE_KEY }}
+      run: |
+        # Dedicated release-signing key, provisioned as a repo secret (ASCII-armored
+        # private key). Fail loud rather than silently shipping an unsigned release.
+        test -n "$GPG_PRIVATE_KEY" || { echo "::error::APPIMAGE_GPG_PRIVATE_KEY secret is empty"; exit 1; }
+        printf '%s\n' "$GPG_PRIVATE_KEY" | gpg --batch --import
+        # appimagetool reads APPIMAGETOOL_SIGN_PASSPHRASE and feeds gpg via loopback;
+        # gpg-agent must be told to accept it without an interactive pinentry prompt.
+        mkdir -p "$HOME/.gnupg" && chmod 700 "$HOME/.gnupg"
+        echo "allow-loopback-pinentry" >> "$HOME/.gnupg/gpg-agent.conf"
+        gpgconf --kill gpg-agent
+
     - name: Build AppImage
       env:
         # GitHub runners lack FUSE; run the tools (and later the result) extracted.
@@ -63,6 +77,8 @@ jobs:
         # little from stripping; skipping it removes a fragile step (linuxdeploy's strip
         # aborts on libraries using newer ELF sections, e.g. .relr.dyn) for ~2-3 MB.
         NO_STRIP: "true"
+        # Passphrase for the release-signing key; consumed by appimagetool's --sign.
+        APPIMAGETOOL_SIGN_PASSPHRASE: ${{ secrets.APPIMAGE_GPG_PASSPHRASE }}
       run: |
         VERSION=$(cat VERSION)
         mkdir -p stage AppDir/usr/share/metainfo
@@ -81,13 +97,41 @@ jobs:
         # Deterministic output filename (independent of the binary's internal version).
         export OUTPUT="Picocrypt-NG-${VERSION}-x86_64.AppImage"
         export VERSION
+
+        # AppImageUpdate delta-update transport: linuxdeploy embeds this string in the
+        # .upd_info ELF section and emits the matching .zsync. The glob (not the literal
+        # version) is what lets an installed build discover every future release; `latest`
+        # resolves to the GitHub release marked "Latest" (non-prerelease). owner/repo come
+        # from the running repo so forks point at themselves, not upstream.
+        UPDATE_INFORMATION="gh-releases-zsync|${GITHUB_REPOSITORY%/*}|${GITHUB_REPOSITORY#*/}|latest|Picocrypt-NG-*-x86_64.AppImage.zsync"
+        # GPG signing: key id is the primary fingerprint from the imported keyring.
+        SIGN_KEY=$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/ {print $10; exit}')
+        test -n "$SIGN_KEY" || { echo "::error::no signing key in keyring"; exit 1; }
+        # Both env-var spellings are exported on purpose: the pinned linuxdeploy build's
+        # bundled appimage plugin uses the legacy names (OUTPUT/VERSION already prove the
+        # legacy contract holds), while the LDAI_-prefixed names cover a newer plugin once
+        # the tooling pin is refreshed. The verification below fails loud if neither path
+        # produced a signed AppImage + .zsync, so a silent no-op cannot ship.
+        export UPDATE_INFORMATION LDAI_UPDATE_INFORMATION="$UPDATE_INFORMATION"
+        export SIGN=1 LDAI_SIGN=1 SIGN_KEY LDAI_SIGN_KEY="$SIGN_KEY"
+
         ./linuxdeploy \
           --appdir AppDir \
           --executable src/Picocrypt-NG \
           --desktop-file stage/io.github.picocrypt_ng.Picocrypt-NG.desktop \
           --icon-file stage/io.github.picocrypt_ng.Picocrypt-NG.png \
           --output appimage
+
+        # Fail loud: the build must have produced the AppImage, its .zsync, and a real
+        # signature from OUR key -- never ship a half-configured release artifact.
         test -f "$OUTPUT"
+        test -f "${OUTPUT}.zsync" || { echo "::error::no .zsync produced -- update information was not honored"; exit 1; }
+        objcopy -O binary --only-section=.sha256_sig "$OUTPUT" sig.bin
+        test -s sig.bin || { echo "::error::.sha256_sig section empty -- AppImage was not signed"; exit 1; }
+        objcopy -O binary --only-section=.sig_key "$OUTPUT" sig_key.asc
+        EMBEDDED_FPR=$(gpg --show-keys --with-colons sig_key.asc | awk -F: '/^fpr:/ {print $10; exit}')
+        test "$EMBEDDED_FPR" = "$SIGN_KEY" || { echo "::error::embedded signer $EMBEDDED_FPR != release key $SIGN_KEY"; exit 1; }
+        rm -f sig.bin sig_key.asc
 
     - name: Smoke test AppImage
       env:
@@ -107,6 +151,7 @@ jobs:
         VERSION=$(cat VERSION)
         mkdir -p out
         mv "Picocrypt-NG-${VERSION}-x86_64.AppImage" out/
+        mv "Picocrypt-NG-${VERSION}-x86_64.AppImage.zsync" out/
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v7
@@ -144,7 +189,11 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae
       with:
-        files: artifacts/${{ env.APPIMAGE_NAME }}
+        # The .zsync must ship alongside the AppImage: AppImageUpdate fetches it from the
+        # same release to compute deltas. Without it the embedded update info is a dead end.
+        files: |
+          artifacts/${{ env.APPIMAGE_NAME }}
+          artifacts/${{ env.APPIMAGE_NAME }}.zsync
         tag_name: ${{ env.VERSION }}
         append_body: true
         body: |

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -1,0 +1,52 @@
+# Verifying Picocrypt-NG releases
+
+## Linux AppImage
+
+The Linux AppImage is GPG-signed in CI and carries AppImageUpdate delta-update
+information, so an installed build can update itself in place (downloading only the
+changed blocks via a `.zsync` published alongside each release).
+
+### Release signing key
+
+```
+Picocrypt-NG Release Signing
+ed25519 — fingerprint: 40D5 5274 9B0E B548 C79D  79F2 2DD9 3FE7 5B45 D97F
+```
+
+To import it, save the block below to a file and run `gpg --import <file>`:
+
+```
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mDMEai6HJBYJKwYBBAHaRw8BAQdA7A56uqCha9ICfgYAlPw49V/Vr/S6CEUnyUZM
+lFDFKnW0S1BpY29jcnlwdC1ORyBSZWxlYXNlIFNpZ25pbmcgPDExOTA4MjIwOStS
+ZXRlbmdhcnRAdXNlcnMubm9yZXBseS5naXRodWIuY29tPoiQBBMWCgA4FiEEQNVS
+dJsOtUjHnXnyLdk/51tF2X8FAmouhyQCGwMFCwkIBwIGFQoJCAsCBBYCAwECHgEC
+F4AACgkQLdk/51tF2X+PIgEA1sMIfiJRqIlTYbxtPaXIPTJyGpoz6PUKxJpc7sDQ
+vpQBAN2uP29K6q9toerA6Oh2i0TOmDRZWJB1VONAbdKfiWUA
+=2583
+-----END PGP PUBLIC KEY BLOCK-----
+```
+
+### How to verify a download
+
+1. **SHA-256 (always available).** Every release body lists the AppImage's SHA-256.
+   Compare it against your download:
+
+   ```
+   sha256sum Picocrypt-NG-<version>-x86_64.AppImage
+   ```
+
+2. **Embedded GPG signature.** The AppImage embeds a detached signature (ELF section
+   `.sha256_sig`) produced by the key above, together with its public key (`.sig_key`).
+   AppImage-aware tooling (e.g. AppImageUpdate / `appimaged`) uses these to confirm the
+   release was signed by the key whose fingerprint is shown above.
+
+### Self-updating
+
+Installed AppImages embed update information pointing at this repository's GitHub
+releases. To pull the latest signed build (delta download):
+
+```
+appimageupdatetool ./Picocrypt-NG-<version>-x86_64.AppImage
+```


### PR DESCRIPTION
Closes the follow-up on #141: delta updates via AppImageUpdate + GPG-signed AppImage.

## What

- **Update information** embedded in the AppImage (`.upd_info` ELF section) via linuxdeploy's `gh-releases-zsync|<owner>|<repo>|latest|Picocrypt-NG-*-x86_64.AppImage.zsync` transport. owner/repo are derived from `$GITHUB_REPOSITORY` (forks point at themselves).
- **.zsync** generated by linuxdeploy and shipped as a release asset — AppImageUpdate fetches it to compute block-level deltas (no full re-download).
- **GPG signature** in CI: signing key imported from a secret, passed through to appimagetool (`SIGN`/`LDAI_SIGN`).
- **Fail-loud verification** after build: `.zsync` exists, `.sha256_sig` is non-empty, and the embedded signer fingerprint equals our release key — a silent no-op cannot ship.
- `SIGNING.md`: release signing key fingerprint + how to verify.

Both legacy (`UPDATE_INFORMATION`/`SIGN`) and `LDAI_`-prefixed env names are set, because the pinned linuxdeploy build's bundled plugin uses the legacy spelling (already proven by the working `OUTPUT`/`VERSION`), while `LDAI_*` covers a future pin refresh.

## Required before merge — repo secrets (Settings → Secrets and variables → Actions)

- `APPIMAGE_GPG_PRIVATE_KEY` — ASCII-armored private signing key
- `APPIMAGE_GPG_PASSPHRASE` — its passphrase

Signing key: ed25519, fp `40D5 5274 9B0E B548 C79D 79F2 2DD9 3FE7 5B45 D97F`. Without the secrets the build **fails loud** (by design) rather than shipping unsigned.

## Validation

Local YAML + actionlint clean. End-to-end (signing + zsync) is validated by the first CI run — trigger `workflow_dispatch` once secrets are set. The `latest` transport requires the release to be marked GitHub "Latest" (non-prerelease), which our `action-gh-release` config already produces.