### PR TITLE
ci: bump softprops/action-gh-release to v3.0.0 (Node 24)

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -191,7 +191,7 @@ jobs:
         echo "EOF" >> "$GITHUB_ENV"
 
     - name: Release
-      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
       with:
         files: out/*.apk
         tag_name: ${{ env.VERSION }}

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -187,7 +187,7 @@ jobs:
         } >> "$GITHUB_ENV"
 
     - name: Release
-      uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
       with:
         # The .zsync must ship alongside the AppImage: AppImageUpdate fetches it from the
         # same release to compute deltas. Without it the embedded update info is a dead end.

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -259,7 +259,7 @@ jobs:
         echo "CHECKSUM_PICOCRYPT_NG_CLI_ARM64=$(sha256sum artifacts/build-linux-arm64/Picocrypt-NG-cli-arm64 | cut -d ' ' -f1)" >> $GITHUB_ENV
 
     - name: Release
-      uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
       with:
         files: |
           artifacts/build-linux-amd64/Picocrypt-NG

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -141,7 +141,7 @@ jobs:
         echo "CHECKSUM_PICOCRYPT_NG_CLI_MACOS=$HASH_CLI" >> $GITHUB_ENV
 
     - name: Release
-      uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
       with:
         files: |
           artifacts/build-macos/Picocrypt-NG.dmg

--- a/.github/workflows/build-snapcraft.yml
+++ b/.github/workflows/build-snapcraft.yml
@@ -97,7 +97,7 @@ jobs:
         done
 
     - name: Release
-      uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
       with:
         files: out/*.snap
         tag_name: ${{ env.VERSION }}

--- a/.github/workflows/build-windows-legacy.yml
+++ b/.github/workflows/build-windows-legacy.yml
@@ -125,7 +125,7 @@ jobs:
         echo "CHECKSUM_LEGACY_CLI=$($hash.Hash)" >> $env:GITHUB_ENV
 
     - name: Release
-      uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
       with:
         files: artifacts/build-windows-legacy/Picocrypt-NG-cli-Legacy.exe
         tag_name: ${{ env.VERSION }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -203,7 +203,7 @@ jobs:
         echo "CHECKSUM_PICOCRYPT_NG_SETUP=$($hashSetup.Hash)" >> $env:GITHUB_ENV
 
     - name: Release
-      uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
       with:
         files: |
           artifacts/build-windows/Picocrypt-NG-portable.exe


### PR DESCRIPTION
Fixes the deprecation warning seen in recent release runs: `softprops/action-gh-release` was on Node 20, which GitHub forces to Node 24 on **2026-06-16** and removes from runners on **2026-09-16**.

## What
- Pin all 7 release jobs to **v3.0.0** (`b4309332981a82ec1c5618f44dd2e27cc8bfbfda`).
- v3.0.0 is a **runtime-only** major (Node 20 → 24) per upstream notes — no input/behaviour changes. Our usage (`files`, `tag_name`, `append_body`, `body`) is unaffected.
- Side fix: unifies a drifted pin — `build-android` was on **v2.5.0** (`a06a81a`), the others on a 2.x (`b25b93d`). All now on v3.0.0.

## Affected workflows
build-linux, build-macos, build-windows, build-windows-legacy, build-snapcraft, build-appimage, build-android.

## Validation
actionlint clean. No behavioural change; first real exercise is the next release run (release job is gated by `needs: build`, so any issue fails loud before publishing).