### PR TITLE
docs: fix build-from-source command (closes #105)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@
 ```bash
 git clone https://github.com/Picocrypt-NG/Picocrypt-NG.git
 cd Picocrypt-NG/src
-go build -o picocrypt cmd/picocrypt/main.go
+go build -o picocrypt ./cmd/picocrypt
 ```
 
 ## Testing

--- a/src/README.md
+++ b/src/README.md
@@ -26,10 +26,10 @@ git clone https://github.com/Picocrypt-NG/Picocrypt-NG.git
 cd Picocrypt-NG/src
 
 # Linux/macOS
-CGO_ENABLED=1 go build -ldflags="-s -w" -o Picocrypt-NG cmd/picocrypt/main.go
+CGO_ENABLED=1 go build -ldflags="-s -w" -o Picocrypt-NG ./cmd/picocrypt
 
 # Windows
-CGO_ENABLED=1 go build -ldflags="-s -w -H=windowsgui -extldflags=-static" -o Picocrypt-NG.exe cmd/picocrypt/main.go
+CGO_ENABLED=1 go build -ldflags="-s -w -H=windowsgui -extldflags=-static" -o Picocrypt-NG.exe ./cmd/picocrypt
 ```
 
 ## Run


### PR DESCRIPTION
## Problem
The build-from-source docs tell users to compile a single file:
```
go build ... cmd/picocrypt/main.go
```
But `package main` is split across build-tag-gated siblings (`main_gui.go` with `//go:build !cli`, `main_cli.go` with `//go:build cli`), so `main.go` alone cannot see `run()`. The build fails with:
```
cmd/picocrypt/main.go:27:2: undefined: run
```
This is exactly what #105 reports (README routes Intel-Mac users to `src/README.md` to build from source, landing them on the broken command).

## Fix
Build the package directory instead of the single file: `./cmd/picocrypt`. This is already the correct form used in `CLI.md`; this PR makes `src/README.md` and `CONTRIBUTING.md` consistent with it.

## Verification
- Old command → `cmd/picocrypt/main.go:27:2: undefined: run`
- New command → builds a working binary cleanly

Closes #105
