### PR TITLE
feat: normalize passwords to Unicode NFC for cross-platform decryption (closes #19)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# v2.15
+<ul>
+	<li>✓ <strong>Cross-platform passwords (Unicode)</strong>: passwords are normalized to Unicode NFC before key derivation, so a password with accented or non-Latin characters typed on macOS now decrypts on Windows/Linux and vice versa. Existing volumes still open — decryption also tries the as-typed and decomposed forms — and ASCII passwords are unaffected. The desktop and CLI show a short advisory when encrypting with a non-ASCII password.</li>
+</ul>
+
 # v2.14
 <ul>
 	<li>✓ <strong>Compression and deniability progress</strong>: both passes now report speed and ETA, like the main encrypt/decrypt pass</li>

--- a/Internals.md
+++ b/Internals.md
@@ -16,6 +16,18 @@ Picocrypt NG uses the following cryptographic primitives:
 
 All primitives used are from the well-known [golang.org/x/crypto](https://pkg.go.dev/golang.org/x/crypto) module.
 
+# Password Normalization
+A visually identical password can be encoded as different UTF-8 bytes depending on the platform's keyboard/input method (e.g. composed `é` U+00E9 vs decomposed `e` + U+0301). Because the password bytes feed Argon2id directly, two such forms would derive different keys, so a volume encrypted on one platform could not be decrypted on another.
+
+To fix this, the password is normalized to **Unicode NFC** (`golang.org/x/text/unicode/norm`) before key derivation, as mandated for passwords by [RFC 8265](https://www.rfc-editor.org/rfc/rfc8265) (PRECIS `OpaqueString`) and recommended by NIST SP 800-63B-4 §3.1.1.2. Only canonical composition is applied — never compatibility normalization (NFKC/NFKD, which would collapse distinct characters and reduce entropy), case folding, or whitespace trimming.
+
+- **Encrypt** normalizes the password to NFC (including the deniability wrapper key), so new volumes are cross-platform-stable.
+- **Decrypt** tries each form in order — NFC, then NFD, then the raw bytes as typed — and keeps the first that authenticates against the volume MAC. This opens new volumes, pre-existing volumes whose password was already NFC/ASCII, and legacy volumes encrypted from decomposed or non-canonical bytes. Trying several canonical forms of the same password never bypasses authentication; each form is verified independently.
+- **ASCII passwords are invariant** under every normalization form, so they collapse to a single candidate with no extra key derivations — the overwhelming majority of volumes are unaffected.
+- **Force-decrypt** bypasses authentication, so it has no signal to choose a form and uses the password exactly as typed.
+
+This is implemented in `internal/password` and applied at every key-derivation chokepoint (desktop/CLI/mobile via `internal/volume`, and the web build in `internal/wasm`). Note one consequence: a *new* volume whose password contains non-ASCII characters may not decrypt in an *older* Picocrypt build that does not normalize, unless the user happens to type the exact stored bytes — the desktop and CLI therefore show an advisory when encrypting with a non-ASCII password.
+
 # Counter Overflow
 Since XChaCha20 has a max message size of 256 GiB, Picocrypt NG will use the HKDF-SHA3 mentioned above to generate a new nonce for XChaCha20 and a new IV for Serpent if the total encrypted data is more than 60 GiB. While this threshold can be increased up to 256 GiB, Picocrypt NG uses 60 GiB to prevent any edge cases with blocks or the counter used by Serpent.
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -14,6 +14,7 @@ require (
 	golang.org/x/crypto v0.53.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
+	golang.org/x/text v0.38.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -48,5 +49,4 @@ require (
 	github.com/yuin/goldmark v1.8.2 // indirect
 	golang.org/x/image v0.42.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
-	golang.org/x/text v0.38.0 // indirect
 )

--- a/src/internal/cli/password.go
+++ b/src/internal/cli/password.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 
+	pwnorm "Picocrypt-NG/internal/password"
+
 	"golang.org/x/term"
 )
 
@@ -73,6 +75,20 @@ func readPasswordSecure(prompt string) (string, error) {
 // ReadPasswordInteractive prompts for password interactively.
 // If confirm is true, asks for confirmation (for encryption).
 // If allowEmpty is true, empty password is allowed (useful when keyfiles provide credentials).
+// nonASCIIPasswordNote returns an advisory to show when an ENCRYPTION password
+// (confirm == true) contains non-ASCII characters, or "" when none is warranted.
+// The password is normalized (NFC) for cross-platform decryption, but the user
+// should still be able to reproduce the exact characters elsewhere — NIST
+// SP 800-63B-4 recommends advising this.
+func nonASCIIPasswordNote(confirm bool, password string) string {
+	if confirm && pwnorm.ContainsNonASCII(password) {
+		return "Note: your password contains non-ASCII characters. They are normalized " +
+			"for cross-platform decryption, but make sure you can type the same " +
+			"characters on every device where you'll decrypt this volume."
+	}
+	return ""
+}
+
 func ReadPasswordInteractive(confirm, allowEmpty bool) (string, error) {
 	// Once the prompt(s) have returned normally, clear the saved tty state so a
 	// later unrelated signal does not re-poke the terminal.
@@ -95,6 +111,10 @@ func ReadPasswordInteractive(confirm, allowEmpty bool) (string, error) {
 		if password != confirmPw {
 			return "", ErrPasswordMismatch
 		}
+	}
+
+	if note := nonASCIIPasswordNote(confirm, password); note != "" {
+		fmt.Fprintln(os.Stderr, note)
 	}
 
 	return password, nil

--- a/src/internal/cli/password_test.go
+++ b/src/internal/cli/password_test.go
@@ -9,6 +9,35 @@ import (
 	"golang.org/x/term"
 )
 
+func TestNonASCIIPasswordNote(t *testing.T) {
+	// Built from a code point so the literal cannot be silently re-normalized.
+	nonASCII := "caf" + string([]rune{0x00E9})
+
+	cases := []struct {
+		name     string
+		confirm  bool
+		password string
+		wantNote bool
+	}{
+		{"non-ascii encrypt", true, nonASCII, true},
+		{"ascii encrypt", true, "plain-password", false},
+		{"non-ascii decrypt (no confirm)", false, nonASCII, false},
+		{"empty encrypt", true, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			note := nonASCIIPasswordNote(tc.confirm, tc.password)
+			if got := note != ""; got != tc.wantNote {
+				t.Errorf("nonASCIIPasswordNote(confirm=%v, %q) note=%q, want note present=%v",
+					tc.confirm, tc.password, note, tc.wantNote)
+			}
+			if tc.wantNote && !strings.Contains(note, "non-ASCII") {
+				t.Errorf("note should mention non-ASCII, got %q", note)
+			}
+		})
+	}
+}
+
 func TestReadPasswordLine(t *testing.T) {
 	testCases := []struct {
 		name  string

--- a/src/internal/header/auth.go
+++ b/src/internal/header/auth.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha3"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"hash"
 )
@@ -135,4 +136,14 @@ func NewKeyfileError(ordered bool) *AuthError {
 		KeyfileOrdered:   ordered,
 		Message:          msg,
 	}
+}
+
+// IsPasswordError reports whether err is an authentication failure attributable
+// to an incorrect password (rather than a keyfile mismatch or other error). The
+// decrypt path uses it to decide whether retrying with another password
+// normalization form (NFC/NFD/raw) could succeed; a keyfile error is
+// independent of the password and would fail identically for every form.
+func IsPasswordError(err error) bool {
+	var authErr *AuthError
+	return errors.As(err, &authErr) && authErr.PasswordIncorrect
 }

--- a/src/internal/password/normalize.go
+++ b/src/internal/password/normalize.go
@@ -47,11 +47,11 @@ func EncodeForKDF(pw string) []byte {
 // for the common case. For a non-ASCII password it returns up to three forms,
 // duplicates removed while preserving order:
 //
-//	1. NFC  — opens new volumes and legacy ASCII/NFC volumes; tried first so a
-//	          correct password matches on the first (and only) derivation.
-//	2. NFD  — opens legacy volumes whose password was decomposed.
-//	3. raw  — opens legacy volumes whose bytes were neither NFC nor NFD (e.g. a
-//	          password pasted with combining marks in non-canonical order).
+//  1. NFC  — opens new volumes and legacy ASCII/NFC volumes; tried first so a
+//     correct password matches on the first (and only) derivation.
+//  2. NFD  — opens legacy volumes whose password was decomposed.
+//  3. raw  — opens legacy volumes whose bytes were neither NFC nor NFD (e.g. a
+//     password pasted with combining marks in non-canonical order).
 //
 // Each candidate is authenticated independently against the volume MAC by the
 // caller; trying several canonical forms of the SAME password never bypasses
@@ -61,17 +61,18 @@ func EncodeForKDF(pw string) []byte {
 // Returned slices are independent allocations, so a caller may zero each one
 // after use without affecting the others.
 func Candidates(pw string) [][]byte {
-	raw := []byte(pw)
-	if isASCII(raw) {
-		return [][]byte{raw}
+	if !ContainsNonASCII(pw) {
+		// ASCII is invariant under every normalization form, so a single
+		// candidate suffices and there is no extra KDF work for the common case.
+		return [][]byte{[]byte(pw)}
 	}
 
-	// Distinct allocations (not norm.*.Bytes, which may alias raw) so the caller
-	// can zero each candidate independently.
+	// Distinct allocations (not norm.*.Bytes, which may alias) so the caller can
+	// zero each candidate independently.
 	forms := [3][]byte{
 		[]byte(norm.NFC.String(pw)),
 		[]byte(norm.NFD.String(pw)),
-		raw,
+		[]byte(pw),
 	}
 
 	candidates := make([][]byte, 0, len(forms))
@@ -83,15 +84,18 @@ func Candidates(pw string) [][]byte {
 	return candidates
 }
 
-// isASCII reports whether b contains only 7-bit ASCII bytes, which Unicode
-// normalization leaves unchanged.
-func isASCII(b []byte) bool {
-	for _, c := range b {
-		if c >= utf8.RuneSelf {
-			return false
+// ContainsNonASCII reports whether pw contains any non-ASCII byte. User
+// interfaces use it to advise that a non-ASCII password — while normalized to a
+// canonical form for cross-platform decryption — may still be hard to reproduce
+// on another device with a different keyboard or input method (NIST
+// SP 800-63B-4 recommends informing users of this).
+func ContainsNonASCII(pw string) bool {
+	for i := 0; i < len(pw); i++ {
+		if pw[i] >= utf8.RuneSelf {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 // containsBytes reports whether set already holds a slice byte-equal to b. A

--- a/src/internal/password/normalize.go
+++ b/src/internal/password/normalize.go
@@ -1,0 +1,107 @@
+// Package password normalizes user passwords to Unicode NFC before the key
+// derivation function, fixing the cross-platform (NFC vs NFD) key mismatch
+// described in issue #19: a visually identical password typed on macOS
+// (sometimes decomposed) versus Windows/Linux (composed) is byte-different and
+// therefore derives a different Argon2 key, so a volume encrypted on one
+// platform cannot be decrypted on another.
+//
+// The normalization form is NFC, mandated for passwords by RFC 8265 (PRECIS
+// OpaqueString profile) and recommended by NIST SP 800-63B-4 §3.1.1.2. This
+// package deliberately applies ONLY canonical composition. It does NOT apply:
+//
+//   - compatibility normalization (NFKC/NFKD), which collapses distinct
+//     characters (e.g. fullwidth/halfwidth, ﬀ→ff) and reduces password entropy;
+//   - case folding, which RFC 8265 omits because it causes false accepts and
+//     enables the Turkish dotless-i collision class;
+//   - whitespace trimming, which silently reduces entropy and causes lockouts.
+//
+// ASCII input is invariant under NFC and is handled without extra work, so the
+// overwhelming majority of existing (ASCII-password) volumes are unaffected.
+package password
+
+import (
+	"bytes"
+	"unicode/utf8"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// Normalize returns pw in Unicode Normalization Form C (NFC).
+func Normalize(pw string) string {
+	return norm.NFC.String(pw)
+}
+
+// EncodeForKDF returns the NFC-normalized password as UTF-8 bytes to feed the
+// KDF when ENCRYPTING, so new volumes derive a canonical, cross-platform-stable
+// key regardless of how the password was typed.
+func EncodeForKDF(pw string) []byte {
+	return []byte(Normalize(pw))
+}
+
+// Candidates returns the ordered, de-duplicated password byte forms to try when
+// DECRYPTING, so volumes stay decryptable across platforms and across the
+// pre/post-normalization format change.
+//
+// For an ASCII password it returns exactly one candidate (the raw bytes): ASCII
+// is invariant under every normalization form, so there is no extra KDF work
+// for the common case. For a non-ASCII password it returns up to three forms,
+// duplicates removed while preserving order:
+//
+//	1. NFC  — opens new volumes and legacy ASCII/NFC volumes; tried first so a
+//	          correct password matches on the first (and only) derivation.
+//	2. NFD  — opens legacy volumes whose password was decomposed.
+//	3. raw  — opens legacy volumes whose bytes were neither NFC nor NFD (e.g. a
+//	          password pasted with combining marks in non-canonical order).
+//
+// Each candidate is authenticated independently against the volume MAC by the
+// caller; trying several canonical forms of the SAME password never bypasses
+// authentication, and the extra derivations only occur when an earlier form
+// fails to verify (i.e. a wrong password or a legacy non-NFC volume).
+//
+// Returned slices are independent allocations, so a caller may zero each one
+// after use without affecting the others.
+func Candidates(pw string) [][]byte {
+	raw := []byte(pw)
+	if isASCII(raw) {
+		return [][]byte{raw}
+	}
+
+	// Distinct allocations (not norm.*.Bytes, which may alias raw) so the caller
+	// can zero each candidate independently.
+	forms := [3][]byte{
+		[]byte(norm.NFC.String(pw)),
+		[]byte(norm.NFD.String(pw)),
+		raw,
+	}
+
+	candidates := make([][]byte, 0, len(forms))
+	for _, f := range forms {
+		if !containsBytes(candidates, f) {
+			candidates = append(candidates, f)
+		}
+	}
+	return candidates
+}
+
+// isASCII reports whether b contains only 7-bit ASCII bytes, which Unicode
+// normalization leaves unchanged.
+func isASCII(b []byte) bool {
+	for _, c := range b {
+		if c >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}
+
+// containsBytes reports whether set already holds a slice byte-equal to b. A
+// linear scan over at most three short slices is cheaper than a map and, unlike
+// a map keyed by string(b), creates no extra in-memory copies of the password.
+func containsBytes(set [][]byte, b []byte) bool {
+	for _, e := range set {
+		if bytes.Equal(e, b) {
+			return true
+		}
+	}
+	return false
+}

--- a/src/internal/password/normalize_test.go
+++ b/src/internal/password/normalize_test.go
@@ -1,0 +1,147 @@
+package password
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Worked Unicode vectors (UAX #15). These pin the exact cross-platform mismatch
+// issue #19 targets: the same visible character in composed (NFC) vs decomposed
+// (NFD) byte forms, which derive different Argon2 keys when fed raw.
+const (
+	eComposed    = "é"             // é  NFC  -> C3 A9
+	eDecomposed  = "é"            // é  NFD  -> 65 CC 81
+	gaComposed   = "가"             // 가 NFC  -> EA B0 80
+	gaDecomposed = "가"       // 가 NFD  -> E1 84 80 E1 85 A1
+	devEmoji     = "\U0001f469‍\U0001f4bb" // 👩‍💻 ZWJ sequence, unchanged by NFC/NFD
+)
+
+var (
+	eNFCBytes  = []byte{0xc3, 0xa9}
+	eNFDBytes  = []byte{0x65, 0xcc, 0x81}
+	gaNFCBytes = []byte{0xea, 0xb0, 0x80}
+)
+
+func TestNormalizeProducesNFC(t *testing.T) {
+	// Composed and decomposed forms of the SAME character must normalize to
+	// identical NFC bytes — that is exactly what lets a password typed on one
+	// platform derive the same key as on another (the #19 fix). If Normalize
+	// stopped normalizing, these would diverge and the test fails.
+	cases := []struct {
+		name string
+		in   string
+		want []byte
+	}{
+		{"é composed", eComposed, eNFCBytes},
+		{"é decomposed", eDecomposed, eNFCBytes},
+		{"가 composed", gaComposed, gaNFCBytes},
+		{"가 decomposed", gaDecomposed, gaNFCBytes},
+	}
+	for _, tc := range cases {
+		if got := []byte(Normalize(tc.in)); !bytes.Equal(got, tc.want) {
+			t.Errorf("Normalize(%s) = % x, want % x", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeIsIdempotent(t *testing.T) {
+	for _, in := range []string{eComposed, eDecomposed, gaDecomposed, devEmoji, "ascii"} {
+		once := Normalize(in)
+		if twice := Normalize(once); twice != once {
+			t.Errorf("Normalize not idempotent for %q: %q != %q", in, twice, once)
+		}
+	}
+}
+
+func TestNormalizeLeavesASCIIUnchanged(t *testing.T) {
+	// ASCII is invariant under NFC, so the millions of existing ASCII-password
+	// volumes are completely unaffected by this change.
+	in := "Correct Horse Battery Staple 123!@#"
+	if got := Normalize(in); got != in {
+		t.Errorf("Normalize(ascii) = %q, want unchanged %q", got, in)
+	}
+}
+
+func TestNormalizeDoesNotCaseFoldOrTrim(t *testing.T) {
+	// NFC must preserve case (RFC 8265 §4.2.2: no case mapping — folding the
+	// Turkish dotless-i class reduces security) and must NOT trim whitespace
+	// (silent entropy loss / lockouts). ß must not fold to "ss".
+	in := " straße "
+	if got := Normalize(in); got != in {
+		t.Errorf("Normalize must preserve ß and surrounding spaces: %q -> %q", in, got)
+	}
+}
+
+func TestNormalizeLeavesEmojiZWJUnchanged(t *testing.T) {
+	// ZWJ emoji sequences have no canonical decomposition; NFC passes them
+	// through byte-for-byte, so emoji passwords are never corrupted.
+	if got := Normalize(devEmoji); got != devEmoji {
+		t.Errorf("Normalize altered ZWJ emoji: % x -> % x", []byte(devEmoji), []byte(got))
+	}
+}
+
+func TestEncodeForKDFIsNFCBytes(t *testing.T) {
+	// Encrypt must feed the KDF the NFC form regardless of how the password was
+	// typed, so new volumes are cross-platform-stable.
+	if got := EncodeForKDF(eDecomposed); !bytes.Equal(got, eNFCBytes) {
+		t.Errorf("EncodeForKDF(decomposed é) = % x, want NFC % x", got, eNFCBytes)
+	}
+}
+
+func TestCandidatesASCIISingleAttempt(t *testing.T) {
+	// The common case: ASCII passwords yield exactly ONE candidate (raw bytes),
+	// guaranteeing no extra Argon2 work and no behavior change. If this grew to
+	// >1, every ASCII wrong-password would pay multiple 1 GiB derivations.
+	got := Candidates("password123")
+	if len(got) != 1 {
+		t.Fatalf("ASCII Candidates len = %d, want 1 (got % x)", len(got), got)
+	}
+	if !bytes.Equal(got[0], []byte("password123")) {
+		t.Errorf("ASCII candidate = % x, want raw bytes", got[0])
+	}
+}
+
+func TestCandidatesNonASCIIOrderAndDedup(t *testing.T) {
+	// NFC must be tried FIRST (so a correct password on a new/NFC volume matches
+	// on the first derivation) and duplicate forms must be collapsed (so we
+	// never run the same Argon2 twice). For a composed-é password NFC == raw, so
+	// after dedup we expect exactly [NFC, NFD].
+	for _, in := range []string{eComposed, eDecomposed} {
+		got := Candidates(in)
+		if len(got) != 2 {
+			t.Fatalf("Candidates(%q) len = %d, want 2 (got % x)", in, len(got), got)
+		}
+		if !bytes.Equal(got[0], eNFCBytes) {
+			t.Errorf("Candidates(%q)[0] = % x, want NFC % x", in, got[0], eNFCBytes)
+		}
+		if !bytes.Equal(got[1], eNFDBytes) {
+			t.Errorf("Candidates(%q)[1] = % x, want NFD % x", in, got[1], eNFDBytes)
+		}
+	}
+}
+
+func TestCandidatesIncludesRawWhenNeitherNFCNorNFD(t *testing.T) {
+	// A non-canonical input (combining marks out of canonical order) differs
+	// from BOTH its NFC and NFD forms, so raw MUST be kept as a third candidate
+	// to keep such legacy volumes decryptable. "e" + U+0301 (acute, ccc=230) +
+	// U+0323 (dot-below, ccc=220): canonical order requires 220 before 230, so
+	// this raw ordering is non-canonical and is preserved by neither NFC nor NFD.
+	nonCanonical := "ẹ́"
+	got := Candidates(nonCanonical)
+	if len(got) != 3 {
+		t.Fatalf("Candidates(non-canonical) len = %d, want 3 (got % x)", len(got), got)
+	}
+	if !bytes.Equal(got[2], []byte(nonCanonical)) {
+		t.Errorf("Candidates[2] = % x, want raw % x", got[2], []byte(nonCanonical))
+	}
+	if bytes.Equal(got[0], []byte(nonCanonical)) || bytes.Equal(got[1], []byte(nonCanonical)) {
+		t.Errorf("raw must be distinct from NFC/NFD candidates for a non-canonical input")
+	}
+}
+
+func TestCandidatesEmptyPassword(t *testing.T) {
+	got := Candidates("")
+	if len(got) != 1 || len(got[0]) != 0 {
+		t.Errorf("Candidates(\"\") = %v, want a single empty candidate", got)
+	}
+}

--- a/src/internal/password/normalize_test.go
+++ b/src/internal/password/normalize_test.go
@@ -5,37 +5,60 @@ import (
 	"testing"
 )
 
-// Worked Unicode vectors (UAX #15). These pin the exact cross-platform mismatch
-// issue #19 targets: the same visible character in composed (NFC) vs decomposed
-// (NFD) byte forms, which derive different Argon2 keys when fed raw.
-const (
-	eComposed    = "é"             // é  NFC  -> C3 A9
-	eDecomposed  = "é"            // é  NFD  -> 65 CC 81
-	gaComposed   = "가"             // 가 NFC  -> EA B0 80
-	gaDecomposed = "가"       // 가 NFD  -> E1 84 80 E1 85 A1
-	devEmoji     = "\U0001f469‍\U0001f4bb" // 👩‍💻 ZWJ sequence, unchanged by NFC/NFD
-)
-
+// Test vectors are built from explicit code points / bytes — never from source
+// literals — so an editor re-normalizing this file cannot silently make the
+// composed/decomposed distinctions vacuous. These are the UAX #15 worked
+// examples behind issue #19: the same visible character in two byte forms.
 var (
+	eComposed    = string([]rune{0x00E9})                  // é  NFC
+	eDecomposed  = string([]rune{0x0065, 0x0301})          // é  NFD (e + combining acute)
+	gaComposed   = string([]rune{0xAC00})                  // 가 NFC
+	gaDecomposed = string([]rune{0x1100, 0x1161})          // 가 NFD (conjoining jamo)
+	devEmoji     = string([]rune{0x1F469, 0x200D, 0x1F4BB}) // 👩‍💻 ZWJ sequence
+	// e + acute (ccc 230) + dot-below (ccc 220): combining marks in non-canonical
+	// order, so the raw bytes equal neither the NFC nor the NFD form.
+	nonCanonical = string([]rune{0x0065, 0x0301, 0x0323})
+
 	eNFCBytes  = []byte{0xc3, 0xa9}
 	eNFDBytes  = []byte{0x65, 0xcc, 0x81}
 	gaNFCBytes = []byte{0xea, 0xb0, 0x80}
+	gaNFDBytes = []byte{0xe1, 0x84, 0x80, 0xe1, 0x85, 0xa1}
 )
+
+// TestVectorConstantsHaveExpectedByteForms documents and locks the UTF-8 byte
+// encodings of the vectors, so a wrong code point above is caught immediately.
+func TestVectorConstantsHaveExpectedByteForms(t *testing.T) {
+	checks := []struct {
+		name string
+		got  []byte
+		want []byte
+	}{
+		{"eComposed", []byte(eComposed), eNFCBytes},
+		{"eDecomposed", []byte(eDecomposed), eNFDBytes},
+		{"gaComposed", []byte(gaComposed), gaNFCBytes},
+		{"gaDecomposed", []byte(gaDecomposed), gaNFDBytes},
+	}
+	for _, c := range checks {
+		if !bytes.Equal(c.got, c.want) {
+			t.Errorf("%s raw bytes = % x, want % x", c.name, c.got, c.want)
+		}
+	}
+}
 
 func TestNormalizeProducesNFC(t *testing.T) {
 	// Composed and decomposed forms of the SAME character must normalize to
 	// identical NFC bytes — that is exactly what lets a password typed on one
 	// platform derive the same key as on another (the #19 fix). If Normalize
-	// stopped normalizing, these would diverge and the test fails.
+	// stopped normalizing, the decomposed cases would diverge and fail.
 	cases := []struct {
 		name string
 		in   string
 		want []byte
 	}{
-		{"é composed", eComposed, eNFCBytes},
-		{"é decomposed", eDecomposed, eNFCBytes},
-		{"가 composed", gaComposed, gaNFCBytes},
-		{"가 decomposed", gaDecomposed, gaNFCBytes},
+		{"e composed", eComposed, eNFCBytes},
+		{"e decomposed", eDecomposed, eNFCBytes},
+		{"ga composed", gaComposed, gaNFCBytes},
+		{"ga decomposed", gaDecomposed, gaNFCBytes},
 	}
 	for _, tc := range cases {
 		if got := []byte(Normalize(tc.in)); !bytes.Equal(got, tc.want) {
@@ -48,7 +71,7 @@ func TestNormalizeIsIdempotent(t *testing.T) {
 	for _, in := range []string{eComposed, eDecomposed, gaDecomposed, devEmoji, "ascii"} {
 		once := Normalize(in)
 		if twice := Normalize(once); twice != once {
-			t.Errorf("Normalize not idempotent for %q: %q != %q", in, twice, once)
+			t.Errorf("Normalize not idempotent for % x: % x != % x", []byte(in), []byte(twice), []byte(once))
 		}
 	}
 }
@@ -65,10 +88,10 @@ func TestNormalizeLeavesASCIIUnchanged(t *testing.T) {
 func TestNormalizeDoesNotCaseFoldOrTrim(t *testing.T) {
 	// NFC must preserve case (RFC 8265 §4.2.2: no case mapping — folding the
 	// Turkish dotless-i class reduces security) and must NOT trim whitespace
-	// (silent entropy loss / lockouts). ß must not fold to "ss".
-	in := " straße "
+	// (silent entropy loss / lockouts). U+00DF (ß) must not fold to "ss".
+	in := " stra" + string([]rune{0x00DF}) + "e " // " straße "
 	if got := Normalize(in); got != in {
-		t.Errorf("Normalize must preserve ß and surrounding spaces: %q -> %q", in, got)
+		t.Errorf("Normalize must preserve U+00DF and surrounding spaces: % x -> % x", []byte(in), []byte(got))
 	}
 }
 
@@ -84,7 +107,7 @@ func TestEncodeForKDFIsNFCBytes(t *testing.T) {
 	// Encrypt must feed the KDF the NFC form regardless of how the password was
 	// typed, so new volumes are cross-platform-stable.
 	if got := EncodeForKDF(eDecomposed); !bytes.Equal(got, eNFCBytes) {
-		t.Errorf("EncodeForKDF(decomposed é) = % x, want NFC % x", got, eNFCBytes)
+		t.Errorf("EncodeForKDF(decomposed e) = % x, want NFC % x", got, eNFCBytes)
 	}
 }
 
@@ -104,18 +127,19 @@ func TestCandidatesASCIISingleAttempt(t *testing.T) {
 func TestCandidatesNonASCIIOrderAndDedup(t *testing.T) {
 	// NFC must be tried FIRST (so a correct password on a new/NFC volume matches
 	// on the first derivation) and duplicate forms must be collapsed (so we
-	// never run the same Argon2 twice). For a composed-é password NFC == raw, so
-	// after dedup we expect exactly [NFC, NFD].
+	// never run the same Argon2 twice). For a composed-e password NFC == raw, so
+	// after dedup we expect exactly [NFC, NFD]; same for the decomposed form
+	// (there NFD == raw).
 	for _, in := range []string{eComposed, eDecomposed} {
 		got := Candidates(in)
 		if len(got) != 2 {
-			t.Fatalf("Candidates(%q) len = %d, want 2 (got % x)", in, len(got), got)
+			t.Fatalf("Candidates(% x) len = %d, want 2 (got % x)", []byte(in), len(got), got)
 		}
 		if !bytes.Equal(got[0], eNFCBytes) {
-			t.Errorf("Candidates(%q)[0] = % x, want NFC % x", in, got[0], eNFCBytes)
+			t.Errorf("Candidates(% x)[0] = % x, want NFC % x", []byte(in), got[0], eNFCBytes)
 		}
 		if !bytes.Equal(got[1], eNFDBytes) {
-			t.Errorf("Candidates(%q)[1] = % x, want NFD % x", in, got[1], eNFDBytes)
+			t.Errorf("Candidates(% x)[1] = % x, want NFD % x", []byte(in), got[1], eNFDBytes)
 		}
 	}
 }
@@ -123,10 +147,7 @@ func TestCandidatesNonASCIIOrderAndDedup(t *testing.T) {
 func TestCandidatesIncludesRawWhenNeitherNFCNorNFD(t *testing.T) {
 	// A non-canonical input (combining marks out of canonical order) differs
 	// from BOTH its NFC and NFD forms, so raw MUST be kept as a third candidate
-	// to keep such legacy volumes decryptable. "e" + U+0301 (acute, ccc=230) +
-	// U+0323 (dot-below, ccc=220): canonical order requires 220 before 230, so
-	// this raw ordering is non-canonical and is preserved by neither NFC nor NFD.
-	nonCanonical := "ẹ́"
+	// to keep such legacy volumes decryptable.
 	got := Candidates(nonCanonical)
 	if len(got) != 3 {
 		t.Fatalf("Candidates(non-canonical) len = %d, want 3 (got % x)", len(got), got)

--- a/src/internal/password/normalize_test.go
+++ b/src/internal/password/normalize_test.go
@@ -10,10 +10,10 @@ import (
 // composed/decomposed distinctions vacuous. These are the UAX #15 worked
 // examples behind issue #19: the same visible character in two byte forms.
 var (
-	eComposed    = string([]rune{0x00E9})                  // é  NFC
-	eDecomposed  = string([]rune{0x0065, 0x0301})          // é  NFD (e + combining acute)
-	gaComposed   = string([]rune{0xAC00})                  // 가 NFC
-	gaDecomposed = string([]rune{0x1100, 0x1161})          // 가 NFD (conjoining jamo)
+	eComposed    = string([]rune{0x00E9})                   // é  NFC
+	eDecomposed  = string([]rune{0x0065, 0x0301})           // é  NFD (e + combining acute)
+	gaComposed   = string([]rune{0xAC00})                   // 가 NFC
+	gaDecomposed = string([]rune{0x1100, 0x1161})           // 가 NFD (conjoining jamo)
 	devEmoji     = string([]rune{0x1F469, 0x200D, 0x1F4BB}) // 👩‍💻 ZWJ sequence
 	// e + acute (ccc 230) + dot-below (ccc 220): combining marks in non-canonical
 	// order, so the raw bytes equal neither the NFC nor the NFD form.
@@ -164,5 +164,26 @@ func TestCandidatesEmptyPassword(t *testing.T) {
 	got := Candidates("")
 	if len(got) != 1 || len(got[0]) != 0 {
 		t.Errorf("Candidates(\"\") = %v, want a single empty candidate", got)
+	}
+}
+
+func TestContainsNonASCII(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"ascii", "Password123!@#", false},
+		{"empty", "", false},
+		{"high-bit-boundary 0x7f", "\x7f", false},
+		{"accented", eComposed, true},
+		{"decomposed", eDecomposed, true},
+		{"hangul", gaComposed, true},
+		{"ascii then non-ascii", "pass" + eComposed, true},
+	}
+	for _, tc := range cases {
+		if got := ContainsNonASCII(tc.in); got != tc.want {
+			t.Errorf("ContainsNonASCII(%s) = %v, want %v", tc.name, got, tc.want)
+		}
 	}
 }

--- a/src/internal/ui/app.go
+++ b/src/internal/ui/app.go
@@ -117,6 +117,11 @@ type App struct {
 	confirmLabel *widget.Label
 	confirmRow   *fyne.Container
 
+	// Advisory shown in encrypt mode when the password contains non-ASCII
+	// characters (#19): normalized for cross-platform decryption, but the user
+	// should be able to reproduce the same characters on other devices.
+	nonASCIIHint *widget.Label
+
 	// Password buttons
 	showHideBtn *widget.Button
 	clearPwdBtn *widget.Button

--- a/src/internal/ui/password_section.go
+++ b/src/internal/ui/password_section.go
@@ -3,6 +3,7 @@ package ui
 
 import (
 	"Picocrypt-NG/internal/app"
+	pwnorm "Picocrypt-NG/internal/password"
 
 	"github.com/Picocrypt/zxcvbn-go"
 
@@ -91,10 +92,20 @@ func (a *App) buildPasswordSection() fyne.CanvasObject {
 	a.confirmLabel = widget.NewLabel("Confirm password:")
 	a.confirmLabel.TextStyle = fyne.TextStyle{Bold: true}
 
+	// Subtle advisory shown only while encrypting with a non-ASCII password (#19).
+	a.nonASCIIHint = widget.NewLabel(
+		"Non-ASCII password: it is normalized so the volume decrypts on any " +
+			"platform, but make sure you can type the same characters on every " +
+			"device where you'll decrypt it.")
+	a.nonASCIIHint.Importance = widget.LowImportance
+	a.nonASCIIHint.Wrapping = fyne.TextWrapWord
+	a.nonASCIIHint.Hide()
+
 	return container.NewVBox(
 		passwordLabel,
 		buttonRow,
 		passwordRow,
+		a.nonASCIIHint,
 		a.confirmLabel,
 		a.confirmRow,
 	)
@@ -107,6 +118,20 @@ func (a *App) updatePasswordStrength() {
 		a.strengthIndicator.SetStrength(a.State.PasswordStrength)
 		a.strengthIndicator.SetVisible(a.State.Password != "")
 		a.strengthIndicator.SetDecryptMode(a.State.Mode == "decrypt")
+	}
+	a.updateNonASCIIHint()
+}
+
+// updateNonASCIIHint shows the non-ASCII advisory only while encrypting with a
+// password that contains non-ASCII characters (#19).
+func (a *App) updateNonASCIIHint() {
+	if a.nonASCIIHint == nil {
+		return
+	}
+	if a.State.Mode != "decrypt" && pwnorm.ContainsNonASCII(a.State.Password) {
+		a.nonASCIIHint.Show()
+	} else {
+		a.nonASCIIHint.Hide()
 	}
 }
 
@@ -197,4 +222,8 @@ func (a *App) updatePasswordUIState(mainDisabled bool, snap app.UISnapshot) {
 			a.confirmRow.Show()
 		}
 	}
+
+	// Re-evaluate the non-ASCII advisory when the mode changes (e.g. it must hide
+	// when switching to decrypt).
+	a.updateNonASCIIHint()
 }

--- a/src/internal/ui/password_test.go
+++ b/src/internal/ui/password_test.go
@@ -13,6 +13,43 @@ import (
 // (a known-weak password must not score above a known-strong one) rather than
 // recomputing zxcvbn inline, so it fails if updatePasswordStrength stops calling
 // zxcvbn or stores the wrong value.
+// TestNonASCIIPasswordHint verifies the #19 advisory is shown only while
+// encrypting with a non-ASCII password, and hidden for ASCII passwords or in
+// decrypt mode. It drives the real updateNonASCIIHint against the built widget.
+func TestNonASCIIPasswordHint(t *testing.T) {
+	fyneApp := newTestFyneApp(t)
+	a := createUIReadyDropTestApp(t, fyneApp)
+
+	// Built from a code point so the literal cannot be silently re-normalized.
+	nonASCII := "caf" + string([]rune{0x00E9})
+
+	fyne.DoAndWait(func() {
+		if a.nonASCIIHint == nil {
+			t.Fatal("nonASCIIHint widget was not built")
+		}
+
+		a.State.Mode = "encrypt"
+		a.State.Password = nonASCII
+		a.updateNonASCIIHint()
+		if !a.nonASCIIHint.Visible() {
+			t.Error("hint should be visible for a non-ASCII password in encrypt mode")
+		}
+
+		a.State.Password = "plain-ascii"
+		a.updateNonASCIIHint()
+		if a.nonASCIIHint.Visible() {
+			t.Error("hint should be hidden for an ASCII password")
+		}
+
+		a.State.Mode = "decrypt"
+		a.State.Password = nonASCII
+		a.updateNonASCIIHint()
+		if a.nonASCIIHint.Visible() {
+			t.Error("hint should be hidden in decrypt mode")
+		}
+	})
+}
+
 func TestPasswordStrengthScoring(t *testing.T) {
 	fyneApp := newTestFyneApp(t)
 

--- a/src/internal/volume/context.go
+++ b/src/internal/volume/context.go
@@ -137,11 +137,12 @@ type OperationContext struct {
 	Header *header.VolumeHeader
 
 	// Cryptographic state
-	Key          []byte               // Argon2-derived key (possibly XORed with keyfile key)
-	KeyfileKey   []byte               // 32-byte key derived from keyfile(s)
-	KeyfileHash  []byte               // SHA3-256(KeyfileKey) for verification
-	SubkeyReader *crypto.SubkeyReader // HKDF stream for deriving MAC/Serpent subkeys
-	CipherSuite  *crypto.CipherSuite  // Initialized cipher suite (XChaCha20 + optional Serpent)
+	Key           []byte               // Argon2-derived key (possibly XORed with keyfile key)
+	KeyfileKey    []byte               // 32-byte key derived from keyfile(s)
+	KeyfileHash   []byte               // SHA3-256(KeyfileKey) for verification
+	passwordBytes []byte               // KDF input for the current password form being tried (#19)
+	SubkeyReader  *crypto.SubkeyReader // HKDF stream for deriving MAC/Serpent subkeys
+	CipherSuite   *crypto.CipherSuite  // Initialized cipher suite (XChaCha20 + optional Serpent)
 
 	// Operation flags
 	IsLegacyV1   bool                    // True if decrypting a v1.x volume (different HKDF timing)
@@ -287,6 +288,19 @@ func (ctx *OperationContext) setKeyfileKey(k []byte) {
 	ctx.KeyfileKey = k
 }
 
+// setPasswordBytes zeros the previous password byte form before storing the new
+// one. The decrypt path sets this per candidate normalization form (#19); the
+// winning form is reused by the RS / verify-first re-derivation paths and is
+// zeroed by Close. The same pointer-identity self-assign guard as setKey applies.
+// (The password also lives in req.Password as an immutable, un-zeroable string —
+// see Close's SECURITY note.)
+func (ctx *OperationContext) setPasswordBytes(b []byte) {
+	if ctx.passwordBytes != nil && (len(b) == 0 || &b[0] != &ctx.passwordBytes[0]) {
+		crypto.SecureZero(ctx.passwordBytes)
+	}
+	ctx.passwordBytes = b
+}
+
 // Close securely zeros all sensitive cryptographic material in the context.
 // This should be called via defer immediately after creating the context.
 //
@@ -307,10 +321,11 @@ func (ctx *OperationContext) Close() {
 	}
 
 	// Zero main key material
-	crypto.SecureZeroMultiple(ctx.Key, ctx.KeyfileKey, ctx.KeyfileHash)
+	crypto.SecureZeroMultiple(ctx.Key, ctx.KeyfileKey, ctx.KeyfileHash, ctx.passwordBytes)
 	ctx.Key = nil
 	ctx.KeyfileKey = nil
 	ctx.KeyfileHash = nil
+	ctx.passwordBytes = nil
 
 	// Close cipher suite (zeros internal key)
 	if ctx.CipherSuite != nil {

--- a/src/internal/volume/decrypt.go
+++ b/src/internal/volume/decrypt.go
@@ -16,6 +16,7 @@ import (
 	"Picocrypt-NG/internal/header"
 	"Picocrypt-NG/internal/keyfile"
 	"Picocrypt-NG/internal/log"
+	pwnorm "Picocrypt-NG/internal/password"
 	"Picocrypt-NG/internal/util"
 )
 
@@ -59,20 +60,11 @@ func Decrypt(ctx context.Context, req *DecryptRequest) error {
 		return err
 	}
 
-	// Phase 3: Derive keys
-	if err := decryptDeriveKeys(opCtx, req); err != nil {
-		cleanupDecrypt(opCtx, req)
-		return err
-	}
-
-	// Phase 4: Process keyfiles
-	if err := decryptProcessKeyfiles(opCtx, req); err != nil {
-		cleanupDecrypt(opCtx, req)
-		return err
-	}
-
-	// Phase 5: Verify authentication
-	if err := decryptVerifyAuth(opCtx, req); err != nil {
+	// Phases 3-5: derive keys, process keyfiles, and verify authentication,
+	// trying each password normalization form (NFC/NFD/raw) until one
+	// authenticates (#19). On success the winning form is left on the context so
+	// the verify-first and RS-retry re-derivations reuse it.
+	if err := decryptDeriveProcessVerify(opCtx, req); err != nil {
 		cleanupDecrypt(opCtx, req)
 		return err
 	}
@@ -220,7 +212,7 @@ func decryptReadHeader(ctx *OperationContext, req *DecryptRequest) error {
 func decryptDeriveKeys(ctx *OperationContext, req *DecryptRequest) error {
 	ctx.SetStatus("Deriving key...")
 
-	key, err := deriveVolumeKey([]byte(req.Password), ctx.Header.Salt, ctx.Header.Flags.Paranoid)
+	key, err := deriveVolumeKey(ctx.passwordBytes, ctx.Header.Salt, ctx.Header.Flags.Paranoid)
 	if err != nil {
 		return err
 	}
@@ -359,6 +351,43 @@ func decryptVerifyAuth(ctx *OperationContext, req *DecryptRequest) error {
 	}
 
 	return nil
+}
+
+// decryptDeriveProcessVerify runs the derive-keys -> process-keyfiles ->
+// verify-auth sequence, trying each password normalization form (NFC/NFD/raw)
+// until one authenticates against the volume MAC (#19). Only a
+// wrong-password/tamper failure triggers the next form; any other error (keyfile
+// mismatch, subkey read, etc.) is independent of the password and returned
+// immediately. The winning form stays on ctx.passwordBytes so the verify-first
+// and RS-retry re-derivations reuse it. ForceDecrypt has no auth gate to choose
+// a form, so it uses the password exactly as typed (a single attempt, preserving
+// historical behavior).
+func decryptDeriveProcessVerify(ctx *OperationContext, req *DecryptRequest) error {
+	candidates := pwnorm.Candidates(req.Password)
+	if req.ForceDecrypt {
+		candidates = [][]byte{[]byte(req.Password)}
+	}
+
+	var lastErr error
+	for i, cand := range candidates {
+		ctx.setPasswordBytes(cand)
+
+		if err := decryptDeriveKeys(ctx, req); err != nil {
+			return err
+		}
+		if err := decryptProcessKeyfiles(ctx, req); err != nil {
+			return err
+		}
+		err := decryptVerifyAuth(ctx, req)
+		if err == nil {
+			return nil
+		}
+		if !header.IsPasswordError(err) || i == len(candidates)-1 {
+			return err
+		}
+		lastErr = err
+	}
+	return lastErr
 }
 
 // reDeriveForRetry resets the key-derivation state before a full-RS decode retry.

--- a/src/internal/volume/deniability.go
+++ b/src/internal/volume/deniability.go
@@ -12,6 +12,7 @@ import (
 	"Picocrypt-NG/internal/encoding"
 	"Picocrypt-NG/internal/fileops"
 	"Picocrypt-NG/internal/header"
+	pwnorm "Picocrypt-NG/internal/password"
 	"Picocrypt-NG/internal/util"
 
 	"golang.org/x/crypto/chacha20"
@@ -101,8 +102,10 @@ func AddDeniability(volumePath, password string, reporter ProgressReporter) erro
 		return fmt.Errorf("write nonce: %w", err)
 	}
 
-	// Derive key using Argon2 (normal mode parameters)
-	key := deriveDeniabilityKey([]byte(password), salt)
+	// Derive key using Argon2 (normal mode parameters). NFC-normalize the
+	// password so a deniable volume — which has no readable header to fall back
+	// on — is cross-platform-decryptable (#19).
+	key := deriveDeniabilityKey(pwnorm.EncodeForKDF(password), salt)
 	defer crypto.SecureZero(key)
 
 	cipher, err := chacha20.NewUnauthenticatedCipher(key, nonce)

--- a/src/internal/volume/deniability.go
+++ b/src/internal/volume/deniability.go
@@ -260,8 +260,25 @@ func RemoveDeniability(volumePath, password string, reporter ProgressReporter, r
 		return "", fmt.Errorf("read nonce: %w", err)
 	}
 
-	// Derive key using Argon2 (normal mode parameters)
-	key := deriveDeniabilityKey([]byte(password), salt)
+	// The deniable wrapper carries no MAC; the correct key is the one whose
+	// keystream decodes a valid inner volume version. Probe the first encoded
+	// version field with each password normalization form (NFC/NFD/raw) and keep
+	// the first that matches, then decrypt the whole volume with that key (#19).
+	probe := make([]byte, header.VersionEncSize)
+	if _, err := io.ReadFull(fin, probe); err != nil {
+		cleanup()
+		return "", fmt.Errorf("read version probe: %w", err)
+	}
+	if _, err := fin.Seek(int64(len(salt)+len(nonce)), io.SeekStart); err != nil {
+		cleanup()
+		return "", fmt.Errorf("seek after probe: %w", err)
+	}
+
+	key, err := selectDeniabilityKey(password, salt, nonce, probe, rs)
+	if err != nil {
+		cleanup()
+		return "", err
+	}
 	defer crypto.SecureZero(key)
 
 	cipher, err := chacha20.NewUnauthenticatedCipher(key, nonce)
@@ -361,6 +378,30 @@ func RemoveDeniability(volumePath, password string, reporter ProgressReporter, r
 	}
 
 	return outputPath, nil
+}
+
+// selectDeniabilityKey returns the deniability key for the first password
+// normalization form (NFC/NFD/raw) whose keystream decodes a valid inner volume
+// version from probe (the RS-encoded version field). It returns an error if no
+// form matches. Trying several canonical forms of the same password does not
+// weaken the wrapper: each candidate must still yield a recognizable inner
+// header. ASCII passwords yield a single candidate, so there is no extra work.
+func selectDeniabilityKey(password string, salt, nonce, probe []byte, rs *encoding.RSCodecs) ([]byte, error) {
+	for _, cand := range pwnorm.Candidates(password) {
+		key := deriveDeniabilityKey(cand, salt)
+		cipher, err := chacha20.NewUnauthenticatedCipher(key, nonce)
+		if err != nil {
+			crypto.SecureZero(key)
+			return nil, fmt.Errorf("create cipher: %w", err)
+		}
+		dec := make([]byte, len(probe))
+		cipher.XORKeyStream(dec, probe)
+		if versionDec, decodeErr := encoding.Decode(rs.RS5, dec, false); decodeErr == nil && header.MatchVersion(versionDec) {
+			return key, nil
+		}
+		crypto.SecureZero(key)
+	}
+	return nil, errors.New("password is incorrect or the file is not a volume")
 }
 
 // IsDeniable checks if a volume appears to have deniability protection.

--- a/src/internal/volume/deniability_progress_test.go
+++ b/src/internal/volume/deniability_progress_test.go
@@ -2,6 +2,7 @@ package volume
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,23 +42,44 @@ func TestDeniabilityReportsSpeedAndETA(t *testing.T) {
 		t.Fatalf("NewRSCodecs: %v", err)
 	}
 	tmpDir := t.TempDir()
-	volPath := filepath.Join(tmpDir, "vol.pcv")
-	if err := os.WriteFile(volPath, bytes.Repeat([]byte("x"), 2*1024*1024), 0644); err != nil {
-		t.Fatalf("write volume: %v", err)
-	}
 
+	// AddDeniability encrypts whatever bytes it is given, so a plain 2 MiB blob
+	// exercises its streaming progress reporting.
+	addPath := filepath.Join(tmpDir, "add.bin")
+	if err := os.WriteFile(addPath, bytes.Repeat([]byte("x"), 2*1024*1024), 0644); err != nil {
+		t.Fatalf("write add input: %v", err)
+	}
 	addRep := &etaStatusReporter{}
-	if err := AddDeniability(volPath, "pw", addRep); err != nil {
+	if err := AddDeniability(addPath, "pw", addRep); err != nil {
 		t.Fatalf("AddDeniability: %v", err)
 	}
 	if !hasSpeedAndETA(addRep.statuses) {
 		t.Errorf("AddDeniability reported no speed+ETA status, got %v", addRep.statuses)
 	}
 
-	// The wrapped bytes are not a real inner volume, so RemoveDeniability fails
-	// verification AFTER the streaming pass — which is all this test asserts.
+	// RemoveDeniability now selects the password form by probing the inner
+	// version field before streaming, so it must operate on a REAL deniable
+	// volume to reach (and report on) the streaming pass. Build one: encrypt a
+	// 2 MiB file, then wrap it.
+	plainPath := filepath.Join(tmpDir, "pt.bin")
+	if err := os.WriteFile(plainPath, bytes.Repeat([]byte("y"), 2*1024*1024), 0644); err != nil {
+		t.Fatalf("write plaintext: %v", err)
+	}
+	volPath := filepath.Join(tmpDir, "vol.pcv")
+	if err := Encrypt(context.Background(), &EncryptRequest{
+		InputFile: plainPath, OutputFile: volPath, Password: "pw",
+		Reporter: &GoldenTestReporter{}, RSCodecs: rs,
+	}); err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if err := AddDeniability(volPath, "pw", &etaStatusReporter{}); err != nil {
+		t.Fatalf("AddDeniability(volume): %v", err)
+	}
+
 	remRep := &etaStatusReporter{}
-	_, _ = RemoveDeniability(volPath, "pw", remRep, rs)
+	if _, err := RemoveDeniability(volPath, "pw", remRep, rs); err != nil {
+		t.Fatalf("RemoveDeniability: %v", err)
+	}
 	if !hasSpeedAndETA(remRep.statuses) {
 		t.Errorf("RemoveDeniability reported no speed+ETA status, got %v", remRep.statuses)
 	}

--- a/src/internal/volume/encrypt.go
+++ b/src/internal/volume/encrypt.go
@@ -15,6 +15,7 @@ import (
 	"Picocrypt-NG/internal/header"
 	"Picocrypt-NG/internal/keyfile"
 	"Picocrypt-NG/internal/log"
+	pwnorm "Picocrypt-NG/internal/password"
 	"Picocrypt-NG/internal/util"
 )
 
@@ -229,7 +230,9 @@ func encryptWriteHeader(ctx *OperationContext, req *EncryptRequest) error {
 func encryptDeriveKeys(ctx *OperationContext, req *EncryptRequest) error {
 	ctx.SetStatus("Deriving key...")
 
-	key, err := deriveVolumeKey([]byte(req.Password), ctx.Header.Salt, req.Paranoid)
+	// Feed the KDF the NFC-normalized password so new volumes derive a
+	// canonical, cross-platform-stable key regardless of how it was typed (#19).
+	key, err := deriveVolumeKey(pwnorm.EncodeForKDF(req.Password), ctx.Header.Salt, req.Paranoid)
 	if err != nil {
 		return err
 	}

--- a/src/internal/volume/normalization_test.go
+++ b/src/internal/volume/normalization_test.go
@@ -1,0 +1,119 @@
+package volume
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"Picocrypt-NG/internal/encoding"
+)
+
+// decomposedPassword is "é" in NFD (U+0065 U+0301), built from explicit code
+// points so the source literal cannot be silently re-composed by an editor.
+// wantNFCBytes is its NFC UTF-8 encoding (U+00E9) — the UAX #15 worked vector
+// behind issue #19: the same visible password in two byte forms.
+var (
+	decomposedPassword = string([]rune{0x0065, 0x0301})
+	wantNFCBytes       = []byte{0xc3, 0xa9}
+)
+
+// captureKDF installs a KDF hook that records the password bytes handed to the
+// volume / deniability key derivation, while still producing a real (fast,
+// byte-sensitive) key so the surrounding encrypt/decrypt logic runs normally.
+// The returned restore func reverts the hooks.
+func captureKDF(volumePW, deniabilityPW *[]byte) func() {
+	return useTestKDF(
+		func(pw, salt []byte, paranoid bool) ([]byte, error) {
+			if volumePW != nil {
+				*volumePW = append([]byte(nil), pw...)
+			}
+			return fastTestVolumeKey(pw, salt, paranoid)
+		},
+		func(pw, salt []byte) []byte {
+			if deniabilityPW != nil {
+				*deniabilityPW = append([]byte(nil), pw...)
+			}
+			return fastTestDeniabilityKey(pw, salt)
+		},
+	)
+}
+
+func writeTempInput(t *testing.T) string {
+	t.Helper()
+	in := filepath.Join(t.TempDir(), "pt.txt")
+	if err := os.WriteFile(in, []byte("plaintext"), 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	return in
+}
+
+// TestEncryptNormalizesPasswordToNFC asserts the encrypt path feeds the KDF the
+// NFC form of the password, so a volume created from a decomposed (e.g. macOS)
+// password is byte-identical to one created from the composed form — the core
+// of the #19 fix. Before normalization the KDF would see the raw NFD bytes and
+// this fails.
+func TestEncryptNormalizesPasswordToNFC(t *testing.T) {
+	rsCodecs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("RS codecs: %v", err)
+	}
+	in := writeTempInput(t)
+	out := filepath.Join(filepath.Dir(in), "v.txt.pcv")
+
+	var fedToKDF []byte
+	restore := captureKDF(&fedToKDF, nil)
+	defer restore()
+
+	req := &EncryptRequest{
+		InputFile:  in,
+		OutputFile: out,
+		Password:   decomposedPassword,
+		Reporter:   &GoldenTestReporter{},
+		RSCodecs:   rsCodecs,
+	}
+	if err := Encrypt(context.Background(), req); err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	if !bytes.Equal(fedToKDF, wantNFCBytes) {
+		t.Errorf("encrypt fed KDF % x, want NFC % x", fedToKDF, wantNFCBytes)
+	}
+}
+
+// TestEncryptDeniabilityNormalizesPasswordToNFC asserts BOTH the inner volume
+// key and the outer deniability-wrapper key are derived from the NFC form, so a
+// deniable volume is cross-platform-decryptable too (the deniability layer has
+// no readable header, so it relies entirely on a canonical password).
+func TestEncryptDeniabilityNormalizesPasswordToNFC(t *testing.T) {
+	rsCodecs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("RS codecs: %v", err)
+	}
+	in := writeTempInput(t)
+	out := filepath.Join(filepath.Dir(in), "v.txt.pcv")
+
+	var fedToVolume, fedToDeniability []byte
+	restore := captureKDF(&fedToVolume, &fedToDeniability)
+	defer restore()
+
+	req := &EncryptRequest{
+		InputFile:   in,
+		OutputFile:  out,
+		Password:    decomposedPassword,
+		Deniability: true,
+		Reporter:    &GoldenTestReporter{},
+		RSCodecs:    rsCodecs,
+	}
+	if err := Encrypt(context.Background(), req); err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	if !bytes.Equal(fedToVolume, wantNFCBytes) {
+		t.Errorf("inner volume key fed KDF % x, want NFC % x", fedToVolume, wantNFCBytes)
+	}
+	if !bytes.Equal(fedToDeniability, wantNFCBytes) {
+		t.Errorf("deniability wrapper fed KDF % x, want NFC % x", fedToDeniability, wantNFCBytes)
+	}
+}

--- a/src/internal/volume/normalization_test.go
+++ b/src/internal/volume/normalization_test.go
@@ -10,19 +10,18 @@ import (
 	"Picocrypt-NG/internal/encoding"
 )
 
-// decomposedPassword is "é" in NFD (U+0065 U+0301), built from explicit code
-// points so the source literal cannot be silently re-composed by an editor.
-// wantNFCBytes is its NFC UTF-8 encoding (U+00E9) — the UAX #15 worked vector
+// Password forms built from explicit code points (never source literals, which
+// an editor could silently re-normalize). These are the UAX #15 worked vectors
 // behind issue #19: the same visible password in two byte forms.
 var (
-	decomposedPassword = string([]rune{0x0065, 0x0301})
+	composedPassword   = string([]rune{0x00E9})         // é  NFC -> C3 A9
+	decomposedPassword = string([]rune{0x0065, 0x0301}) // é  NFD -> 65 CC 81
 	wantNFCBytes       = []byte{0xc3, 0xa9}
 )
 
-// captureKDF installs a KDF hook that records the password bytes handed to the
+// captureKDF installs a KDF hook recording the password bytes handed to the
 // volume / deniability key derivation, while still producing a real (fast,
-// byte-sensitive) key so the surrounding encrypt/decrypt logic runs normally.
-// The returned restore func reverts the hooks.
+// byte-sensitive) key so the surrounding logic runs normally.
 func captureKDF(volumePW, deniabilityPW *[]byte) func() {
 	return useTestKDF(
 		func(pw, salt []byte, paranoid bool) ([]byte, error) {
@@ -40,6 +39,30 @@ func captureKDF(volumePW, deniabilityPW *[]byte) func() {
 	)
 }
 
+// countingKDF installs a hook that counts volume-key derivations (used to assert
+// how many password-form candidates were tried).
+func countingKDF(count *int) func() {
+	return useTestKDF(
+		func(pw, salt []byte, paranoid bool) ([]byte, error) {
+			*count++
+			return fastTestVolumeKey(pw, salt, paranoid)
+		},
+		fastTestDeniabilityKey,
+	)
+}
+
+// legacyKDF installs an ENCRYPT hook that derives the volume key from fixedPW
+// regardless of the (normalized) input — simulating a pre-normalization volume
+// whose stored key came from raw, un-normalized password bytes.
+func legacyKDF(fixedPW []byte) func() {
+	return useTestKDF(
+		func(_, salt []byte, paranoid bool) ([]byte, error) {
+			return fastTestVolumeKey(fixedPW, salt, paranoid)
+		},
+		fastTestDeniabilityKey,
+	)
+}
+
 func writeTempInput(t *testing.T) string {
 	t.Helper()
 	in := filepath.Join(t.TempDir(), "pt.txt")
@@ -49,11 +72,53 @@ func writeTempInput(t *testing.T) string {
 	return in
 }
 
+// roundTripVolume encrypts plain with encPW then decrypts with decPW, returning
+// the decrypt error (nil on success). On success it also asserts the recovered
+// plaintext matches. Encrypt failures are fatal (not the behavior under test).
+func roundTripVolume(t *testing.T, encPW, decPW string, deniability bool) error {
+	t.Helper()
+	rsCodecs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("RS codecs: %v", err)
+	}
+	dir := t.TempDir()
+	in := filepath.Join(dir, "pt.txt")
+	plain := []byte("secret cross-platform payload")
+	if err := os.WriteFile(in, plain, 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	vol := filepath.Join(dir, "v.txt.pcv")
+	out := filepath.Join(dir, "out.txt")
+
+	if err := Encrypt(context.Background(), &EncryptRequest{
+		InputFile: in, OutputFile: vol, Password: encPW, Deniability: deniability,
+		Reporter: &GoldenTestReporter{}, RSCodecs: rsCodecs,
+	}); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	if err := Decrypt(context.Background(), &DecryptRequest{
+		InputFile: vol, OutputFile: out, Password: decPW, Deniability: deniability,
+		Reporter: &GoldenTestReporter{}, RSCodecs: rsCodecs,
+	}); err != nil {
+		return err
+	}
+
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !bytes.Equal(got, plain) {
+		t.Fatalf("recovered plaintext = %q, want %q", got, plain)
+	}
+	return nil
+}
+
+// --- Phase 2: encrypt-side normalization ---
+
 // TestEncryptNormalizesPasswordToNFC asserts the encrypt path feeds the KDF the
-// NFC form of the password, so a volume created from a decomposed (e.g. macOS)
-// password is byte-identical to one created from the composed form — the core
-// of the #19 fix. Before normalization the KDF would see the raw NFD bytes and
-// this fails.
+// NFC form, so a volume created from a decomposed password is byte-identical to
+// one created from the composed form — the core of the #19 fix.
 func TestEncryptNormalizesPasswordToNFC(t *testing.T) {
 	rsCodecs, err := encoding.NewRSCodecs()
 	if err != nil {
@@ -66,26 +131,20 @@ func TestEncryptNormalizesPasswordToNFC(t *testing.T) {
 	restore := captureKDF(&fedToKDF, nil)
 	defer restore()
 
-	req := &EncryptRequest{
-		InputFile:  in,
-		OutputFile: out,
-		Password:   decomposedPassword,
-		Reporter:   &GoldenTestReporter{},
-		RSCodecs:   rsCodecs,
-	}
-	if err := Encrypt(context.Background(), req); err != nil {
+	if err := Encrypt(context.Background(), &EncryptRequest{
+		InputFile: in, OutputFile: out, Password: decomposedPassword,
+		Reporter: &GoldenTestReporter{}, RSCodecs: rsCodecs,
+	}); err != nil {
 		t.Fatalf("Encrypt: %v", err)
 	}
-
 	if !bytes.Equal(fedToKDF, wantNFCBytes) {
 		t.Errorf("encrypt fed KDF % x, want NFC % x", fedToKDF, wantNFCBytes)
 	}
 }
 
 // TestEncryptDeniabilityNormalizesPasswordToNFC asserts BOTH the inner volume
-// key and the outer deniability-wrapper key are derived from the NFC form, so a
-// deniable volume is cross-platform-decryptable too (the deniability layer has
-// no readable header, so it relies entirely on a canonical password).
+// key and the outer deniability-wrapper key derive from the NFC form (the
+// deniability layer has no readable header, so it relies on a canonical form).
 func TestEncryptDeniabilityNormalizesPasswordToNFC(t *testing.T) {
 	rsCodecs, err := encoding.NewRSCodecs()
 	if err != nil {
@@ -98,22 +157,233 @@ func TestEncryptDeniabilityNormalizesPasswordToNFC(t *testing.T) {
 	restore := captureKDF(&fedToVolume, &fedToDeniability)
 	defer restore()
 
-	req := &EncryptRequest{
-		InputFile:   in,
-		OutputFile:  out,
-		Password:    decomposedPassword,
-		Deniability: true,
-		Reporter:    &GoldenTestReporter{},
-		RSCodecs:    rsCodecs,
-	}
-	if err := Encrypt(context.Background(), req); err != nil {
+	if err := Encrypt(context.Background(), &EncryptRequest{
+		InputFile: in, OutputFile: out, Password: decomposedPassword, Deniability: true,
+		Reporter: &GoldenTestReporter{}, RSCodecs: rsCodecs,
+	}); err != nil {
 		t.Fatalf("Encrypt: %v", err)
 	}
-
 	if !bytes.Equal(fedToVolume, wantNFCBytes) {
 		t.Errorf("inner volume key fed KDF % x, want NFC % x", fedToVolume, wantNFCBytes)
 	}
 	if !bytes.Equal(fedToDeniability, wantNFCBytes) {
 		t.Errorf("deniability wrapper fed KDF % x, want NFC % x", fedToDeniability, wantNFCBytes)
+	}
+}
+
+// --- Phase 3: decrypt-side try-both ---
+
+// TestDecryptTriesNormalizationFormsRoundTrip is the core #19 fix: a volume
+// encrypted from either composed or decomposed input must decrypt from either
+// form. Without decrypt-side try-both, decrypting an NFC-stored volume with the
+// decomposed form fails.
+func TestDecryptTriesNormalizationFormsRoundTrip(t *testing.T) {
+	forms := []struct {
+		name string
+		pw   string
+	}{
+		{"NFC", composedPassword},
+		{"NFD", decomposedPassword},
+	}
+	for _, enc := range forms {
+		for _, dec := range forms {
+			t.Run(enc.name+"_encrypt_"+dec.name+"_decrypt", func(t *testing.T) {
+				if err := roundTripVolume(t, enc.pw, dec.pw, false); err != nil {
+					t.Errorf("cross-form round-trip failed: %v", err)
+				}
+			})
+		}
+	}
+}
+
+// TestDecryptDeniabilityTriesNormalizationForms verifies the deniability
+// unwrap path also tries multiple forms (it selects the key by probing the
+// decrypted inner header).
+func TestDecryptDeniabilityTriesNormalizationForms(t *testing.T) {
+	if err := roundTripVolume(t, decomposedPassword, composedPassword, true); err != nil {
+		t.Errorf("deniable encrypt(NFD) -> decrypt(NFC): %v", err)
+	}
+	if err := roundTripVolume(t, composedPassword, decomposedPassword, true); err != nil {
+		t.Errorf("deniable encrypt(NFC) -> decrypt(NFD): %v", err)
+	}
+}
+
+// TestDecryptOpensLegacyNFDVolumeViaNFDCandidate simulates a pre-normalization
+// volume whose stored key came from raw decomposed bytes. Typing the composed
+// form must still open it: the NFC candidate fails and the NFD candidate matches.
+func TestDecryptOpensLegacyNFDVolumeViaNFDCandidate(t *testing.T) {
+	rsCodecs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("RS codecs: %v", err)
+	}
+	dir := t.TempDir()
+	in := filepath.Join(dir, "pt.txt")
+	plain := []byte("legacy nfd-origin payload")
+	if err := os.WriteFile(in, plain, 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	vol := filepath.Join(dir, "v.txt.pcv")
+	out := filepath.Join(dir, "out.txt")
+
+	// Stored key derives from the raw NFD bytes regardless of normalization.
+	restoreEnc := legacyKDF([]byte(decomposedPassword))
+	encErr := Encrypt(context.Background(), &EncryptRequest{
+		InputFile: in, OutputFile: vol, Password: composedPassword,
+		Reporter: &GoldenTestReporter{}, RSCodecs: rsCodecs,
+	})
+	restoreEnc() // restore the byte-sensitive KDF for decryption
+	if encErr != nil {
+		t.Fatalf("encrypt: %v", encErr)
+	}
+
+	// User types the composed form; only the NFD candidate reproduces the key.
+	if err := Decrypt(context.Background(), &DecryptRequest{
+		InputFile: vol, OutputFile: out, Password: composedPassword,
+		Reporter: &GoldenTestReporter{}, RSCodecs: rsCodecs,
+	}); err != nil {
+		t.Fatalf("legacy NFD volume failed to open via NFD candidate: %v", err)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !bytes.Equal(got, plain) {
+		t.Errorf("recovered plaintext = %q, want %q", got, plain)
+	}
+}
+
+// TestDecryptOpensLegacyRawVolumeViaRawCandidate simulates a legacy volume whose
+// password bytes were neither NFC nor NFD (combining marks in non-canonical
+// order). Only the raw candidate reproduces the key, so dropping raw from the
+// candidate set would lock such volumes out.
+func TestDecryptOpensLegacyRawVolumeViaRawCandidate(t *testing.T) {
+	nonCanonical := string([]rune{0x0065, 0x0301, 0x0323}) // e + acute + dot-below
+	rsCodecs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("RS codecs: %v", err)
+	}
+	dir := t.TempDir()
+	in := filepath.Join(dir, "pt.txt")
+	plain := []byte("legacy non-canonical payload")
+	if err := os.WriteFile(in, plain, 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	vol := filepath.Join(dir, "v.txt.pcv")
+	out := filepath.Join(dir, "out.txt")
+
+	restoreEnc := legacyKDF([]byte(nonCanonical))
+	encErr := Encrypt(context.Background(), &EncryptRequest{
+		InputFile: in, OutputFile: vol, Password: nonCanonical,
+		Reporter: &GoldenTestReporter{}, RSCodecs: rsCodecs,
+	})
+	restoreEnc()
+	if encErr != nil {
+		t.Fatalf("encrypt: %v", encErr)
+	}
+
+	if err := Decrypt(context.Background(), &DecryptRequest{
+		InputFile: vol, OutputFile: out, Password: nonCanonical,
+		Reporter: &GoldenTestReporter{}, RSCodecs: rsCodecs,
+	}); err != nil {
+		t.Fatalf("legacy raw volume failed to open via raw candidate: %v", err)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !bytes.Equal(got, plain) {
+		t.Errorf("recovered plaintext = %q, want %q", got, plain)
+	}
+}
+
+// TestDecryptWrongNonASCIIPasswordFails ensures try-both never accepts a wrong
+// password: after exhausting every candidate form, decryption must fail.
+func TestDecryptWrongNonASCIIPasswordFails(t *testing.T) {
+	wrong := string([]rune{0x00FC}) // ü, a different non-ASCII password
+	if err := roundTripVolume(t, composedPassword, wrong, false); err == nil {
+		t.Fatal("decrypt with a wrong non-ASCII password must fail after trying all forms")
+	}
+}
+
+// TestDecryptASCIIPasswordTriesSingleCandidate locks the performance invariant:
+// an ASCII password collapses to exactly one candidate form, so even a WRONG
+// ASCII password — which exhausts the whole candidate list — runs the (1 GiB)
+// KDF exactly once, not three times. A CORRECT password would short-circuit on
+// the first candidate and mask a regression in the candidate count, so this
+// deliberately uses a wrong password to make the count observable.
+func TestDecryptASCIIPasswordTriesSingleCandidate(t *testing.T) {
+	rsCodecs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("RS codecs: %v", err)
+	}
+	dir := t.TempDir()
+	in := filepath.Join(dir, "pt.txt")
+	if err := os.WriteFile(in, []byte("ascii payload"), 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	vol := filepath.Join(dir, "v.txt.pcv")
+	out := filepath.Join(dir, "out.txt")
+
+	if err := Encrypt(context.Background(), &EncryptRequest{
+		InputFile: in, OutputFile: vol, Password: "ascii-password",
+		Reporter: &GoldenTestReporter{}, RSCodecs: rsCodecs,
+	}); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	var derivations int
+	restore := countingKDF(&derivations)
+	defer restore()
+	// Wrong ASCII password: the candidate loop runs to exhaustion, so the
+	// derivation count equals the number of candidate forms.
+	if err := Decrypt(context.Background(), &DecryptRequest{
+		InputFile: vol, OutputFile: out, Password: "wrong-ascii-password",
+		Reporter: &GoldenTestReporter{}, RSCodecs: rsCodecs,
+	}); err == nil {
+		t.Fatal("decrypt with a wrong password unexpectedly succeeded")
+	}
+	if derivations != 1 {
+		t.Errorf("wrong ASCII password ran %d KDF derivations, want exactly 1 candidate form", derivations)
+	}
+}
+
+// TestDecryptForceDecryptUsesPasswordAsTyped verifies ForceDecrypt derives the
+// key from the password EXACTLY AS TYPED (no normalization). ForceDecrypt
+// bypasses authentication, so there is no MAC to choose a normalization form; it
+// must therefore preserve the historical raw-bytes behavior. Counting
+// derivations cannot catch a regression here (ForceDecrypt always stops at the
+// first candidate regardless), so this captures the bytes handed to the KDF and
+// asserts they are the raw, un-normalized form — not NFC.
+func TestDecryptForceDecryptUsesPasswordAsTyped(t *testing.T) {
+	rsCodecs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("RS codecs: %v", err)
+	}
+	dir := t.TempDir()
+	in := filepath.Join(dir, "pt.txt")
+	if err := os.WriteFile(in, []byte("payload"), 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	vol := filepath.Join(dir, "v.txt.pcv")
+	out := filepath.Join(dir, "out.txt")
+
+	if err := Encrypt(context.Background(), &EncryptRequest{
+		InputFile: in, OutputFile: vol, Password: composedPassword,
+		Reporter: &GoldenTestReporter{}, RSCodecs: rsCodecs,
+	}); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	var fedToKDF []byte
+	restore := captureKDF(&fedToKDF, nil)
+	defer restore()
+	// Decomposed form under ForceDecrypt: the KDF must see the raw decomposed
+	// bytes, not the NFC form that try-both would normalize to.
+	_ = Decrypt(context.Background(), &DecryptRequest{
+		InputFile: vol, OutputFile: out, Password: decomposedPassword, ForceDecrypt: true,
+		Reporter: &GoldenTestReporter{}, RSCodecs: rsCodecs,
+	})
+	if !bytes.Equal(fedToKDF, []byte(decomposedPassword)) {
+		t.Errorf("ForceDecrypt fed KDF % x, want raw as-typed % x (no normalization)", fedToKDF, []byte(decomposedPassword))
 	}
 }

--- a/src/internal/wasm/decrypt.go
+++ b/src/internal/wasm/decrypt.go
@@ -8,6 +8,7 @@ import (
 	"Picocrypt-NG/internal/crypto"
 	"Picocrypt-NG/internal/encoding"
 	"Picocrypt-NG/internal/header"
+	pwnorm "Picocrypt-NG/internal/password"
 	"Picocrypt-NG/internal/util"
 )
 
@@ -45,51 +46,39 @@ func DecryptVolume(volumeData []byte, password string) ([]byte, int) {
 		return nil, ErrUnsupported
 	}
 
-	// Derive key
-	passwordBytes := []byte(password)
-	key, err := crypto.DeriveKey(passwordBytes, hdr.Salt, hdr.Flags.Paranoid)
-	zeroWASMSensitiveBuffer(wasmZeroingDecryptPasswordBytes, passwordBytes)
-	if err != nil {
-		return nil, ErrCorruptedHeader
-	}
-	defer crypto.SecureZero(key)
-
 	// Prepare keyfile hash (zeros since no keyfiles)
 	keyfileHash := make([]byte, 32)
 	defer zeroWASMSensitiveBuffer(wasmZeroingDecryptKeyfileHash, keyfileHash)
 
-	// Initialize HKDF and verify auth based on version
-	var subkeyReader *crypto.SubkeyReader
 	isLegacyV1 := hdr.IsLegacyV1()
 
-	if isLegacyV1 {
-		// v1: Verify password using SHA3-512(key), HKDF uses plain key
-		authResult := header.VerifyV1Header(key, hdr)
-		if !authResult.Valid {
-			return nil, ErrWrongPassword
-		}
-
-		// v1: HKDF with plain key (no keyfile XOR since web doesn't support keyfiles)
-		hkdfStream := crypto.NewHKDFStream(key, hdr.HKDFSalt)
-		subkeyReader = crypto.NewSubkeyReader(hkdfStream)
-	} else {
-		// v2: Initialize HKDF first, then verify header MAC
-		hkdfStream := crypto.NewHKDFStream(key, hdr.HKDFSalt)
-		subkeyReader = crypto.NewSubkeyReader(hkdfStream)
-
-		// Read header subkey for verification
-		subkeyHeader, err := subkeyReader.HeaderSubkey()
+	// Derive the key, trying each password normalization form (NFC/NFD/raw) until
+	// one authenticates against the header (#19). ASCII passwords yield a single
+	// candidate, so there is no extra KDF work for the common case.
+	var key []byte
+	var subkeyReader *crypto.SubkeyReader
+	for _, cand := range pwnorm.Candidates(password) {
+		k, err := crypto.DeriveKey(cand, hdr.Salt, hdr.Flags.Paranoid)
+		zeroWASMSensitiveBuffer(wasmZeroingDecryptPasswordBytes, cand)
 		if err != nil {
 			return nil, ErrCorruptedHeader
 		}
-
-		// Verify header MAC
-		authResult := header.VerifyV2Header(subkeyHeader, hdr, keyfileHash)
-		zeroWASMSensitiveBuffer(wasmZeroingDecryptHeaderSubkey, subkeyHeader)
-		if !authResult.Valid {
-			return nil, ErrWrongPassword
+		valid, sr, errCode := verifyWASMHeader(k, hdr, keyfileHash, isLegacyV1)
+		if errCode != 0 {
+			crypto.SecureZero(k)
+			return nil, errCode
 		}
+		if valid {
+			key = k
+			subkeyReader = sr
+			break
+		}
+		crypto.SecureZero(k)
 	}
+	if key == nil {
+		return nil, ErrWrongPassword
+	}
+	defer crypto.SecureZero(key)
 
 	// Read remaining subkeys
 	macSubkey, err := subkeyReader.MACSubkey()
@@ -153,6 +142,36 @@ func DecryptVolume(volumeData []byte, password string) ([]byte, int) {
 	}
 
 	return plaintext, 0
+}
+
+// verifyWASMHeader checks whether key authenticates the volume header and, on
+// success, returns the HKDF subkey reader positioned for the remaining subkey
+// reads. valid is false for a wrong key (a candidate password form that does not
+// match); errCode is non-zero only for a hard failure (corrupted header), not
+// for a wrong password.
+func verifyWASMHeader(key []byte, hdr *header.VolumeHeader, keyfileHash []byte, isLegacyV1 bool) (valid bool, sr *crypto.SubkeyReader, errCode int) {
+	if isLegacyV1 {
+		// v1: verify password via SHA3-512(key); HKDF uses the plain key.
+		if !header.VerifyV1Header(key, hdr).Valid {
+			return false, nil, 0
+		}
+		hkdfStream := crypto.NewHKDFStream(key, hdr.HKDFSalt)
+		return true, crypto.NewSubkeyReader(hkdfStream), 0
+	}
+
+	// v2: initialize HKDF, then verify the header MAC.
+	hkdfStream := crypto.NewHKDFStream(key, hdr.HKDFSalt)
+	reader := crypto.NewSubkeyReader(hkdfStream)
+	subkeyHeader, err := reader.HeaderSubkey()
+	if err != nil {
+		return false, nil, ErrCorruptedHeader
+	}
+	authValid := header.VerifyV2Header(subkeyHeader, hdr, keyfileHash).Valid
+	zeroWASMSensitiveBuffer(wasmZeroingDecryptHeaderSubkey, subkeyHeader)
+	if !authValid {
+		return false, nil, 0
+	}
+	return true, reader, 0
 }
 
 func hasUnsupportedWASMFeature(flags header.Flags) bool {

--- a/src/internal/wasm/encrypt.go
+++ b/src/internal/wasm/encrypt.go
@@ -7,6 +7,7 @@ import (
 	"Picocrypt-NG/internal/crypto"
 	"Picocrypt-NG/internal/encoding"
 	"Picocrypt-NG/internal/header"
+	pwnorm "Picocrypt-NG/internal/password"
 	"Picocrypt-NG/internal/util"
 )
 
@@ -128,8 +129,9 @@ func EncryptVolume(plaintext []byte, password string) ([]byte, int) {
 		Padded:         false,
 	}
 
-	// Derive key
-	passwordBytes := []byte(password)
+	// Derive key from the NFC-normalized password (#19) so web-encrypted
+	// volumes are cross-platform-decryptable regardless of how it was typed.
+	passwordBytes := pwnorm.EncodeForKDF(password)
 	key, err := crypto.DeriveKey(passwordBytes, salt, false)
 	zeroWASMSensitiveBuffer(wasmZeroingPasswordBytes, passwordBytes)
 	if err != nil {

--- a/src/internal/wasm/normalization_test.go
+++ b/src/internal/wasm/normalization_test.go
@@ -1,0 +1,35 @@
+package wasm
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Built from explicit code points so the source literal cannot be silently
+// re-normalized: nfdPassword is "é" decomposed (U+0065 U+0301), nfcPassword is
+// the composed form (U+00E9). Same visible password, different bytes.
+var (
+	nfdPassword = string([]rune{0x0065, 0x0301})
+	nfcPassword = string([]rune{0x00E9})
+)
+
+// TestWASMEncryptNormalizesPassword proves the web build normalizes the
+// password to NFC on encrypt: a volume created with the decomposed form must
+// decrypt with the composed form (#19). Without normalization the two forms
+// derive different Argon2 keys and decryption fails with ErrWrongPassword.
+func TestWASMEncryptNormalizesPassword(t *testing.T) {
+	original := []byte("cross-platform web volume")
+
+	ciphertext, errCode := EncryptVolume(original, nfdPassword)
+	if errCode != 0 {
+		t.Fatalf("encrypt failed with error code %d", errCode)
+	}
+
+	plaintext, errCode := DecryptVolume(ciphertext, nfcPassword)
+	if errCode != 0 {
+		t.Fatalf("decrypt with composed form failed (code %d): encrypt did not normalize to NFC", errCode)
+	}
+	if !bytes.Equal(plaintext, original) {
+		t.Errorf("roundtrip mismatch\ngot:  %q\nwant: %q", plaintext, original)
+	}
+}

--- a/src/internal/wasm/normalization_test.go
+++ b/src/internal/wasm/normalization_test.go
@@ -33,3 +33,34 @@ func TestWASMEncryptNormalizesPassword(t *testing.T) {
 		t.Errorf("roundtrip mismatch\ngot:  %q\nwant: %q", plaintext, original)
 	}
 }
+
+// TestWASMDecryptTriesNormalizationForms proves the web decrypt path tries
+// multiple password forms: a volume stored under the NFC form must also open
+// when the user types the decomposed form (#19). Without decrypt-side try-both
+// the decomposed form derives a different key and fails with ErrWrongPassword.
+func TestWASMDecryptTriesNormalizationForms(t *testing.T) {
+	cases := []struct {
+		name    string
+		encrypt string
+		decrypt string
+	}{
+		{"NFC_encrypt_NFD_decrypt", nfcPassword, nfdPassword},
+		{"NFD_encrypt_NFC_decrypt", nfdPassword, nfcPassword},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := []byte("web cross-form payload")
+			ciphertext, errCode := EncryptVolume(original, tc.encrypt)
+			if errCode != 0 {
+				t.Fatalf("encrypt failed with error code %d", errCode)
+			}
+			plaintext, errCode := DecryptVolume(ciphertext, tc.decrypt)
+			if errCode != 0 {
+				t.Fatalf("decrypt failed with error code %d (try-both not applied?)", errCode)
+			}
+			if !bytes.Equal(plaintext, original) {
+				t.Errorf("roundtrip mismatch\ngot:  %q\nwant: %q", plaintext, original)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #19.

## Problem
A visually identical password can be encoded as different UTF-8 bytes depending on the platform's keyboard/input method (composed `é` U+00E9 vs decomposed `e`+U+0301). Because the password bytes feed Argon2id directly with no normalization, the two forms derive different keys — so a volume encrypted with a non-ASCII password on one OS may not decrypt on another.

## Approach (researched against primary sources)
Normalize to **Unicode NFC** — mandated for passwords by [RFC 8265](https://www.rfc-editor.org/rfc/rfc8265) (PRECIS `OpaqueString`), recommended by NIST SP 800-63B-4 §3.1.1.2, and the canonical form per [UAX #15](https://www.unicode.org/reports/tr15/). Deliberately **not** NFKC/NFKD (collapses distinct chars, cuts entropy), **no** case folding (RFC 8265 omits it; Turkish dotless-i class), **no** whitespace trimming.

Design is asymmetric and backward-compatible:
- **Encrypt** → always NFC (incl. the deniability wrapper key). New volumes are cross-platform-stable.
- **Decrypt** → try `[NFC, NFD, raw]` in order, keep the first that authenticates against the volume MAC. Opens new volumes, pre-existing NFC/ASCII volumes, and legacy volumes encrypted from decomposed/non-canonical bytes.
- **ASCII fast-path** → invariant under every form ⇒ a single candidate, **zero** extra key derivations for the overwhelming majority of volumes.
- **No header flag / no format bump** — the v2 header MAC gives cheap wrong-key detection, and deniable volumes have no readable header anyway, so a uniform try-both is simpler and works everywhere.
- **Force-decrypt** bypasses auth (no signal to pick a form) ⇒ uses the password exactly as typed.

Trying several canonical forms of the *same* password never bypasses authentication — each form is verified independently; constant-time MAC compare is preserved.

## What's included
- `internal/password` — `Normalize`, `EncodeForKDF`, `Candidates`, `ContainsNonASCII`.
- Encrypt-NFC at every chokepoint: `internal/volume` (CLI/GUI/mobile), `AddDeniability`, and `internal/wasm` (web build bypasses `volume`).
- Decrypt try-both: `volume.Decrypt` (candidate loop, winning form reused by RS-retry / verify-first), `RemoveDeniability` (probes the inner version field to select the key, then streams once — fail-fast), `wasm.DecryptVolume`.
- **Advisory** when encrypting with a non-ASCII password: a subtle GUI hint (encrypt mode only) + a one-line CLI note (NIST SP 800-63B-4 advises informing users).
- Docs: `Internals.md` "Password Normalization" + `Changelog.md` v2.15.

## Compatibility
- ASCII passwords and all existing ASCII/NFC volumes: **unchanged**.
- Forward caveat (documented): a *new* non-ASCII-password volume may not open in an *older* Picocrypt build that doesn't normalize, unless the exact stored bytes are typed — hence the advisory.

## Testing
- Cross-form round-trip matrix (NFC/NFD × NFC/NFD), legacy NFD-origin and non-canonical-raw volumes opened via the NFD/raw candidates, wrong-password failure, deniability + WASM cross-form, ASCII single-derivation and force-decrypt-as-typed **guards mutation-verified** (they fail under injected regressions), UAX #15 byte-vector guards (built from code points so editors can't re-normalize them vacuously).
- `go test ./...` green; `internal/volume` + `internal/ui` pass `-race`; `gofmt`, `go vet`, `golangci-lint` (0 issues), `gosec` (0 issues) clean. Commits SSH-signed.

## Out of scope (follow-up)
Opt-in **re-encryption migration** of legacy non-ASCII volumes to NFC — non-urgent because try-both already opens them, and it has its own CLI/GUI surface. Tracked separately.
