### PR TITLE
feat(android): folder & multi-file encryption + Compress toggle (#9)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -105,6 +105,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.documentfile)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)

--- a/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/FileCopyServiceTest.kt
+++ b/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/FileCopyServiceTest.kt
@@ -236,7 +236,24 @@ class FileCopyServiceTest {
         assertFalse("Output file should be deleted", outputFile.exists())
         assertTrue("Input file should remain", inputFile.exists())
     }
-    
+
+    @Test
+    fun cleanupOperationFilesBeforeStart_preservesStagingTree() = runTest {
+        // Bug 2 regression: staged folder/multi-file inputs live under staging/ and are the
+        // very inputs the operation is about to read. Pre-start cleanup must not wipe them
+        // (staging hygiene is owned by StagingService.wipeStaging at pick time and
+        // clearOperation after the op), or Go would get paths to deleted files.
+        val staged = File(context.filesDir, "picocrypt_files/staging/MyDocs")
+        staged.mkdirs()
+        val a = File(staged, "a.txt").apply { writeText("a") }
+
+        FileCopyService.cleanupOperationFilesBeforeStart(context)
+
+        assertTrue("staged input must survive pre-start cleanup", a.exists())
+        // cleanup
+        File(context.filesDir, "picocrypt_files/staging").deleteRecursively()
+    }
+
     @Test
     fun deleteFile_removes_existing_file() = runTest {
         val internalDir = File(context.filesDir, "picocrypt_files")

--- a/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/StagingServiceInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/io/github/picocrypt_ng/picocrypt_ng/StagingServiceInstrumentedTest.kt
@@ -1,0 +1,34 @@
+package io.github.picocrypt_ng.picocrypt_ng
+
+import androidx.documentfile.provider.DocumentFile
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class StagingServiceInstrumentedTest {
+    private val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    @Test fun stageTree_preservesStructure() = runBlocking {
+        val src = File(ctx.cacheDir, "srctree").apply { deleteRecursively(); mkdirs() }
+        File(src, "sub").mkdirs()
+        File(src, "a.txt").writeText("a")
+        File(src, "sub/b.txt").writeText("b")
+
+        val tree = DocumentFile.fromFile(src)
+        val sel = StagingService.stageTree(ctx, tree).getOrThrow()
+        assertEquals(SelectionKind.FOLDER, sel.kind)
+        assertEquals("srctree.zip.pcv", sel.suggestedOutputName)
+        assertEquals(2, sel.inputFiles.size)
+        assertTrue(sel.inputFiles.any { it.endsWith("/srctree/a.txt") })
+        assertTrue(sel.inputFiles.any { it.endsWith("/srctree/sub/b.txt") })
+        assertEquals(1, sel.onlyFolders.size)
+        assertTrue(sel.onlyFolders[0].endsWith("/staging/srctree"))
+        StagingService.wipeStaging(ctx)
+    }
+}

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/AppError.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/AppError.kt
@@ -108,6 +108,15 @@ sealed class AppError(
             userMessage: String = "Failed to save file",
             technicalMessage: String? = null
         ) : FileError(userMessage, technicalMessage)
+
+        /**
+         * Internal storage cannot hold the staged copy + temp zip + output volume.
+         * Folder/multi-file encryption peaks at ~3x the selection size before cleanup.
+         */
+        class InsufficientStorage(
+            userMessage: String = "Not enough free space to encrypt this selection",
+            technicalMessage: String? = null
+        ) : FileError(userMessage, technicalMessage)
     }
     
     /**

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FileCopyService.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FileCopyService.kt
@@ -408,9 +408,6 @@ object FileCopyService {
             // Clean up any remaining incomplete files (but not input/keyfiles)
             cleanupIncompleteFiles(context)
 
-            // Folder/multi-file staging tree (StagingService) is a subtree, not flat files -- wipe it whole.
-            File(internalDir, "staging").deleteRecursively()
-
             allSuccess
         } catch (e: CancellationException) {
             throw e

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FileCopyService.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FileCopyService.kt
@@ -407,7 +407,10 @@ object FileCopyService {
             
             // Clean up any remaining incomplete files (but not input/keyfiles)
             cleanupIncompleteFiles(context)
-            
+
+            // Folder/multi-file staging tree (StagingService) is a subtree, not flat files -- wipe it whole.
+            File(internalDir, "staging").deleteRecursively()
+
             allSuccess
         } catch (e: CancellationException) {
             throw e

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FormData.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FormData.kt
@@ -28,6 +28,7 @@ data class FormData(
     val verifyFirst: Boolean = false,
     val keyfileFilenames: List<KeyfileInfo>, // Keyfile info with internal path and display name
     val keyfileOrdered: Boolean,
+    val compress: Boolean = false,
     val decryptionInfo: DecryptionInfo? = null
 ) {
     val isDecrypt: Boolean
@@ -88,6 +89,7 @@ data class FormData(
         if (verifyFirst != other.verifyFirst) return false
         if (keyfileFilenames != other.keyfileFilenames) return false
         if (keyfileOrdered != other.keyfileOrdered) return false
+        if (compress != other.compress) return false
         if (decryptionInfo != other.decryptionInfo) return false
         
         return true
@@ -105,6 +107,7 @@ data class FormData(
         result = 31 * result + verifyFirst.hashCode()
         result = 31 * result + keyfileFilenames.hashCode()
         result = 31 * result + keyfileOrdered.hashCode()
+        result = 31 * result + compress.hashCode()
         result = 31 * result + (decryptionInfo?.hashCode() ?: 0)
         return result
     }

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FormData.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FormData.kt
@@ -53,6 +53,14 @@ data class FormData(
         get() = passwordInput.isNotEmpty() && ((isEncrypt && isPasswordsMatch) || isDecrypt)
 
     /**
+     * True when a concrete input is selected: a single copied file, or a staged
+     * folder/multi-file selection. WorkButton gates the Encrypt button on this so
+     * folder/multi selections (which have an empty copiedFilePath) are not blocked.
+     */
+    val hasSelectedInput: Boolean
+        get() = copiedFilePath.isNotEmpty() || inputFiles.isNotEmpty()
+
+    /**
      * True when the selected file is a numbered split-volume chunk (e.g. secret.pcv.0).
      * Mirrors Go fileops.IsSplitChunkPath. Android cannot recombine chunks (single-file
      * picker, no sibling access), so such files are rejected loudly rather than run --

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FormData.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FormData.kt
@@ -29,12 +29,24 @@ data class FormData(
     val keyfileFilenames: List<KeyfileInfo>, // Keyfile info with internal path and display name
     val keyfileOrdered: Boolean,
     val compress: Boolean = false,
+    // Folder/multi-file selection (StagingService output). For SINGLE_FILE these stay
+    // empty and copiedFilePath carries the one input; for FOLDER/MULTI_FILE the staged
+    // tree is forwarded to Go as these arrays and copiedFilePath is empty.
+    val inputFiles: List<String> = emptyList(),
+    val onlyFolders: List<String> = emptyList(),
+    val onlyFiles: List<String> = emptyList(),
+    val selectionKind: SelectionKind = SelectionKind.SINGLE_FILE,
+    val suggestedOutputName: String = "",
     val decryptionInfo: DecryptionInfo? = null
 ) {
+    // A folder/multi selection always encrypts (Go zips it) and is never a decrypt or a
+    // split-volume chunk -- those are single-file concepts keyed off the filename.
     val isDecrypt: Boolean
-        get() = selectedFilename.isNotEmpty() && selectedFilename.endsWith(".pcv")
+        get() = selectionKind == SelectionKind.SINGLE_FILE &&
+            selectedFilename.isNotEmpty() && selectedFilename.endsWith(".pcv")
     val isEncrypt: Boolean
-        get() = selectedFilename.isNotEmpty() && !selectedFilename.endsWith(".pcv")
+        get() = selectionKind != SelectionKind.SINGLE_FILE ||
+            (selectedFilename.isNotEmpty() && !selectedFilename.endsWith(".pcv"))
     val isPasswordsMatch: Boolean
         get() = passwordInput.contentEquals(confirmPasswordInput)
     val isPasswordValid: Boolean
@@ -48,7 +60,7 @@ data class FormData(
      * target and double-encrypted.
      */
     val isSplitVolumeChunk: Boolean
-        get() = isSplitVolumeChunkName(selectedFilename)
+        get() = selectionKind == SelectionKind.SINGLE_FILE && isSplitVolumeChunkName(selectedFilename)
     
     /**
      * Clears password fields by zeroing the character arrays.
@@ -90,8 +102,13 @@ data class FormData(
         if (keyfileFilenames != other.keyfileFilenames) return false
         if (keyfileOrdered != other.keyfileOrdered) return false
         if (compress != other.compress) return false
+        if (inputFiles != other.inputFiles) return false
+        if (onlyFolders != other.onlyFolders) return false
+        if (onlyFiles != other.onlyFiles) return false
+        if (selectionKind != other.selectionKind) return false
+        if (suggestedOutputName != other.suggestedOutputName) return false
         if (decryptionInfo != other.decryptionInfo) return false
-        
+
         return true
     }
     
@@ -108,6 +125,11 @@ data class FormData(
         result = 31 * result + keyfileFilenames.hashCode()
         result = 31 * result + keyfileOrdered.hashCode()
         result = 31 * result + compress.hashCode()
+        result = 31 * result + inputFiles.hashCode()
+        result = 31 * result + onlyFolders.hashCode()
+        result = 31 * result + onlyFiles.hashCode()
+        result = 31 * result + selectionKind.hashCode()
+        result = 31 * result + suggestedOutputName.hashCode()
         result = 31 * result + (decryptionInfo?.hashCode() ?: 0)
         return result
     }

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/GoBridge.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/GoBridge.kt
@@ -133,11 +133,16 @@ object GoBridge {
         inputFile: String,
         outputFile: String,
         password: ByteArray,
-        options: EncryptOptions
+        options: EncryptOptions,
+        inputFiles: List<String> = emptyList(),
+        onlyFolders: List<String> = emptyList(),
+        onlyFiles: List<String> = emptyList()
     ): Result<Unit> {
         return try {
             // Build JSON request (password is passed separately as bytes, never in JSON)
-            val requestJson = buildEncryptRequestJson(operationID, inputFile, outputFile, options)
+            val requestJson = buildEncryptRequestJson(
+                operationID, inputFile, outputFile, options, inputFiles, onlyFolders, onlyFiles
+            )
 
             // Note: gomobile copies the array across JNI; that transient bridge copy is not reachable for zeroing (intrinsic to the binding).
             val errorMsg = Mobile.startEncrypt(requestJson, password)
@@ -276,10 +281,18 @@ object GoBridge {
         operationID: String,
         inputFile: String,
         outputFile: String,
-        options: EncryptOptions
+        options: EncryptOptions,
+        inputFiles: List<String> = emptyList(),
+        onlyFolders: List<String> = emptyList(),
+        onlyFiles: List<String> = emptyList()
     ): String = JSONObject().apply {
         put("operationID", operationID)
         put("inputFile", inputFile)
+        // Folder/multi-file selection arrays forwarded to the Go core (it zips them).
+        // Always present (empty for the single-file path) so the Go side reads a stable shape.
+        put("inputFiles", JSONArray().apply { inputFiles.forEach { put(it) } })
+        put("onlyFolders", JSONArray().apply { onlyFolders.forEach { put(it) } })
+        put("onlyFiles", JSONArray().apply { onlyFiles.forEach { put(it) } })
         put("outputFile", outputFile)
         put("comments", options.comments)
         put("keyfiles", JSONArray().apply { options.keyfiles.forEach { put(it) } })

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/MainViewModel.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/MainViewModel.kt
@@ -138,6 +138,11 @@ class MainViewModel(
                 copiedFilePath = "",
                 comments = "",
                 keyfileFilenames = emptyList(),
+                inputFiles = emptyList(),
+                onlyFolders = emptyList(),
+                onlyFiles = emptyList(),
+                selectionKind = SelectionKind.SINGLE_FILE,
+                suggestedOutputName = "",
                 decryptionInfo = null
             )
             
@@ -173,6 +178,11 @@ class MainViewModel(
             verifyFirst = false,
             keyfileFilenames = emptyList(),
             keyfileOrdered = false,
+            inputFiles = emptyList(),
+            onlyFolders = emptyList(),
+            onlyFiles = emptyList(),
+            selectionKind = SelectionKind.SINGLE_FILE,
+            suggestedOutputName = "",
             decryptionInfo = null
         )
         _formState.value = reset

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationManager.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationManager.kt
@@ -57,7 +57,7 @@ object OperationManager {
             paranoid = formData.paranoid,
             reedSolomon = formData.reedSolomon,
             deniability = formData.deniability,
-            compress = false, // Not supported in UI yet
+            compress = formData.compress,
             keyfiles = formData.keyfileFilenames.map { it.internalPath },
             keyfileOrdered = formData.keyfileOrdered
         )

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationManager.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/OperationManager.kt
@@ -23,14 +23,21 @@ object OperationManager {
         context: Context,
         formData: FormData
     ): Result<String> = withContext(Dispatchers.IO) {
-        if (formData.copiedFilePath.isEmpty()) {
+        // A folder/multi-file selection encrypts the staged tree (inputFiles), not a
+        // single copiedFilePath. Validate the right source per selection kind.
+        val isMulti = formData.selectionKind != SelectionKind.SINGLE_FILE
+        if (!isMulti && formData.copiedFilePath.isEmpty()) {
+            return@withContext Result.failure(AppError.ValidationError.NoFileSelected)
+        }
+        if (isMulti && formData.inputFiles.isEmpty()) {
             return@withContext Result.failure(AppError.ValidationError.NoFileSelected)
         }
 
         // A numbered split-volume chunk (secret.pcv.0) does not end in .pcv, so it lands
         // on the encrypt path and would be DOUBLE-ENCRYPTED. Android cannot recombine
-        // (single-file picker), so reject it loudly before any work.
-        if (formData.isSplitVolumeChunk) {
+        // (single-file picker), so reject it loudly before any work. Only meaningful for
+        // a single-file selection (isSplitVolumeChunk is already SINGLE_FILE-gated).
+        if (!isMulti && formData.isSplitVolumeChunk) {
             return@withContext Result.failure(AppError.ValidationError.SplitVolumeNotSupported)
         }
 
@@ -46,7 +53,9 @@ object OperationManager {
         // Clean up old files before starting new operation to prevent contamination
         FileCopyService.cleanupOperationFilesBeforeStart(context)
 
-        // Generate output file path using FileCopyService
+        // Generate output file path using FileCopyService. For encrypt this is a fixed
+        // output_file.pcv regardless of the input path, so an empty copiedFilePath (multi
+        // selection) is fine.
         val outputFilePath = FileCopyService.getOutputFilePath(context, formData.copiedFilePath, isEncrypt = true)
 
         // Start operation
@@ -61,14 +70,19 @@ object OperationManager {
             keyfiles = formData.keyfileFilenames.map { it.internalPath },
             keyfileOrdered = formData.keyfileOrdered
         )
-        
+
         // Encode the password to UTF-8 bytes without a String; GoBridge zeroes them.
+        // For a multi selection the single inputFile is empty and the staged arrays carry
+        // the inputs; for a single file the arrays are empty (the degenerate case).
         val result = GoBridge.startEncrypt(
             operationID,
-            formData.copiedFilePath,
+            if (isMulti) "" else formData.copiedFilePath,
             outputFilePath,
             formData.passwordInput.toUtf8BytesSecure(),
-            options
+            options,
+            inputFiles = formData.inputFiles,
+            onlyFolders = formData.onlyFolders,
+            onlyFiles = formData.onlyFiles
         )
         
         result.onSuccess {
@@ -242,8 +256,13 @@ object OperationManager {
                 outputFilePath = operation.outputFile,
                 keyfilePaths = keyfilePaths
             )
+
+            // A folder/multi selection stages plaintext copies under STAGING_DIR that the
+            // per-file cleanup above does not cover (it only knows the single input path).
+            // Wipe the staging tree so plaintext does not linger after the operation.
+            StagingService.wipeStaging(context)
         }
-        
+
         _currentOperation.value = null
     }
     

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/StagingService.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/StagingService.kt
@@ -1,0 +1,146 @@
+package io.github.picocrypt_ng.picocrypt_ng
+
+import android.content.Context
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+
+enum class SelectionKind { SINGLE_FILE, MULTI_FILE, FOLDER }
+
+data class StagedSelection(
+    val kind: SelectionKind,
+    val displayName: String,
+    val stagingRoot: String,
+    val inputFiles: List<String>,
+    val onlyFolders: List<String>,
+    val onlyFiles: List<String>,
+    val suggestedOutputName: String,
+)
+
+object StagingService {
+    private const val STAGING_DIR = "picocrypt_files/staging"
+
+    // ---- pure helpers (JVM-testable) ----
+    fun resolveCollision(existing: Set<String>, name: String): String {
+        if (name !in existing) return name
+        val dot = name.lastIndexOf('.')
+        val stem = if (dot > 0) name.substring(0, dot) else name
+        val ext = if (dot > 0) name.substring(dot) else ""
+        var i = 1
+        while ("$stem ($i)$ext" in existing) i++
+        return "$stem ($i)$ext"
+    }
+    fun folderOutputName(rootName: String): String = "$rootName.zip.pcv"
+    fun multiFileOutputName(unixSeconds: Long): String = "encrypted-$unixSeconds.zip.pcv"
+
+    // ---- IO ----
+    private fun stagingDir(context: Context): File = File(context.filesDir, STAGING_DIR).also { it.mkdirs() }
+    fun wipeStaging(context: Context) { File(context.filesDir, STAGING_DIR).deleteRecursively() }
+
+    suspend fun copyTreeToStaging(context: Context, treeUri: Uri): Result<StagedSelection> =
+        withContext(Dispatchers.IO) {
+            val tree = DocumentFile.fromTreeUri(context, treeUri)
+                ?: return@withContext Result.failure(copyError("Could not open folder", "$treeUri"))
+            stageTree(context, tree)
+        }
+
+    internal suspend fun stageTree(context: Context, tree: DocumentFile): Result<StagedSelection> =
+        withContext(Dispatchers.IO) {
+            try {
+                wipeStaging(context)
+                val rootName = tree.name ?: "folder"
+                val root = File(stagingDir(context), rootName)
+                val files = mutableListOf<String>()
+                copyChildren(context, tree, root, files)
+                if (files.isEmpty()) return@withContext Result.failure(copyError("The selected folder is empty", rootName))
+                Result.success(
+                    StagedSelection(
+                        kind = SelectionKind.FOLDER,
+                        displayName = rootName,
+                        stagingRoot = stagingDir(context).absolutePath,
+                        inputFiles = files,
+                        onlyFolders = listOf(root.absolutePath),
+                        onlyFiles = emptyList(),
+                        suggestedOutputName = folderOutputName(rootName),
+                    )
+                )
+            } catch (e: CancellationException) {
+                wipeStaging(context); throw e
+            } catch (e: Exception) {
+                wipeStaging(context)
+                Result.failure(copyError("Failed to read folder: ${e.message ?: "error"}", e.message))
+            }
+        }
+
+    private fun copyChildren(context: Context, dir: DocumentFile, dest: File, out: MutableList<String>) {
+        dest.mkdirs()
+        for (child in dir.listFiles()) {
+            if (child.isVirtual) continue
+            val name = child.name ?: continue
+            when {
+                child.isDirectory -> copyChildren(context, child, File(dest, name), out)
+                child.isFile -> {
+                    val target = File(dest, name)
+                    context.contentResolver.openInputStream(child.uri)?.use { input ->
+                        FileOutputStream(target).use { output -> input.copyTo(output) }
+                    } ?: throw IllegalStateException("could not open ${child.uri}")
+                    out.add(target.absolutePath)
+                }
+            }
+        }
+    }
+
+    suspend fun copyFilesToStaging(context: Context, uris: List<Uri>, nowUnixSeconds: Long): Result<StagedSelection> =
+        withContext(Dispatchers.IO) {
+            try {
+                wipeStaging(context)
+                val dir = stagingDir(context)
+                val used = mutableSetOf<String>()
+                val files = mutableListOf<String>()
+                for (uri in uris) {
+                    val display = queryDisplayName(context, uri) ?: "file"
+                    val name = resolveCollision(used, display)
+                    used.add(name)
+                    val target = File(dir, name)
+                    context.contentResolver.openInputStream(uri)?.use { input ->
+                        FileOutputStream(target).use { output -> input.copyTo(output) }
+                    } ?: return@withContext Result.failure(copyError("Could not open a selected file", "$uri"))
+                    files.add(target.absolutePath)
+                }
+                if (files.isEmpty()) return@withContext Result.failure(copyError("No files selected", null))
+                Result.success(
+                    StagedSelection(
+                        kind = SelectionKind.MULTI_FILE,
+                        displayName = if (files.size == 1) used.first() else "${files.size} files",
+                        stagingRoot = dir.absolutePath,
+                        inputFiles = files,
+                        onlyFolders = emptyList(),
+                        onlyFiles = files,
+                        suggestedOutputName = multiFileOutputName(nowUnixSeconds),
+                    )
+                )
+            } catch (e: CancellationException) {
+                wipeStaging(context); throw e
+            } catch (e: Exception) {
+                wipeStaging(context)
+                Result.failure(copyError("Failed to copy files: ${e.message ?: "error"}", e.message))
+            }
+        }
+
+    private fun queryDisplayName(context: Context, uri: Uri): String? {
+        context.contentResolver.query(uri, null, null, null, null)?.use { c ->
+            if (c.moveToFirst()) {
+                val i = c.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+                if (i != -1) return c.getString(i)
+            }
+        }
+        return null
+    }
+
+    private fun copyError(user: String, tech: String?) =
+        AppError.FileError.CopyFailed(userMessage = user, technicalMessage = tech)
+}

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/StagingService.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/StagingService.kt
@@ -37,6 +37,30 @@ object StagingService {
     fun folderOutputName(rootName: String): String = "$rootName.zip.pcv"
     fun multiFileOutputName(unixSeconds: Long): String = "encrypted-$unixSeconds.zip.pcv"
 
+    const val SPACE_MARGIN_BYTES: Long = 16L * 1024 * 1024 // 16 MiB headroom
+
+    /** Peak internal usage ~= staged copy + encrypted temp zip + output volume, before cleanup. */
+    fun requiredBytes(total: Long): Long = 3L * total + SPACE_MARGIN_BYTES
+    fun hasSpaceFor(total: Long, usable: Long): Boolean = usable >= requiredBytes(total)
+
+    private fun usableSpace(context: Context): Long =
+        File(context.filesDir, STAGING_DIR).let { it.mkdirs(); it.usableSpace }
+
+    private fun treeSize(dir: DocumentFile): Long {
+        var sum = 0L
+        for (c in dir.listFiles()) {
+            if (c.isVirtual) continue
+            sum += if (c.isDirectory) treeSize(c) else c.length()
+        }
+        return sum
+    }
+
+    private fun insufficient(total: Long, usable: Long) = AppError.FileError.InsufficientStorage(
+        userMessage = "Not enough free space. This selection needs about " +
+            "${requiredBytes(total) / (1024 * 1024)} MiB free; ${usable / (1024 * 1024)} MiB available.",
+        technicalMessage = "required=${requiredBytes(total)} usable=$usable",
+    )
+
     // ---- IO ----
     private fun stagingDir(context: Context): File = File(context.filesDir, STAGING_DIR).also { it.mkdirs() }
     fun wipeStaging(context: Context) { File(context.filesDir, STAGING_DIR).deleteRecursively() }
@@ -52,6 +76,9 @@ object StagingService {
         withContext(Dispatchers.IO) {
             try {
                 wipeStaging(context)
+                val total = treeSize(tree)
+                val usable = usableSpace(context)
+                if (!hasSpaceFor(total, usable)) return@withContext Result.failure(insufficient(total, usable))
                 val rootName = tree.name ?: "folder"
                 val root = File(stagingDir(context), rootName)
                 val files = mutableListOf<String>()
@@ -98,6 +125,9 @@ object StagingService {
         withContext(Dispatchers.IO) {
             try {
                 wipeStaging(context)
+                val total = uris.sumOf { DocumentFile.fromSingleUri(context, it)?.length() ?: 0L }
+                val usable = usableSpace(context)
+                if (!hasSpaceFor(total, usable)) return@withContext Result.failure(insufficient(total, usable))
                 val dir = stagingDir(context)
                 val used = mutableSetOf<String>()
                 val files = mutableListOf<String>()

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/AdvancedCard.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/AdvancedCard.kt
@@ -101,6 +101,9 @@ fun AdvancedCard(viewModel: MainViewModel, modifier: Modifier = Modifier) {
             LabeledCheckbox(stringResource(R.string.deniability), formData.deniability) {
                 viewModel.updateFormData(formData.copy(deniability = it))
             }
+            LabeledCheckbox(stringResource(R.string.compress), formData.compress) {
+                viewModel.updateFormData(formData.copy(compress = it))
+            }
         }
     }
 }

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/FileCard.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/FileCard.kt
@@ -15,6 +15,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,6 +24,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -34,7 +37,10 @@ import io.github.picocrypt_ng.picocrypt_ng.GoBridge
 import io.github.picocrypt_ng.picocrypt_ng.MainViewModel
 import io.github.picocrypt_ng.picocrypt_ng.R
 import androidx.compose.runtime.collectAsState
+import io.github.picocrypt_ng.picocrypt_ng.StagedSelection
+import io.github.picocrypt_ng.picocrypt_ng.StagingService
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 
@@ -169,12 +175,39 @@ fun ChooseFile(viewModel: MainViewModel) {
             }
         }
     }
-    
+
+    val scope = rememberCoroutineScope()
+
+    val folderPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree()
+    ) { uri: Uri? ->
+        uri ?: return@rememberLauncherForActivityResult
+        isCopying = true
+        scope.launch {
+            val result = StagingService.copyTreeToStaging(context, uri)
+            applyStagedSelection(viewModel, result)
+            isCopying = false
+        }
+    }
+
+    val filesPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenMultipleDocuments()
+    ) { uris: List<Uri> ->
+        if (uris.isEmpty()) return@rememberLauncherForActivityResult
+        isCopying = true
+        scope.launch {
+            val result = StagingService.copyFilesToStaging(context, uris, System.currentTimeMillis() / 1000)
+            applyStagedSelection(viewModel, result)
+            isCopying = false
+        }
+    }
+
+    var menuOpen by remember { mutableStateOf(false) }
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(8.dp)
-            .clickable(enabled = !isCopying) { filePickerLauncher.launch("*/*") },
+            .clickable(enabled = !isCopying) { menuOpen = true },
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         if (isCopying) {
@@ -187,6 +220,44 @@ fun ChooseFile(viewModel: MainViewModel) {
                 contentDescription = stringResource(R.string.choose_file_description)
             )
         }
+        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.choose_single_file)) },
+                onClick = { menuOpen = false; filePickerLauncher.launch("*/*") }
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.choose_multiple_files)) },
+                onClick = { menuOpen = false; filesPickerLauncher.launch(arrayOf("*/*")) }
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.choose_folder)) },
+                onClick = { menuOpen = false; folderPickerLauncher.launch(null) }
+            )
+        }
+    }
+}
+
+private fun applyStagedSelection(viewModel: MainViewModel, result: Result<StagedSelection>) {
+    result.onSuccess { sel ->
+        viewModel.resetFormToDefaults()
+        val base = viewModel.formState.value
+        viewModel.updateFormData(
+            base.copy(
+                selectedFilename = sel.displayName,
+                copiedFilePath = "",
+                inputFiles = sel.inputFiles,
+                onlyFolders = sel.onlyFolders,
+                onlyFiles = sel.onlyFiles,
+                selectionKind = sel.kind,
+                suggestedOutputName = sel.suggestedOutputName,
+                comments = "",
+                decryptionInfo = null,
+            )
+        )
+    }.onFailure { error ->
+        viewModel.setError(
+            (error as? AppError) ?: AppError.fromException(error as? Exception ?: Exception(error.message ?: "error"))
+        )
     }
 }
 

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/ProgressCard.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/ProgressCard.kt
@@ -241,23 +241,24 @@ fun ProgressCard(
             // Data (outputFile/formData) comes from the polled OperationState; the sealed
             // Success state only drives control flow + carries the type.
             val op = operationState
-            val outputFileName = op?.formData?.selectedFilename?.let { selectedFilename ->
-                if (ui.type == OperationType.ENCRYPT) {
-                    // For encryption: add .pcv if not present
-                    if (selectedFilename.endsWith(".pcv")) {
-                        selectedFilename
+            val outputFileName = op?.formData?.suggestedOutputName?.takeIf { it.isNotEmpty() }
+                ?: op?.formData?.selectedFilename?.let { selectedFilename ->
+                    if (ui.type == OperationType.ENCRYPT) {
+                        // For encryption: add .pcv if not present
+                        if (selectedFilename.endsWith(".pcv")) {
+                            selectedFilename
+                        } else {
+                            "$selectedFilename.pcv"
+                        }
                     } else {
-                        "$selectedFilename.pcv"
+                        // For decryption: remove .pcv if present
+                        if (selectedFilename.endsWith(".pcv")) {
+                            selectedFilename.removeSuffix(".pcv")
+                        } else {
+                            selectedFilename
+                        }
                     }
-                } else {
-                    // For decryption: remove .pcv if present
-                    if (selectedFilename.endsWith(".pcv")) {
-                        selectedFilename.removeSuffix(".pcv")
-                    } else {
-                        selectedFilename
-                    }
-                }
-            } ?: op?.let { File(it.outputFile).name } // Fallback to internal storage name if formData is null
+                } ?: op?.let { File(it.outputFile).name } // Fallback to internal storage name if formData is null
 
             AlertDialog(
                 modifier = modifier,

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/WorkButton.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/WorkButton.kt
@@ -43,7 +43,7 @@ fun WorkButton(
     var showErrorDialog by rememberSaveable { mutableStateOf<AppError?>(null) }
     
     val isOperationActive = operationState != null && !operationState!!.done
-    val isButtonEnabled = formData.isFormValid && !isOperationActive && formData.copiedFilePath.isNotEmpty()
+    val isButtonEnabled = formData.isFormValid && !isOperationActive && formData.hasSelectedInput
     var shouldStartOperation by remember { mutableStateOf(false) }
     
     // Start operation when button is clicked

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5,6 +5,9 @@
     <string name="choose_file">Choose a file</string>
     <string name="copying_file">Copying file…</string>
     <string name="choose_file_description">Choose file</string>
+    <string name="choose_single_file">Single file</string>
+    <string name="choose_multiple_files">Multiple files</string>
+    <string name="choose_folder">Folder</string>
     
     <!-- Password Card -->
     <string name="password">Password</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="reed_solomon">Reed-Solomon</string>
     <string name="paranoid">Paranoid</string>
     <string name="deniability">Deniability</string>
+    <string name="compress">Compress</string>
     <string name="expand_or_collapse">Expand or collapse</string>
 
     <!-- Decrypt Options Card -->

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/FormDataTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/FormDataTest.kt
@@ -345,6 +345,24 @@ class FormDataTest {
         assertTrue("precondition: chunk is classified as split", formData.isSplitVolumeChunk)
         assertFalse("a split chunk must invalidate the form", formData.isFormValid)
     }
+
+    @Test
+    fun hasSelectedInput_trueForSingleFile() {
+        val fd = TestDataBuilders.createEncryptFormData(copiedFilePath = "/data/input_file.txt")
+        assertTrue(fd.hasSelectedInput)
+    }
+
+    @Test
+    fun hasSelectedInput_trueForFolderSelection() {
+        val fd = TestDataBuilders.createFolderEncryptFormData()
+        assertTrue(fd.hasSelectedInput)
+    }
+
+    @Test
+    fun hasSelectedInput_falseWhenNothingSelected() {
+        val fd = TestDataBuilders.createEncryptFormData(copiedFilePath = "")
+        assertFalse(fd.hasSelectedInput)
+    }
 }
 
 

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/FormDataTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/FormDataTest.kt
@@ -304,6 +304,36 @@ class FormDataTest {
     }
 
     @Test
+    fun `FOLDER selection is encrypt regardless of filename extension`() {
+        // A folder/multi-file selection always encrypts (Go zips it). The displayName
+        // has no .pcv extension and may have no extension at all, so isEncrypt must key
+        // off selectionKind, not the filename. isDecrypt/isSplitVolumeChunk are
+        // single-file-only concepts and must be false here.
+        val formData = TestDataBuilders.createFolderEncryptFormData(displayName = "MyDocs")
+        assertEquals(SelectionKind.FOLDER, formData.selectionKind)
+        assertTrue("a folder selection must be an encrypt", formData.isEncrypt)
+        assertFalse("a folder selection must never be a decrypt", formData.isDecrypt)
+        assertFalse("split-volume detection is single-file-only", formData.isSplitVolumeChunk)
+    }
+
+    @Test
+    fun `equals and hashCode reflect selection fields`() {
+        // The selection model (inputFiles/onlyFolders/onlyFiles/selectionKind/
+        // suggestedOutputName) is part of FormData's identity: two forms that differ only
+        // in their staged selection must not be considered equal, else a stale folder
+        // selection could be mistaken for a new one.
+        val a = TestDataBuilders.createFolderEncryptFormData(displayName = "MyDocs")
+        val b = TestDataBuilders.createFolderEncryptFormData(displayName = "MyDocs")
+        val c = TestDataBuilders.createFolderEncryptFormData(
+            displayName = "MyDocs",
+            inputFiles = listOf("/stage/MyDocs/only-one.txt")
+        )
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertNotEquals(a, c)
+    }
+
+    @Test
     fun `isFormValid is false for a split volume chunk`() {
         // A split chunk must never be a runnable operation: it does not end in .pcv, so
         // isEncrypt is true and it would be double-encrypted. The work button gates on

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/GoBridgeTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/GoBridgeTest.kt
@@ -77,6 +77,18 @@ class GoBridgeTest {
     }
 
     @Test
+    fun buildEncryptRequestJson_includesCompressTrue() {
+        val json = GoBridge.buildEncryptRequestJson(
+            operationID = "op1",
+            inputFile = "/data/in.txt",
+            outputFile = "/data/out.pcv",
+            options = EncryptOptions(compress = true)
+        )
+        val obj = JSONObject(json)
+        assertTrue(obj.getBoolean("compress"))
+    }
+
+    @Test
     fun `buildDecryptRequestJson serializes every option and never the password`() {
         val json = JSONObject(
             GoBridge.buildDecryptRequestJson(

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/GoBridgeTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/GoBridgeTest.kt
@@ -89,6 +89,43 @@ class GoBridgeTest {
     }
 
     @Test
+    fun buildEncryptRequestJson_includesSelectionArrays() {
+        // A folder/multi-file selection is forwarded to Go as inputFiles/onlyFolders/
+        // onlyFiles arrays (Go zips them). The single-file path leaves these empty.
+        // This asserts the REAL serialization so a dropped/renamed array fails the build.
+        val json = GoBridge.buildEncryptRequestJson(
+            operationID = "op1",
+            inputFile = "",
+            outputFile = "/data/out.pcv",
+            options = EncryptOptions(),
+            inputFiles = listOf("/s/Root/a.txt", "/s/Root/sub/b.txt"),
+            onlyFolders = listOf("/s/Root"),
+            onlyFiles = emptyList(),
+        )
+        val obj = JSONObject(json)
+        assertEquals(2, obj.getJSONArray("inputFiles").length())
+        assertEquals("/s/Root", obj.getJSONArray("onlyFolders").getString(0))
+        assertEquals(0, obj.getJSONArray("onlyFiles").length())
+    }
+
+    @Test
+    fun buildEncryptRequestJson_singleFileEmitsEmptySelectionArrays() {
+        // The single-file path must stay the degenerate case: inputFile carries the path
+        // and the three selection arrays are present but empty (Go treats it as one file).
+        val json = GoBridge.buildEncryptRequestJson(
+            operationID = "op1",
+            inputFile = "/data/in.txt",
+            outputFile = "/data/out.pcv",
+            options = EncryptOptions(),
+        )
+        val obj = JSONObject(json)
+        assertEquals("/data/in.txt", obj.getString("inputFile"))
+        assertEquals(0, obj.getJSONArray("inputFiles").length())
+        assertEquals(0, obj.getJSONArray("onlyFolders").length())
+        assertEquals(0, obj.getJSONArray("onlyFiles").length())
+    }
+
+    @Test
     fun `buildDecryptRequestJson serializes every option and never the password`() {
         val json = JSONObject(
             GoBridge.buildDecryptRequestJson(

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/OperationManagerTest.kt
@@ -178,7 +178,9 @@ class OperationManagerTest {
         mockkObject(GoBridge)
         try {
             every { GoBridge.startOperation() } returns Result.success("op_test")
-            every { GoBridge.startEncrypt(any(), any(), any(), any(), any()) } returns Result.success(Unit)
+            every {
+                GoBridge.startEncrypt(any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Result.success(Unit)
 
             // Establish an active (non-done) operation.
             val started = OperationManager.startEncrypt(
@@ -245,7 +247,9 @@ class OperationManagerTest {
         mockkObject(GoBridge)
         try {
             every { GoBridge.startOperation() } returns Result.success("op_clear")
-            every { GoBridge.startEncrypt(any(), any(), any(), any(), any()) } returns Result.success(Unit)
+            every {
+                GoBridge.startEncrypt(any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Result.success(Unit)
 
             // Establish an active (non-done) operation through the public seam.
             val started = OperationManager.startEncrypt(
@@ -296,7 +300,9 @@ class OperationManagerTest {
         mockkObject(GoBridge)
         try {
             every { GoBridge.startOperation() } returns Result.success("op_old")
-            every { GoBridge.startEncrypt(any(), any(), any(), any(), any()) } returns Result.success(Unit)
+            every {
+                GoBridge.startEncrypt(any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Result.success(Unit)
 
             val started = OperationManager.startEncrypt(
                 mockContext,
@@ -493,7 +499,9 @@ class OperationManagerTest {
         mockkObject(GoBridge)
         try {
             every { GoBridge.startOperation() } returns Result.success("op_enc")
-            every { GoBridge.startEncrypt(any(), any(), any(), any(), any()) } returns Result.success(Unit)
+            every {
+                GoBridge.startEncrypt(any(), any(), any(), any(), any(), any(), any(), any())
+            } returns Result.success(Unit)
 
             val started = OperationManager.startEncrypt(
                 mockContext,
@@ -669,6 +677,87 @@ class OperationManagerTest {
         } finally {
             unmockkObject(GoBridge)
             tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `startEncrypt on a folder selection sends empty inputFile and the staged arrays`() = runTest {
+        // A folder/multi selection encrypts the staged tree, not a single copied file.
+        // OperationManager must hand GoBridge an EMPTY inputFile (so Go does not also try
+        // to read a non-existent single path) and forward the inputFiles/onlyFolders the
+        // staging step produced. Capture the bridge args and prove the selection flows
+        // through. GoBridge is the Go mobile AAR (absent on the JVM classpath), so mock
+        // it; startEncrypt resolves an output path under context.filesDir, so back it
+        // with a real temp dir (the relaxed mock returns null otherwise).
+        val tmpDir = createTempDirectory(prefix = "opmgr_folder").toFile()
+        every { mockContext.filesDir } returns tmpDir
+
+        mockkObject(GoBridge)
+        try {
+            every { GoBridge.startOperation() } returns Result.success("op_folder")
+            val inputFileSlot = slot<String>()
+            val inputFilesSlot = slot<List<String>>()
+            val onlyFoldersSlot = slot<List<String>>()
+            every {
+                GoBridge.startEncrypt(
+                    any(),
+                    capture(inputFileSlot),
+                    any(),
+                    any(),
+                    any(),
+                    inputFiles = capture(inputFilesSlot),
+                    onlyFolders = capture(onlyFoldersSlot),
+                    onlyFiles = any(),
+                )
+            } returns Result.success(Unit)
+
+            val formData = TestDataBuilders.createFolderEncryptFormData(displayName = "MyDocs")
+            val result = OperationManager.startEncrypt(mockContext, formData)
+
+            assertTrue("folder encrypt should start", result.isSuccess)
+            assertTrue("bridge args must be captured", inputFilesSlot.isCaptured)
+            assertEquals(
+                "a multi selection must send an empty single inputFile",
+                "",
+                inputFileSlot.captured
+            )
+            assertEquals(
+                "the staged inputFiles must flow to the bridge",
+                formData.inputFiles,
+                inputFilesSlot.captured
+            )
+            assertEquals(
+                "the staged onlyFolders must flow to the bridge",
+                formData.onlyFolders,
+                onlyFoldersSlot.captured
+            )
+        } finally {
+            unmockkObject(GoBridge)
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `startEncrypt fails loud on a folder selection with no staged files`() = runTest {
+        // A FOLDER selectionKind with an empty inputFiles list is an invalid selection
+        // (staging produced nothing). It must fail with NoFileSelected before any Go work,
+        // exactly as an empty single-file copiedFilePath does.
+        mockkObject(GoBridge)
+        try {
+            val formData = TestDataBuilders.createFolderEncryptFormData()
+                .copy(inputFiles = emptyList())
+            val result = OperationManager.startEncrypt(mockContext, formData)
+
+            assertTrue("empty folder selection must fail", result.isFailure)
+            result.onFailure {
+                assertTrue(
+                    "Error should be NoFileSelected",
+                    it is AppError.ValidationError.NoFileSelected
+                )
+            }
+            verify(exactly = 0) { GoBridge.startOperation() }
+        } finally {
+            unmockkObject(GoBridge)
         }
     }
 

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/StagingServiceTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/StagingServiceTest.kt
@@ -20,4 +20,11 @@ class StagingServiceTest {
     @Test fun folderOutputName_keepsRootName() {
         assertEquals("MyDocs.zip.pcv", StagingService.folderOutputName("MyDocs"))
     }
+    @Test fun requiredBytes_isThreeXPlusMargin() {
+        assertEquals(3L * 1000 + StagingService.SPACE_MARGIN_BYTES, StagingService.requiredBytes(1000))
+    }
+    @Test fun hasSpaceFor_refusesWhenTight() {
+        assertEquals(false, StagingService.hasSpaceFor(total = 1000, usable = 3000))
+        assertEquals(true, StagingService.hasSpaceFor(total = 1000, usable = 3L * 1000 + StagingService.SPACE_MARGIN_BYTES))
+    }
 }

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/StagingServiceTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/StagingServiceTest.kt
@@ -1,0 +1,23 @@
+package io.github.picocrypt_ng.picocrypt_ng
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StagingServiceTest {
+    @Test fun resolveCollision_uniqueWhenFree() {
+        assertEquals("a.txt", StagingService.resolveCollision(emptySet(), "a.txt"))
+    }
+    @Test fun resolveCollision_appendsCounter() {
+        assertEquals("a (1).txt", StagingService.resolveCollision(setOf("a.txt"), "a.txt"))
+        assertEquals("a (2).txt", StagingService.resolveCollision(setOf("a.txt", "a (1).txt"), "a.txt"))
+    }
+    @Test fun resolveCollision_noExtension() {
+        assertEquals("README (1)", StagingService.resolveCollision(setOf("README"), "README"))
+    }
+    @Test fun multiFileOutputName_isRandomEncryptedZipPcv() {
+        assertEquals("encrypted-1700000000.zip.pcv", StagingService.multiFileOutputName(1_700_000_000L))
+    }
+    @Test fun folderOutputName_keepsRootName() {
+        assertEquals("MyDocs.zip.pcv", StagingService.folderOutputName("MyDocs"))
+    }
+}

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/testutils/TestDataBuilders.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/testutils/TestDataBuilders.kt
@@ -5,6 +5,7 @@ import io.github.picocrypt_ng.picocrypt_ng.FormData
 import io.github.picocrypt_ng.picocrypt_ng.KeyfileInfo
 import io.github.picocrypt_ng.picocrypt_ng.OperationState
 import io.github.picocrypt_ng.picocrypt_ng.OperationType
+import io.github.picocrypt_ng.picocrypt_ng.SelectionKind
 
 /**
  * Test data builders for creating test objects.
@@ -41,6 +42,34 @@ object TestDataBuilders {
         )
     }
     
+    /**
+     * Creates a FormData for a FOLDER selection (folder/multi-file encrypt path).
+     * The staged input lives in [inputFiles]/[onlyFolders]; [copiedFilePath] is empty
+     * because a multi selection sends arrays, not a single inputFile.
+     */
+    fun createFolderEncryptFormData(
+        displayName: String = "MyDocs",
+        inputFiles: List<String> = listOf("/stage/MyDocs/a.txt", "/stage/MyDocs/sub/b.txt"),
+        onlyFolders: List<String> = listOf("/stage/MyDocs"),
+        password: String = "testpassword",
+    ): FormData = FormData(
+        selectedFilename = displayName,
+        copiedFilePath = "",
+        comments = "",
+        passwordInput = password.toCharArray(),
+        confirmPasswordInput = password.toCharArray(),
+        reedSolomon = false,
+        paranoid = false,
+        deniability = false,
+        keyfileFilenames = emptyList(),
+        keyfileOrdered = false,
+        inputFiles = inputFiles,
+        onlyFolders = onlyFolders,
+        selectionKind = SelectionKind.FOLDER,
+        suggestedOutputName = "$displayName.zip.pcv",
+        decryptionInfo = null,
+    )
+
     /**
      * Creates a FormData for decryption with default values.
      */

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ materialIconsExtended = "1.7.8"
 coroutines = "1.11.0"
 mockk = "1.14.7"
 archTesting = "2.2.0"
+documentfile = "1.0.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -38,6 +39,7 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 androidx-arch-core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "archTesting" }
+androidx-documentfile = { group = "androidx.documentfile", name = "documentfile", version.ref = "documentfile" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/src/mobile/android.go
+++ b/src/mobile/android.go
@@ -54,6 +54,9 @@ func DetectOperation(filePath string) (isEncrypt bool, err error) {
 type EncryptRequestJSON struct {
 	OperationID    string   `json:"operationID"`
 	InputFile      string   `json:"inputFile"`
+	InputFiles     []string `json:"inputFiles"`
+	OnlyFolders    []string `json:"onlyFolders"`
+	OnlyFiles      []string `json:"onlyFiles"`
 	OutputFile     string   `json:"outputFile"`
 	Comments       string   `json:"comments"`
 	Keyfiles       []string `json:"keyfiles"`
@@ -103,7 +106,7 @@ func StartEncrypt(requestJSON string, password []byte) string {
 	}
 
 	// Validate inputs
-	if req.InputFile == "" {
+	if req.InputFile == "" && len(req.InputFiles) == 0 {
 		return failOperation(req.OperationID, fmt.Errorf("input file is required"))
 	}
 	if req.OutputFile == "" {
@@ -149,6 +152,9 @@ func StartEncrypt(requestJSON string, password []byte) string {
 		// Build encrypt request
 		encryptReq := &volume.EncryptRequest{
 			InputFile:      req.InputFile,
+			InputFiles:     req.InputFiles,
+			OnlyFolders:    req.OnlyFolders,
+			OnlyFiles:      req.OnlyFiles,
 			OutputFile:     req.OutputFile,
 			Password:       pw,
 			Keyfiles:       req.Keyfiles,

--- a/src/mobile/android_test.go
+++ b/src/mobile/android_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	perrors "Picocrypt-NG/internal/errors"
 	"Picocrypt-NG/internal/encoding"
+	perrors "Picocrypt-NG/internal/errors"
 	"Picocrypt-NG/internal/header"
 	"Picocrypt-NG/internal/volume"
 )

--- a/src/mobile/android_test.go
+++ b/src/mobile/android_test.go
@@ -1,6 +1,7 @@
 package mobile
 
 import (
+	"archive/zip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	perrors "Picocrypt-NG/internal/errors"
+	"Picocrypt-NG/internal/encoding"
 	"Picocrypt-NG/internal/header"
 	"Picocrypt-NG/internal/volume"
 )
@@ -381,10 +383,82 @@ func TestStartEncryptPassesMultiFileSelection(t *testing.T) {
 	}
 }
 
+func TestStartEncryptFolderRoundTripsToZip(t *testing.T) {
+	resetProgressMap()
+
+	root := t.TempDir()
+	folder := filepath.Join(root, "MyDocs")
+	if err := os.MkdirAll(filepath.Join(folder, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	a := filepath.Join(folder, "a.txt")
+	b := filepath.Join(folder, "sub", "b.txt")
+	if err := os.WriteFile(a, []byte("aaa"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("bbb"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(root, "MyDocs.zip.pcv")
+
+	id := StartOperation()
+	reqJSON, err := json.Marshal(EncryptRequestJSON{
+		OperationID: id,
+		InputFiles:  []string{a, b},
+		OnlyFolders: []string{folder},
+		OutputFile:  out,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := StartEncrypt(string(reqJSON), []byte("pw")); got != "" {
+		t.Fatalf("StartEncrypt = %q, want empty", got)
+	}
+	// Real Argon2id KDF takes ~3-4 s; use a longer deadline than waitForDone's 2 s.
+	if state := waitForDoneTimeout(t, id, 30*time.Second); state.Status == "Error" {
+		t.Fatalf("encrypt failed: %s", state.Error)
+	}
+
+	// Decrypt to a .zip and inspect entries.
+	zipOut := filepath.Join(root, "decrypted.zip")
+	rsCodecs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := volume.Decrypt(context.Background(), &volume.DecryptRequest{
+		InputFile:  out,
+		OutputFile: zipOut,
+		Password:   "pw",
+		RSCodecs:   rsCodecs,
+	}); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+
+	zr, err := zip.OpenReader(zipOut)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	defer func() { _ = zr.Close() }()
+	got := map[string]bool{}
+	for _, f := range zr.File {
+		got[f.Name] = true
+	}
+	for _, want := range []string{"MyDocs/a.txt", "MyDocs/sub/b.txt"} {
+		if !got[want] {
+			t.Fatalf("zip missing %q; entries=%v", want, got)
+		}
+	}
+}
+
 func waitForDone(t *testing.T, id string) *ProgressState {
 	t.Helper()
+	return waitForDoneTimeout(t, id, 2*time.Second)
+}
 
-	deadline := time.Now().Add(2 * time.Second)
+func waitForDoneTimeout(t *testing.T, id string, timeout time.Duration) *ProgressState {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		state, err := getProgress(id)
 		if err != nil {

--- a/src/mobile/android_test.go
+++ b/src/mobile/android_test.go
@@ -327,6 +327,60 @@ func TestStartEncryptZeroesPasswordBytes(t *testing.T) {
 	_ = waitForDone(t, id)
 }
 
+func TestStartEncryptPassesMultiFileSelection(t *testing.T) {
+	resetProgressMap()
+
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	for _, p := range []string{a, b} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	outputPath := filepath.Join(dir, "out.pcv")
+
+	var captured *volume.EncryptRequest
+	orig := runEncrypt
+	runEncrypt = func(_ context.Context, req *volume.EncryptRequest) error {
+		captured = req
+		return nil
+	}
+	defer func() { runEncrypt = orig }()
+
+	id := StartOperation()
+	reqJSON, err := json.Marshal(EncryptRequestJSON{
+		OperationID: id,
+		InputFiles:  []string{a, b},
+		OnlyFiles:   []string{a, b},
+		OnlyFolders: []string{dir},
+		OutputFile:  outputPath,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := StartEncrypt(string(reqJSON), []byte("pw")); got != "" {
+		t.Fatalf("StartEncrypt(...) = %q, want empty", got)
+	}
+	_ = waitForDone(t, id)
+
+	if captured == nil {
+		t.Fatal("runEncrypt was not called")
+	}
+	if len(captured.InputFiles) != 2 || captured.InputFiles[0] != a || captured.InputFiles[1] != b {
+		t.Fatalf("InputFiles = %#v, want [%q %q]", captured.InputFiles, a, b)
+	}
+	if len(captured.OnlyFiles) != 2 {
+		t.Fatalf("OnlyFiles = %#v, want 2 entries", captured.OnlyFiles)
+	}
+	if len(captured.OnlyFolders) != 1 || captured.OnlyFolders[0] != dir {
+		t.Fatalf("OnlyFolders = %#v, want [%q]", captured.OnlyFolders, dir)
+	}
+	if captured.InputFile != "" {
+		t.Fatalf("InputFile = %q, want empty for multi-file selection", captured.InputFile)
+	}
+}
+
 func waitForDone(t *testing.T, id string) *ProgressState {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Adds Android encryption of a **folder** or **multiple files** into a single `.pcv` volume (byte-compatible with the desktop/CLI), plus a **Compress** toggle. Encrypt direction only. Addresses the folder-encryption request raised in the #9 thread.

## Approach

Kotlin copies the picked SAF tree / files into a **structure-preserving staging dir** under app-internal storage, then passes real paths to the gomobile bridge as `inputFiles[]` + `onlyFolders[]`/`onlyFiles[]`. The Go core (which already supports these fields) zips the selection with `<Root>/sub/file` entries (top folder name preserved, matching desktop / #130) and encrypts. The zip/entry logic and the audit-critical `encryptPreprocess` are **reused unchanged** — the only Go change is bridge plumbing.

## Commits

- `feat(mobile)` bridge multi-file/folder encrypt selection (android.go: `InputFiles`/`OnlyFolders`/`OnlyFiles`)
- `build(android)` add `androidx.documentfile` for SAF tree access
- `test(mobile)` folder encrypt round-trips to a structure-preserving zip
- `feat(android)` Compress toggle in advanced settings (default OFF)
- `feat(android)` `StagingService` for structure-preserving SAF staging (collision-rename)
- `feat(android)` hard-refuse folder encryption on low storage (~3× selection)
- `feat(android)` selection model for folder/multi-file encrypt (FormData → OperationManager → GoBridge)
- `feat(android)` folder/multi-file pickers (File / Files / Folder) and export naming
- `fix(android)` enable folder/multi encrypt button + stop wiping staged inputs

Output naming mirrors desktop: folder → `<Root>.zip.pcv`, multi-file → `encrypted-<unix>.zip.pcv`, single file unchanged.

## Out of scope (by design)

- Decrypt-to-folder round-trip — a folder volume decrypts to a `.zip` (auto-unzip stays OFF on Android).
- Split volumes on Android (still rejected loudly).
- F-Droid distribution.

## Testing

- **Go:** `go test ./...` + `go vet ./...` green, including the new bridge selection test and the folder→zip interop round-trip test (real Argon2id/XChaCha20 pipeline).
- **Android:** 133 unit tests pass; `compileDebugKotlin` and `compileDebugAndroidTestKotlin` both green.
- Final holistic review caught and fixed **two runtime defects** (encrypt button disabled for folder/multi selections; pre-start cleanup deleting the staged inputs); re-review approved. Regression tests added for both (`FormData.hasSelectedInput` JVM tests; `cleanupOperationFilesBeforeStart_preservesStagingTree` instrumented test).

## Caveats for reviewers

- **Instrumented tests compile but were not run** in this environment (no device/emulator). Device end-to-end smoke (pick folder → encrypt → save `<Root>.zip.pcv` → decrypt on desktop → verify structure) is pending.
- The **gomobile AAR is a gitignored build artifact**; CI rebuilds it from the updated Go source. A local device build requires `cd android && ./build-gomobile.sh` first so the new bridge fields are present at runtime.

Refs #9
