### PR TITLE
feat(ui): tooltips on advanced settings (#79)

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Picocrypt/infectious v0.0.0-20250713161924-ae9b3ccb49d7
 	github.com/Picocrypt/serpent v0.0.0-20240830233833-9ad6ab254fd7
 	github.com/Picocrypt/zxcvbn-go v0.0.0-20250412183938-d59695960527
+	github.com/dweymouth/fyne-tooltip v0.4.0
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20260406072232-3ac4aa2bb164
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -37,7 +38,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade // indirect
 	github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/nicksnyder/go-i18n/v2 v2.6.1 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -13,9 +13,10 @@ github.com/Picocrypt/zxcvbn-go v0.0.0-20250412183938-d59695960527/go.mod h1:u0rc
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dweymouth/fyne-tooltip v0.4.0 h1:ZkMhy4f8lHklyjNnKJlSEJ2pLPnYWVD7tu2+YEgmp+w=
+github.com/dweymouth/fyne-tooltip v0.4.0/go.mod h1:jXYbY561DTIXXqkauzltI3o/hsVaQd2KY8Ry2FXy7Xk=
 github.com/felixge/fgprof v0.9.3 h1:VvyZxILNuCiUCSXtPtYmmtGvb65nqXh2QFWc0Wpf2/g=
 github.com/felixge/fgprof v0.9.3/go.mod h1:RdbpDgzqYVh/T9fPELJyV7EYJuHB55UTEULNun8eiPw=
 github.com/fredbi/uri v1.1.1 h1:xZHJC08GZNIUhbP5ImTHnt5Ya0T8FI2VAwI/37kh2Ko=

--- a/src/internal/ui/advanced_section.go
+++ b/src/internal/ui/advanced_section.go
@@ -10,6 +10,8 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/widget"
+
+	ttwidget "github.com/dweymouth/fyne-tooltip/widget"
 )
 
 // updateAdvancedSection updates the advanced options based on mode.
@@ -62,41 +64,46 @@ func (a *App) updateAdvancedSection() {
 // buildEncryptOptions creates encrypt mode options.
 func (a *App) buildEncryptOptions() {
 	// Row 1: Paranoid + Compress
-	a.paranoidCheck = widget.NewCheck("Paranoid mode", func(checked bool) {
+	a.paranoidCheck = ttwidget.NewCheck("Paranoid mode", func(checked bool) {
 		a.State.Paranoid = checked
 	})
+	a.paranoidCheck.SetToolTip("Provides the highest level of security attainable")
 	a.paranoidCheck.SetChecked(a.State.Paranoid)
 
-	a.compressCheck = widget.NewCheck("Compress files", func(checked bool) {
+	a.compressCheck = ttwidget.NewCheck("Compress files", func(checked bool) {
 		a.State.Compress = checked
 		// Auto-toggle .zip suffix in output filename
 		a.updateOutputFileForCompress(checked)
 	})
+	a.compressCheck.SetToolTip("Compress files with Deflate before encrypting")
 	a.compressCheck.SetChecked(a.State.Compress)
 
 	row1 := container.NewGridWithColumns(2, a.paranoidCheck, a.compressCheck)
 
 	// Row 2: Reed-Solomon + Delete files
-	a.reedSolomonCheck = widget.NewCheck("Reed-Solomon", func(checked bool) {
+	a.reedSolomonCheck = ttwidget.NewCheck("Reed-Solomon", func(checked bool) {
 		a.State.ReedSolomon = checked
 	})
+	a.reedSolomonCheck.SetToolTip("Prevent file corruption with erasure coding")
 	a.reedSolomonCheck.SetChecked(a.State.ReedSolomon)
 
-	a.deleteCheck = widget.NewCheck("Delete files", func(checked bool) {
+	a.deleteCheck = ttwidget.NewCheck("Delete files", func(checked bool) {
 		a.State.Delete = checked
 	})
+	a.deleteCheck.SetToolTip("Delete the input files after encryption")
 	a.deleteCheck.SetChecked(a.State.Delete)
 
 	row2 := container.NewGridWithColumns(2, a.reedSolomonCheck, a.deleteCheck)
 
 	// Row 3: Deniability + Recursively
-	a.deniabilityCheck = widget.NewCheck("Deniability", func(checked bool) {
+	a.deniabilityCheck = ttwidget.NewCheck("Deniability", func(checked bool) {
 		a.State.Deniability = checked
 		a.updateUIState()
 	})
+	a.deniabilityCheck.SetToolTip("Warning: only use this if you know what it does!")
 	a.deniabilityCheck.SetChecked(a.State.Deniability)
 
-	a.recursivelyCheck = widget.NewCheck("Recursively", func(checked bool) {
+	a.recursivelyCheck = ttwidget.NewCheck("Recursively", func(checked bool) {
 		a.State.Recursively = checked
 		if checked {
 			a.State.Compress = false
@@ -106,15 +113,17 @@ func (a *App) buildEncryptOptions() {
 		}
 		a.updateUIState()
 	})
+	a.recursivelyCheck.SetToolTip("Warning: only use this if you know what it does!")
 	a.recursivelyCheck.SetChecked(a.State.Recursively)
 
 	row3 := container.NewGridWithColumns(2, a.deniabilityCheck, a.recursivelyCheck)
 
 	// Row 4: Split into chunks
-	a.splitCheck = widget.NewCheck("Split:", func(checked bool) {
+	a.splitCheck = ttwidget.NewCheck("Split:", func(checked bool) {
 		a.State.Split = checked
 		a.updateUIState() // Update status to show increased disk space requirement
 	})
+	a.splitCheck.SetToolTip("Split the output file into smaller chunks")
 	a.splitCheck.SetChecked(a.State.Split)
 
 	a.splitSizeEntry = widget.NewEntry()
@@ -129,7 +138,7 @@ func (a *App) buildEncryptOptions() {
 		a.updateUIState() // Update status to show increased disk space requirement
 	}
 
-	a.splitUnitSelect = widget.NewSelect(a.State.SplitUnits, func(selected string) {
+	a.splitUnitSelect = ttwidget.NewSelect(a.State.SplitUnits, func(selected string) {
 		for i, unit := range a.State.SplitUnits {
 			if unit == selected {
 				// #nosec G115 -- i is bounded by SplitUnits length (5 items: KiB, MiB, GiB, TiB, Total)
@@ -138,6 +147,7 @@ func (a *App) buildEncryptOptions() {
 			}
 		}
 	})
+	a.splitUnitSelect.SetToolTip("Choose the chunk units")
 	a.splitUnitSelect.SetSelectedIndex(int(a.State.SplitSelected))
 
 	splitRow := container.NewBorder(nil, nil,
@@ -155,25 +165,28 @@ func (a *App) buildEncryptOptions() {
 // buildDecryptOptions creates decrypt mode options.
 func (a *App) buildDecryptOptions() {
 	// Row 1: Force decrypt + Verify first
-	a.forceDecryptCheck = widget.NewCheck("Force decrypt", func(checked bool) {
+	a.forceDecryptCheck = ttwidget.NewCheck("Force decrypt", func(checked bool) {
 		a.State.Keep = checked
 	})
+	a.forceDecryptCheck.SetToolTip("Override security measures when decrypting")
 	a.forceDecryptCheck.SetChecked(a.State.Keep)
 
-	a.verifyFirstCheck = widget.NewCheck("Verify first", func(checked bool) {
+	a.verifyFirstCheck = ttwidget.NewCheck("Verify first", func(checked bool) {
 		a.State.VerifyFirst = checked
 	})
+	a.verifyFirstCheck.SetToolTip("Verify integrity before decryption (slower but more secure)")
 	a.verifyFirstCheck.SetChecked(a.State.VerifyFirst)
 
 	row1 := container.NewGridWithColumns(2, a.forceDecryptCheck, a.verifyFirstCheck)
 
 	// Row 2: Delete volume + Auto unzip
-	a.deleteVolumeCheck = widget.NewCheck("Delete volume", func(checked bool) {
+	a.deleteVolumeCheck = ttwidget.NewCheck("Delete volume", func(checked bool) {
 		a.State.Delete = checked
 	})
+	a.deleteVolumeCheck.SetToolTip("Delete the volume after a successful decryption")
 	a.deleteVolumeCheck.SetChecked(a.State.Delete)
 
-	a.autoUnzipCheck = widget.NewCheck("Auto unzip", func(checked bool) {
+	a.autoUnzipCheck = ttwidget.NewCheck("Auto unzip", func(checked bool) {
 		a.State.AutoUnzip = checked
 		if !checked {
 			a.State.SameLevel = false
@@ -183,14 +196,16 @@ func (a *App) buildDecryptOptions() {
 		}
 		a.updateUIState()
 	})
+	a.autoUnzipCheck.SetToolTip("Extract .zip upon decryption (may overwrite files)")
 	a.autoUnzipCheck.SetChecked(a.State.AutoUnzip)
 
 	row2 := container.NewGridWithColumns(2, a.deleteVolumeCheck, a.autoUnzipCheck)
 
 	// Row 3: Same level (only if auto unzip is relevant)
-	a.sameLevelCheck = widget.NewCheck("Same level", func(checked bool) {
+	a.sameLevelCheck = ttwidget.NewCheck("Same level", func(checked bool) {
 		a.State.SameLevel = checked
 	})
+	a.sameLevelCheck.SetToolTip("Extract .zip contents to same folder as volume")
 	a.sameLevelCheck.SetChecked(a.State.SameLevel)
 
 	row3 := container.NewGridWithColumns(2, a.sameLevelCheck, widget.NewLabel(""))

--- a/src/internal/ui/advanced_section_test.go
+++ b/src/internal/ui/advanced_section_test.go
@@ -5,14 +5,15 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
-	"fyne.io/fyne/v2/widget"
+
+	ttwidget "github.com/dweymouth/fyne-tooltip/widget"
 )
 
 // assertCheckboxWiring verifies a build...Options checkbox is present, correctly
 // labeled, and that its OnChanged closure drives the mapped State field in both
 // directions. OnChanged is invoked directly (not SetChecked, which no-ops when
 // the value is unchanged) so the production callback runs unconditionally.
-func assertCheckboxWiring(t *testing.T, c *widget.Check, wantLabel string, getField func() bool) {
+func assertCheckboxWiring(t *testing.T, c *ttwidget.Check, wantLabel string, getField func() bool) {
 	t.Helper()
 	if c == nil {
 		t.Fatalf("checkbox %q is nil", wantLabel)
@@ -234,7 +235,7 @@ func TestEncryptAdvancedOptionsNeverSoftLock(t *testing.T) {
 
 		for _, c := range []struct {
 			name string
-			box  *widget.Check
+			box  *ttwidget.Check
 		}{
 			{"Paranoid mode", a.paranoidCheck},
 			{"Compress files", a.compressCheck},
@@ -246,6 +247,57 @@ func TestEncryptAdvancedOptionsNeverSoftLock(t *testing.T) {
 		} {
 			if c.box.Disabled() {
 				t.Errorf("#56 regression: %q is disabled under Paranoid+Reed-Solomon+Deniability; this combo must not lock any option", c.name)
+			}
+		}
+	})
+}
+
+func TestAdvancedOptionsSetTooltips(t *testing.T) {
+	newTestFyneApp(t)
+
+	t.Run("encrypt", func(t *testing.T) {
+		a := createTestApp(t)
+		a.advancedContainer = container.NewVBox()
+		a.buildEncryptOptions()
+
+		for _, c := range []struct {
+			name string
+			tt   interface{ ToolTip() string }
+			want string
+		}{
+			{"Paranoid mode", a.paranoidCheck, "Provides the highest level of security attainable"},
+			{"Compress files", a.compressCheck, "Compress files with Deflate before encrypting"},
+			{"Reed-Solomon", a.reedSolomonCheck, "Prevent file corruption with erasure coding"},
+			{"Delete files", a.deleteCheck, "Delete the input files after encryption"},
+			{"Deniability", a.deniabilityCheck, "Warning: only use this if you know what it does!"},
+			{"Recursively", a.recursivelyCheck, "Warning: only use this if you know what it does!"},
+			{"Split:", a.splitCheck, "Split the output file into smaller chunks"},
+			{"split units", a.splitUnitSelect, "Choose the chunk units"},
+		} {
+			if got := c.tt.ToolTip(); got != c.want {
+				t.Errorf("%s tooltip = %q, want %q", c.name, got, c.want)
+			}
+		}
+	})
+
+	t.Run("decrypt", func(t *testing.T) {
+		a := createTestApp(t)
+		a.advancedContainer = container.NewVBox()
+		a.buildDecryptOptions()
+
+		for _, c := range []struct {
+			name string
+			tt   interface{ ToolTip() string }
+			want string
+		}{
+			{"Force decrypt", a.forceDecryptCheck, "Override security measures when decrypting"},
+			{"Verify first", a.verifyFirstCheck, "Verify integrity before decryption (slower but more secure)"},
+			{"Delete volume", a.deleteVolumeCheck, "Delete the volume after a successful decryption"},
+			{"Auto unzip", a.autoUnzipCheck, "Extract .zip upon decryption (may overwrite files)"},
+			{"Same level", a.sameLevelCheck, "Extract .zip contents to same folder as volume"},
+		} {
+			if got := c.tt.ToolTip(); got != c.want {
+				t.Errorf("%s tooltip = %q, want %q", c.name, got, c.want)
 			}
 		}
 	})

--- a/src/internal/ui/app.go
+++ b/src/internal/ui/app.go
@@ -49,6 +49,9 @@ import (
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
+
+	fynetooltip "github.com/dweymouth/fyne-tooltip"
+	ttwidget "github.com/dweymouth/fyne-tooltip/widget"
 )
 
 //go:embed key.png
@@ -137,22 +140,22 @@ type App struct {
 	changeBtn *widget.Button
 
 	// Advanced options (encrypt mode)
-	paranoidCheck    *widget.Check
-	compressCheck    *widget.Check
-	reedSolomonCheck *widget.Check
-	deleteCheck      *widget.Check
-	deniabilityCheck *widget.Check
-	recursivelyCheck *widget.Check
-	splitCheck       *widget.Check
+	paranoidCheck    *ttwidget.Check
+	compressCheck    *ttwidget.Check
+	reedSolomonCheck *ttwidget.Check
+	deleteCheck      *ttwidget.Check
+	deniabilityCheck *ttwidget.Check
+	recursivelyCheck *ttwidget.Check
+	splitCheck       *ttwidget.Check
 	splitSizeEntry   *widget.Entry
-	splitUnitSelect  *widget.Select
+	splitUnitSelect  *ttwidget.Select
 
 	// Advanced options (decrypt mode)
-	forceDecryptCheck *widget.Check
-	verifyFirstCheck  *widget.Check
-	deleteVolumeCheck *widget.Check
-	autoUnzipCheck    *widget.Check
-	sameLevelCheck    *widget.Check
+	forceDecryptCheck *ttwidget.Check
+	verifyFirstCheck  *ttwidget.Check
+	deleteVolumeCheck *ttwidget.Check
+	autoUnzipCheck    *ttwidget.Check
+	sameLevelCheck    *ttwidget.Check
 
 	// Modals
 	passgenModal   dialog.Dialog
@@ -242,6 +245,9 @@ func (a *App) Run(startupPaths []string) {
 	a.Window.SetCloseIntercept(func() {
 		snap := a.State.UISnapshot()
 		if !snap.Working && !snap.ShowProgress {
+			if !isMobile() {
+				fynetooltip.DestroyWindowToolTipLayer(a.Window.Canvas())
+			}
 			a.Window.Close()
 		}
 	})
@@ -275,6 +281,9 @@ func (a *App) Run(startupPaths []string) {
 
 	a.scheduleStartupPaths(startupPaths)
 
+	if !isMobile() {
+		content = fynetooltip.AddWindowToolTipLayer(content, a.Window.Canvas())
+	}
 	a.Window.SetContent(content)
 	a.Window.ShowAndRun()
 }

--- a/src/internal/ui/mobile.go
+++ b/src/internal/ui/mobile.go
@@ -16,6 +16,8 @@ import (
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
+
+	ttwidget "github.com/dweymouth/fyne-tooltip/widget"
 )
 
 // isMobile returns true if running on a mobile device
@@ -489,35 +491,35 @@ func (a *App) updateMobileAdvancedSection() {
 // buildMobileEncryptOptions creates encrypt options for mobile
 func (a *App) buildMobileEncryptOptions() {
 	// Checkboxes with more spacing
-	a.paranoidCheck = widget.NewCheck("Paranoid mode", func(checked bool) {
+	a.paranoidCheck = ttwidget.NewCheck("Paranoid mode", func(checked bool) {
 		a.State.Paranoid = checked
 	})
 	a.paranoidCheck.SetChecked(a.State.Paranoid)
 
-	a.compressCheck = widget.NewCheck("Compress files", func(checked bool) {
+	a.compressCheck = ttwidget.NewCheck("Compress files", func(checked bool) {
 		a.State.Compress = checked
 		// Auto-toggle .zip suffix in output filename
 		a.updateOutputFileForCompress(checked)
 	})
 	a.compressCheck.SetChecked(a.State.Compress)
 
-	a.reedSolomonCheck = widget.NewCheck("Reed-Solomon", func(checked bool) {
+	a.reedSolomonCheck = ttwidget.NewCheck("Reed-Solomon", func(checked bool) {
 		a.State.ReedSolomon = checked
 	})
 	a.reedSolomonCheck.SetChecked(a.State.ReedSolomon)
 
-	a.deleteCheck = widget.NewCheck("Delete files", func(checked bool) {
+	a.deleteCheck = ttwidget.NewCheck("Delete files", func(checked bool) {
 		a.State.Delete = checked
 	})
 	a.deleteCheck.SetChecked(a.State.Delete)
 
-	a.deniabilityCheck = widget.NewCheck("Deniability", func(checked bool) {
+	a.deniabilityCheck = ttwidget.NewCheck("Deniability", func(checked bool) {
 		a.State.Deniability = checked
 		a.updateUIState()
 	})
 	a.deniabilityCheck.SetChecked(a.State.Deniability)
 
-	a.recursivelyCheck = widget.NewCheck("Recursively", func(checked bool) {
+	a.recursivelyCheck = ttwidget.NewCheck("Recursively", func(checked bool) {
 		a.State.Recursively = checked
 		if checked {
 			a.State.Compress = false
@@ -535,7 +537,7 @@ func (a *App) buildMobileEncryptOptions() {
 	row3 := container.NewGridWithColumns(2, a.deniabilityCheck, a.recursivelyCheck)
 
 	// Split section
-	a.splitCheck = widget.NewCheck("Split:", func(checked bool) {
+	a.splitCheck = ttwidget.NewCheck("Split:", func(checked bool) {
 		a.State.Split = checked
 		a.updateUIState()
 	})
@@ -553,7 +555,7 @@ func (a *App) buildMobileEncryptOptions() {
 		a.updateUIState()
 	}
 
-	a.splitUnitSelect = widget.NewSelect(a.State.SplitUnits, func(selected string) {
+	a.splitUnitSelect = ttwidget.NewSelect(a.State.SplitUnits, func(selected string) {
 		for i, unit := range a.State.SplitUnits {
 			if unit == selected {
 				// #nosec G115 -- i is bounded by SplitUnits length (5 items: KiB, MiB, GiB, TiB, Total)
@@ -574,17 +576,17 @@ func (a *App) buildMobileEncryptOptions() {
 
 // buildMobileDecryptOptions creates decrypt options for mobile
 func (a *App) buildMobileDecryptOptions() {
-	a.forceDecryptCheck = widget.NewCheck("Force decrypt", func(checked bool) {
+	a.forceDecryptCheck = ttwidget.NewCheck("Force decrypt", func(checked bool) {
 		a.State.Keep = checked
 	})
 	a.forceDecryptCheck.SetChecked(a.State.Keep)
 
-	a.verifyFirstCheck = widget.NewCheck("Verify first", func(checked bool) {
+	a.verifyFirstCheck = ttwidget.NewCheck("Verify first", func(checked bool) {
 		a.State.VerifyFirst = checked
 	})
 	a.verifyFirstCheck.SetChecked(a.State.VerifyFirst)
 
-	a.deleteCheck = widget.NewCheck("Delete encrypted", func(checked bool) {
+	a.deleteCheck = ttwidget.NewCheck("Delete encrypted", func(checked bool) {
 		a.State.Delete = checked
 	})
 	a.deleteCheck.SetChecked(a.State.Delete)

--- a/src/internal/ui/widgets.go
+++ b/src/internal/ui/widgets.go
@@ -6,8 +6,6 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
-	"fyne.io/fyne/v2/container"
-	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 )
@@ -270,60 +268,6 @@ func (e *PasswordEntry) SetHidden(hidden bool) {
 // IsHidden returns whether the password is currently hidden.
 func (e *PasswordEntry) IsHidden() bool {
 	return e.hidden
-}
-
-// TooltipButton is a button with a tooltip that shows on hover.
-type TooltipButton struct {
-	widget.Button
-	tooltip string
-	popup   *widget.PopUp
-}
-
-var _ desktop.Hoverable = (*TooltipButton)(nil)
-
-// NewTooltipButton creates a new button with a tooltip.
-func NewTooltipButton(label string, tooltip string, onTapped func()) *TooltipButton {
-	b := &TooltipButton{tooltip: tooltip}
-	b.Text = label
-	b.OnTapped = onTapped
-	b.ExtendBaseWidget(b)
-	return b
-}
-
-// SetTooltip updates the tooltip text.
-func (b *TooltipButton) SetTooltip(tooltip string) {
-	b.tooltip = tooltip
-}
-
-// MouseIn is called when the mouse enters the button - shows tooltip.
-func (b *TooltipButton) MouseIn(e *desktop.MouseEvent) {
-	if b.tooltip == "" || b.Disabled() {
-		return
-	}
-	c := fyne.CurrentApp().Driver().CanvasForObject(b)
-	if c == nil {
-		return
-	}
-	// Use canvas.Text for simple single-line tooltip
-	text := canvas.NewText(b.tooltip, theme.Color(theme.ColorNameForeground))
-	text.TextSize = theme.CaptionTextSize()
-	// Add padding around the text
-	bg := canvas.NewRectangle(theme.Color(theme.ColorNameOverlayBackground))
-	content := container.NewStack(bg, container.NewPadded(text))
-	b.popup = widget.NewPopUp(content, c)
-	pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(b)
-	b.popup.ShowAtPosition(fyne.NewPos(pos.X, pos.Y+b.Size().Height+2))
-}
-
-// MouseMoved is called when the mouse moves within the button.
-func (b *TooltipButton) MouseMoved(e *desktop.MouseEvent) {}
-
-// MouseOut is called when the mouse leaves the button - hides tooltip.
-func (b *TooltipButton) MouseOut() {
-	if b.popup != nil {
-		b.popup.Hide()
-		b.popup = nil
-	}
 }
 
 // ColoredLabel is a label with custom text color.

--- a/src/internal/ui/widgets_test.go
+++ b/src/internal/ui/widgets_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/test"
 	fynetheme "fyne.io/fyne/v2/theme"
 )
 
@@ -311,43 +310,6 @@ func TestDisabledEntry(t *testing.T) {
 
 		if entry.Text != "Test content" {
 			t.Errorf("Expected text 'Test content', got '%s'", entry.Text)
-		}
-	})
-}
-
-// TestTooltipButton tests the tooltip button widget.
-func TestTooltipButton(t *testing.T) {
-	newTestFyneApp(t)
-
-	t.Run("NewTooltipButton", func(t *testing.T) {
-		tapped := false
-		btn := NewTooltipButton("Click", "This is a tooltip", func() {
-			tapped = true
-		})
-
-		if btn == nil {
-			t.Fatal("Expected non-nil button")
-		}
-		if btn.Text != "Click" {
-			t.Errorf("Expected text 'Click', got '%s'", btn.Text)
-		}
-		if btn.tooltip != "This is a tooltip" {
-			t.Errorf("Expected tooltip 'This is a tooltip', got '%s'", btn.tooltip)
-		}
-
-		// Simulate tap
-		test.Tap(btn)
-		if !tapped {
-			t.Error("Expected OnTapped to be called")
-		}
-	})
-
-	t.Run("SetTooltip", func(t *testing.T) {
-		btn := NewTooltipButton("Click", "Initial", nil)
-		btn.SetTooltip("Updated tooltip")
-
-		if btn.tooltip != "Updated tooltip" {
-			t.Errorf("Expected tooltip 'Updated tooltip', got '%s'", btn.tooltip)
 		}
 	})
 }

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -142,9 +142,9 @@ func TestMacOSReleaseWorkflowPublishesCLIFromFlatArtifact(t *testing.T) {
 		t.Fatalf("macOS upload artifact path = %#v, want flat release-staging/", uploadStep.With["path"])
 	}
 
-	checksumStep := mustStepNamed(t, releaseJob, "Generate checksums")
-	mustContain(t, checksumStep.Run, "set -euo pipefail")
-	mustContain(t, checksumStep.Run, "test -s artifacts/build-macos/Picocrypt-NG-cli-macos")
+	verifyStep := mustStepNamed(t, releaseJob, "Verify artifacts present")
+	mustContain(t, verifyStep.Run, "set -euo pipefail")
+	mustContain(t, verifyStep.Run, "test -s artifacts/build-macos/Picocrypt-NG-cli-macos")
 
 	releaseStep := mustHaveStepUsingPrefix(t, releaseJob, "softprops/action-gh-release@")
 	files, ok := releaseStep.With["files"].(string)


### PR DESCRIPTION
## Summary

Restores stable, flicker-free hover tooltips on the advanced encrypt/decrypt settings in the Fyne GUI — a regression from the original (giu) Picocrypt that made the options less discoverable for newcomers.

- Fyne has **no native tooltip API** (verified against v2.7.4), so this adds `github.com/dweymouth/fyne-tooltip` v0.4.0, which renders tooltips in a **non-interactive window overlay layer** rather than an event-stealing `PopUp`. That overlay approach is what eliminates the button flicker that blocked the earlier attempt.
- Migrated the advanced `widget.Check`/`widget.Select` controls to drop-in `ttwidget.Check`/`ttwidget.Select` (they embed the originals, so wiring, disable-state, and state binding are unchanged) and assigned each its original tooltip string. "Verify first" is NG-only (no legacy string) and reuses the existing `--verify-first` CLI copy.
- Installed one window-level tooltip layer at `SetContent` (desktop/web only — mobile has no hover) and tear it down on close.
- Removed the dead, flicker-prone custom `TooltipButton` (it was never wired into the UI, only referenced by its own test).

Out of scope (optional follow-up): tooltips on the password toolbar, keyfile manager, dialogs, and the split-size entry.

Closes #79.

## Test Plan

- [x] `cd src && go build ./...`
- [x] `cd src && go test ./...` (incl. new `TestAdvancedOptionsSetTooltips` asserting each control's tooltip text)
- [x] `cd src && go vet ./...` and `golangci-lint run ./internal/ui/...` (0 issues)
- [x] `GOOS=js GOARCH=wasm go build ./cmd/wasm` (new dependency cross-compiles)
- [ ] Manual: hover each advanced control on desktop → tooltip appears after the standard delay with no flicker; switching encrypt↔decrypt keeps tooltips working