### PR TITLE
fix(macos): ad-hoc sign .app to avoid 'damaged' Gatekeeper block

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -91,6 +91,19 @@ jobs:
             Picocrypt-NG.app/Contents/Info.plist | grep -q 'io.github.picocryptng.pcv' \
             || (echo "::error::UTExportedTypeDeclarations lost UTI"; exit 1)
         # === end Phase 3 ===
+        # === Ad-hoc code signing (free; no paid Apple Developer ID) ===
+        # Re-seal the assembled bundle so the signature covers the swapped
+        # executable, icon and injected Info.plist. Without a valid seal a
+        # quarantined download triggers the harsh "app is damaged and can't be
+        # opened" Gatekeeper block on Apple Silicon (an arm64 binary must be at
+        # least ad-hoc signed to run at all). A valid ad-hoc seal downgrades
+        # that to the bypassable "unidentified developer" prompt. It does NOT
+        # remove the warning entirely; that needs a paid Developer ID +
+        # notarization. spctl --assess is intentionally NOT run here: ad-hoc
+        # signatures are expected to fail notarization assessment.
+        codesign --force --deep --sign - Picocrypt-NG.app
+        codesign --verify --deep --strict --verbose=2 Picocrypt-NG.app
+        # === end ad-hoc signing ===
         mkdir out
         cp -R Picocrypt-NG.app out
         hdiutil create Picocrypt-NG.dmg -volname Picocrypt-NG -fs APFS -format UDZO -srcfolder out

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Make sure to only download Picocrypt NG from this repository to ensure that you 
 
 If your antivirus flags Picocrypt NG as a virus, please report it as a false positive to help everyone.
 
+**Code signing:** Free Windows code signing for Picocrypt NG is provided by the [SignPath Foundation](https://signpath.org/) open-source program (integration in progress).
+
 ## macOS
 Download Picocrypt NG <a href="https://github.com/Picocrypt-NG/Picocrypt-NG/releases/latest/download/Picocrypt-NG.dmg">here</a>, open the container, and drag Picocrypt NG to your Applications.
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Download Picocrypt NG <a href="https://github.com/Picocrypt-NG/Picocrypt-NG/rele
 
 **Apple Silicon vs Intel:** The released macOS app is built for Apple Silicon and targets macOS 15.0+. Intel Mac users and users on older macOS releases need to <a href="src/README.md">build from source</a> or use the CLI-only version where appropriate.
 
-**Gatekeeper Warning:** macOS may block the app with a "forbidden" icon because the release is unsigned. If you're on supported Apple Silicon hardware and macOS 15.0+, this is a Gatekeeper warning rather than a Picocrypt NG runtime error.
+**Gatekeeper Warning:** The release is ad-hoc signed but not notarized (notarization needs a paid Apple Developer ID), so macOS shows a Gatekeeper warning the first time you open it. This is a Gatekeeper prompt, not a Picocrypt NG runtime error.
 
-To fix, use one of these methods:
+To open it, use one of these methods:
 - **Right-click → Open** (instead of double-clicking), then confirm
 - **System Settings → Privacy & Security** → scroll down → "Open Anyway"
-- **Terminal:** `xattr -cr /Applications/Picocrypt-NG.app`
+- **Terminal:** `xattr -cr /Applications/Picocrypt-NG.app` — most reliable, and the fix if a re-download re-applies quarantine and you see "app is damaged and can't be opened"
 
 The CLI-only build avoids the `.app` bundle path and is useful for terminal-only use.
 


### PR DESCRIPTION
Closes the macOS half of the launch complaints in Picocrypt-NG/discussions#163 (Ozwel: "downloaded from internet … appears as a damaged file").

## Root cause
`build-macos.yml` assembles the `.app` by swapping the executable, icon and injecting a fresh `Info.plist`, but never re-seals the bundle. An arm64 binary must be at least ad-hoc signed to run, and a quarantined download with a missing/broken bundle seal hits the harsh **"app is damaged and can't be opened"** Gatekeeper path on Apple Silicon — exactly what was reported.

## Change
- Re-seal the finished bundle with an **ad-hoc** signature (`codesign --force --deep --sign -`) before packaging into the dmg, and verify the seal in CI (`codesign --verify --deep --strict`).
- `README.md`: state the app is ad-hoc signed (not notarized) and that `xattr -cr` clears the "damaged" message if a re-download re-applies quarantine.

## What this does / does not do
- ✅ Free — no paid Apple Developer ID.
- ✅ Downgrades the hard "damaged" block to the bypassable "unidentified developer" prompt (Right-click → Open / Open Anyway).
- ❌ Does **not** remove the Gatekeeper warning entirely — that requires a paid Developer ID + notarization. `spctl --assess` is intentionally not run (ad-hoc fails notarization assessment by design).

## Verification
Cannot run `codesign` locally (no macOS). Validated by the `macos-26` CI runner via the added `codesign --verify` step; final confirmation is launching the resulting dmg on quarantined Apple Silicon.