### PR TITLE
feat(wasm): paranoid mode + header comments via options-object bridge (P0)

### DIFF
--- a/src/cmd/wasm/main.go
+++ b/src/cmd/wasm/main.go
@@ -66,10 +66,11 @@ func decrypt(this js.Value, args []js.Value) (result any) {
 	passwordBytes := []byte(args[1].String())
 	defer crypto.SecureZero(passwordBytes)
 
-	plaintext, errCode := wasm.DecryptVolume(fileData, passwordBytes)
+	res, errCode := wasm.DecryptVolume(fileData, passwordBytes)
 	if errCode != 0 {
 		return errCode
 	}
+	plaintext := res.Plaintext
 	defer crypto.SecureZero(plaintext)
 
 	out := js.Global().Get("Uint8Array").New(len(plaintext) + 1)

--- a/src/cmd/wasm/main.go
+++ b/src/cmd/wasm/main.go
@@ -106,7 +106,7 @@ func encrypt(this js.Value, args []js.Value) (result any) {
 	passwordBytes := []byte(args[1].String())
 	defer crypto.SecureZero(passwordBytes)
 
-	ciphertext, errCode := wasm.EncryptVolume(fileData, passwordBytes)
+	ciphertext, errCode := wasm.EncryptVolume(fileData, passwordBytes, wasm.EncryptOptions{})
 	if errCode != 0 {
 		return errCode
 	}

--- a/src/cmd/wasm/main.go
+++ b/src/cmd/wasm/main.go
@@ -6,118 +6,149 @@ import (
 	"syscall/js"
 
 	"Picocrypt-NG/internal/crypto"
+	"Picocrypt-NG/internal/header"
 	"Picocrypt-NG/internal/wasm"
 )
 
 func main() {
 	js.Global().Set("picocryptEncrypt", js.FuncOf(encrypt))
 	js.Global().Set("picocryptDecrypt", js.FuncOf(decrypt))
-
-	// Keep WASM alive
 	<-make(chan struct{})
 }
 
-// errInvalidArg is the bridge-level error code returned to JS when an exported
-// callback is invoked with a malformed argument (wrong arity, a non-Uint8Array
-// data argument, or a non-string password). It is a non-zero number distinct
-// from the internal/wasm pipeline codes 1-5 so the consuming site keeps
-// detecting failure via `typeof result === 'number'`.
-const errInvalidArg = 6
+const (
+	// errInvalidArg is the bridge-level failure code for a malformed options
+	// object. Non-zero and distinct from internal/wasm codes 1-5 so the site
+	// keeps treating it as failure.
+	errInvalidArg = 6
+	// maxVolumeBytes caps the in-memory whole-file model at 1 GiB.
+	maxVolumeBytes = 1 << 30
+)
 
-// validateArgs reports whether args carries the expected (Uint8Array, string)
-// pair. It performs every check via type predicates that cannot panic, so it is
-// safe to call before any args[0].Get/CopyBytesToGo access. A malformed call
-// from JS (null, a number, a non-Uint8Array typed array, a missing password)
-// is rejected here instead of crashing the instance.
-func validateArgs(args []js.Value) bool {
-	if len(args) < 2 {
-		return false
-	}
-	if !args[0].InstanceOf(js.Global().Get("Uint8Array")) {
-		return false
-	}
-	return args[1].Type() == js.TypeString
+// errorResult builds {code: N}.
+func errorResult(code int) any {
+	o := js.Global().Get("Object").New()
+	o.Set("code", code)
+	return o
 }
 
-// args[0] = Uint8Array, args[1] = password string
-// returns Uint8Array (0 prefix + plaintext) or error code int
-func decrypt(this js.Value, args []js.Value) (result any) {
-	// Recover from any panic so a malformed js.Value cannot escape FuncOf and
-	// kill the WASM instance; return the same error code the caller handles.
-	defer func() {
-		if r := recover(); r != nil {
-			result = errInvalidArg
-		}
-	}()
-
-	if !validateArgs(args) {
-		return errInvalidArg
+// readUint8Array copies a real Uint8Array to a Go slice. ok=false for any other
+// shape (undefined, null, wrong typed array, plain object) — checked before any
+// length/byte access so a bad value cannot panic.
+func readUint8Array(v js.Value) ([]byte, bool) {
+	if !v.InstanceOf(js.Global().Get("Uint8Array")) {
+		return nil, false
 	}
+	n := v.Get("length").Int()
+	b := make([]byte, n)
+	js.CopyBytesToGo(b, v)
+	return b, true
+}
 
-	length := args[0].Get("length").Int()
-	if length <= 0 || length > 1<<30 {
-		return 1
+// optBool reads obj[key] as a boolean, defaulting to false.
+func optBool(obj js.Value, key string) bool {
+	v := obj.Get(key)
+	return v.Type() == js.TypeBoolean && v.Bool()
+}
+
+// optString reads obj[key] as a string, defaulting to "".
+func optString(obj js.Value, key string) string {
+	v := obj.Get(key)
+	if v.Type() == js.TypeString {
+		return v.String()
 	}
+	return ""
+}
 
-	fileData := make([]byte, length)
-	js.CopyBytesToGo(fileData, args[0])
-	defer crypto.SecureZero(fileData)
-
-	passwordBytes := []byte(args[1].String())
-	defer crypto.SecureZero(passwordBytes)
-
-	res, errCode := wasm.DecryptVolume(fileData, passwordBytes)
-	if errCode != 0 {
-		return errCode
-	}
-	plaintext := res.Plaintext
-	defer crypto.SecureZero(plaintext)
-
-	out := js.Global().Get("Uint8Array").New(len(plaintext) + 1)
-	resultData := make([]byte, len(plaintext)+1)
-	defer crypto.SecureZero(resultData)
-	resultData[0] = 0
-	copy(resultData[1:], plaintext)
-	js.CopyBytesToJS(out, resultData)
-	return out
+// successData builds {code:0, data: Uint8Array}.
+func successData(data []byte) any {
+	out := js.Global().Get("Uint8Array").New(len(data))
+	js.CopyBytesToJS(out, data)
+	o := js.Global().Get("Object").New()
+	o.Set("code", 0)
+	o.Set("data", out)
+	return o
 }
 
 func encrypt(this js.Value, args []js.Value) (result any) {
-	// Recover from any panic so a malformed js.Value cannot escape FuncOf and
-	// kill the WASM instance; return the same error code the caller handles.
+	// A panic between validation and use must not escape FuncOf and kill the
+	// instance; convert it to the same malformed-argument code.
 	defer func() {
 		if r := recover(); r != nil {
-			result = errInvalidArg
+			result = errorResult(errInvalidArg)
 		}
 	}()
 
-	if !validateArgs(args) {
-		return errInvalidArg
+	if len(args) < 1 || args[0].Type() != js.TypeObject {
+		return errorResult(errInvalidArg)
 	}
+	opts := args[0]
 
-	length := args[0].Get("length").Int()
-	if length <= 0 || length > 1<<30 {
-		return 1
+	data, ok := readUint8Array(opts.Get("data"))
+	if !ok || len(data) == 0 || len(data) > maxVolumeBytes {
+		return errorResult(errInvalidArg)
 	}
+	pw := opts.Get("password")
+	if pw.Type() != js.TypeString {
+		return errorResult(errInvalidArg)
+	}
+	comments := optString(opts, "comments")
+	if len(comments) > header.MaxCommentLen {
+		return errorResult(errInvalidArg)
+	}
+	paranoid := optBool(opts, "paranoid")
 
-	fileData := make([]byte, length)
-	js.CopyBytesToGo(fileData, args[0])
-	defer crypto.SecureZero(fileData)
-
-	passwordBytes := []byte(args[1].String())
+	passwordBytes := []byte(pw.String())
 	defer crypto.SecureZero(passwordBytes)
+	defer crypto.SecureZero(data)
 
-	ciphertext, errCode := wasm.EncryptVolume(fileData, passwordBytes, wasm.EncryptOptions{})
-	if errCode != 0 {
-		return errCode
+	volumeData, code := wasm.EncryptVolume(data, passwordBytes, wasm.EncryptOptions{
+		Paranoid: paranoid,
+		Comments: comments,
+	})
+	if code != 0 {
+		return errorResult(code)
 	}
-	defer crypto.SecureZero(ciphertext)
+	defer crypto.SecureZero(volumeData)
+	return successData(volumeData)
+}
 
-	out := js.Global().Get("Uint8Array").New(len(ciphertext) + 1)
-	resultData := make([]byte, len(ciphertext)+1)
-	defer crypto.SecureZero(resultData)
-	resultData[0] = 0
-	copy(resultData[1:], ciphertext)
-	js.CopyBytesToJS(out, resultData)
-	return out
+func decrypt(this js.Value, args []js.Value) (result any) {
+	defer func() {
+		if r := recover(); r != nil {
+			result = errorResult(errInvalidArg)
+		}
+	}()
+
+	if len(args) < 1 || args[0].Type() != js.TypeObject {
+		return errorResult(errInvalidArg)
+	}
+	opts := args[0]
+
+	data, ok := readUint8Array(opts.Get("data"))
+	if !ok || len(data) == 0 || len(data) > maxVolumeBytes {
+		return errorResult(errInvalidArg)
+	}
+	pw := opts.Get("password")
+	if pw.Type() != js.TypeString {
+		return errorResult(errInvalidArg)
+	}
+
+	passwordBytes := []byte(pw.String())
+	defer crypto.SecureZero(passwordBytes)
+	defer crypto.SecureZero(data)
+
+	res, code := wasm.DecryptVolume(data, passwordBytes)
+	if code != 0 {
+		return errorResult(code)
+	}
+	defer crypto.SecureZero(res.Plaintext)
+
+	out := js.Global().Get("Uint8Array").New(len(res.Plaintext))
+	js.CopyBytesToJS(out, res.Plaintext)
+	o := js.Global().Get("Object").New()
+	o.Set("code", 0)
+	o.Set("data", out)
+	o.Set("comments", res.Comments)
+	return o
 }

--- a/src/cmd/wasm/validate_wasm_test.go
+++ b/src/cmd/wasm/validate_wasm_test.go
@@ -7,24 +7,10 @@ import (
 	"testing"
 )
 
-// These tests run under a live JS host via the wasm exec shim, e.g.:
-//
-//	cd src && GOOS=js GOARCH=wasm go test ./cmd/wasm/ \
-//	    -exec "$(go env GOROOT)/lib/wasm/go_js_wasm_exec"
-//
-// The //go:build js && wasm tag excludes them from a normal `go test ./...`, so
-// they only ever execute where syscall/js is real. No node on PATH => the exec
-// shim cannot run them at all (they are skipped by absence, never silently
-// passed).
-
-// TestInvalidArgErrorCodeContract pins the bridge-level error code returned to
-// JS for a malformed argument. WHY: the consuming website detects failure via
-// `typeof result === 'number'` and maps the internal/wasm codes 1-5; a new
-// malformed-argument code must stay a non-zero number distinct from 1-5 so the
-// site still treats it as failure (not success, not a hang).
+// Pins the bridge error code: non-zero and distinct from internal/wasm 1-5.
 func TestInvalidArgErrorCodeContract(t *testing.T) {
 	if errInvalidArg == 0 {
-		t.Fatal("errInvalidArg must be non-zero so JS sees an error number, not success")
+		t.Fatal("errInvalidArg must be non-zero")
 	}
 	for _, c := range []int{1, 2, 3, 4, 5} {
 		if errInvalidArg == c {
@@ -33,89 +19,91 @@ func TestInvalidArgErrorCodeContract(t *testing.T) {
 	}
 }
 
-// TestValidateArgsArity locks the arity gate: fewer than two arguments is
-// rejected before any js.Value field access (which would panic).
-func TestValidateArgsArity(t *testing.T) {
-	if validateArgs([]js.Value{}) {
-		t.Fatal("validateArgs must reject zero args")
+// codeOf extracts result.code from a bridge return; -1 if the shape is wrong.
+func codeOf(v any) int {
+	jv, ok := v.(js.Value)
+	if !ok || jv.Type() != js.TypeObject {
+		return -1
 	}
-	if validateArgs([]js.Value{js.Undefined()}) {
-		t.Fatal("validateArgs must reject fewer than 2 args")
+	c := jv.Get("code")
+	if c.Type() != js.TypeNumber {
+		return -1
 	}
+	return c.Int()
 }
 
-// TestValidateArgsRejectsBadShapes locks the type gate: args[0] must be a real
-// Uint8Array and args[1] must be a string. Each rejected shape here is one that
-// would otherwise drive args[0].Get("length").Int() / CopyBytesToGo into a
-// panic and kill the instance.
-func TestValidateArgsRejectsBadShapes(t *testing.T) {
-	validData := js.Global().Get("Uint8Array").New(4)
+func newOpts(fields map[string]any) js.Value {
+	o := js.Global().Get("Object").New()
+	for k, val := range fields {
+		o.Set(k, val)
+	}
+	return o
+}
+
+// Malformed inputs must return {code: errInvalidArg}, never panic out of FuncOf.
+func TestBridgeRejectsBadInput(t *testing.T) {
+	u8 := js.Global().Get("Uint8Array").New(4)
 	cases := []struct {
 		name string
-		a0   js.Value
-		a1   js.Value
+		arg  js.Value
 	}{
-		{"null data", js.Null(), js.ValueOf("pw")},
-		{"undefined data", js.Undefined(), js.ValueOf("pw")},
-		{"number data", js.ValueOf(42), js.ValueOf("pw")},
-		{"string data", js.ValueOf("not-bytes"), js.ValueOf("pw")},
-		{"wrong typed array", js.Global().Get("Int8Array").New(4), js.ValueOf("pw")},
-		{"non-string password", validData, js.ValueOf(42)},
+		{"non-object arg", js.ValueOf(42)},
+		{"missing data", newOpts(map[string]any{"password": "pw"})},
+		{"data not uint8array", newOpts(map[string]any{"data": "nope", "password": "pw"})},
+		{"missing password", newOpts(map[string]any{"data": u8})},
+		{"password not string", newOpts(map[string]any{"data": u8, "password": 7})},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if validateArgs([]js.Value{tc.a0, tc.a1}) {
-				t.Fatalf("validateArgs accepted invalid args (%s)", tc.name)
-			}
-		})
-	}
-}
-
-// TestValidateArgsAcceptsValid ensures the gate does not reject a legitimate
-// (Uint8Array, string) pair.
-func TestValidateArgsAcceptsValid(t *testing.T) {
-	if !validateArgs([]js.Value{js.Global().Get("Uint8Array").New(4), js.ValueOf("pw")}) {
-		t.Fatal("validateArgs rejected a valid (Uint8Array, string) pair")
-	}
-}
-
-// TestCallbacksDoNotCrashOnBadArg is the core DoS regression: a malformed
-// argument that on HEAD drives args[0].Get("length").Int() to panic out of the
-// js.FuncOf trampoline (permanently killing the WASM instance, with main()
-// parked on <-make(chan struct{}) and no recovery short of page reload) must
-// instead return the int errInvalidArg and leave the instance alive. The test
-// invokes the exported callbacks directly with a number where a Uint8Array is
-// expected and asserts a clean int return — proving no panic escaped.
-func TestCallbacksDoNotCrashOnBadArg(t *testing.T) {
-	badArgs := []js.Value{js.ValueOf(42), js.ValueOf("pw")}
-	callbacks := []struct {
+	for _, cb := range []struct {
 		name string
 		fn   func(js.Value, []js.Value) any
-	}{
-		{"encrypt", encrypt},
-		{"decrypt", decrypt},
-	}
-	for _, cb := range callbacks {
-		t.Run(cb.name, func(t *testing.T) {
-			got := cb.fn(js.Undefined(), badArgs)
-			n, ok := got.(int)
-			if !ok {
-				t.Fatalf("%s(badArg) returned %T (%v); want int errInvalidArg", cb.name, got, got)
-			}
-			if n != errInvalidArg {
-				t.Fatalf("%s(badArg)=%d; want errInvalidArg=%d", cb.name, n, errInvalidArg)
-			}
-		})
+	}{{"encrypt", encrypt}, {"decrypt", decrypt}} {
+		for _, tc := range cases {
+			t.Run(cb.name+"/"+tc.name, func(t *testing.T) {
+				if got := codeOf(cb.fn(js.Undefined(), []js.Value{tc.arg})); got != errInvalidArg {
+					t.Fatalf("%s(%s) code=%d; want errInvalidArg=%d", cb.name, tc.name, got, errInvalidArg)
+				}
+			})
+		}
 	}
 }
 
-// The recover() defers in encrypt/decrypt are a forward-looking backstop for a
-// Go panic occurring between validation and use. They are not separately unit
-// tested here because, once validateArgs has accepted the arguments, a genuine
-// Uint8Array drives no panic at all, and the only "instanceof Uint8Array but not
-// a real typed array" shape (e.g. Object.create(Uint8Array.prototype)) throws a
-// JS host exception inside syscall/js when its length getter runs — that is not a
-// Go panic and recover() cannot intercept it. Such a shape can only come from
-// adversarial same-origin JS; the consuming site's contract passes a real
-// Uint8Array. The realistic malformed-argument cases are covered by
-// TestValidateArgsRejectsBadShapes and TestCallbacksDoNotCrashOnBadArg above.
+// Over-long comments are rejected at the bridge with errInvalidArg.
+func TestBridgeRejectsLongComments(t *testing.T) {
+	u8 := js.Global().Get("Uint8Array").New(4)
+	long := make([]byte, 0)
+	for i := 0; i < 100000; i++ { // > header.MaxCommentLen (99999)
+		long = append(long, 'a')
+	}
+	arg := newOpts(map[string]any{"data": u8, "password": "pw", "comments": string(long)})
+	if got := codeOf(encrypt(js.Undefined(), []js.Value{arg})); got != errInvalidArg {
+		t.Fatalf("over-long comments code=%d; want errInvalidArg=%d", got, errInvalidArg)
+	}
+}
+
+// A valid encrypt then decrypt round-trips through the bridge objects, carrying comments.
+func TestBridgeRoundTrip(t *testing.T) {
+	plain := []byte("bridge round trip")
+	u8 := js.Global().Get("Uint8Array").New(len(plain))
+	js.CopyBytesToJS(u8, plain)
+
+	encArg := newOpts(map[string]any{"data": u8, "password": "pw", "paranoid": true, "comments": "hi"})
+	encRes := encrypt(js.Undefined(), []js.Value{encArg}).(js.Value)
+	if encRes.Get("code").Int() != 0 {
+		t.Fatalf("encrypt code=%d; want 0", encRes.Get("code").Int())
+	}
+
+	decArg := newOpts(map[string]any{"data": encRes.Get("data"), "password": "pw"})
+	decRes := decrypt(js.Undefined(), []js.Value{decArg}).(js.Value)
+	if decRes.Get("code").Int() != 0 {
+		t.Fatalf("decrypt code=%d; want 0", decRes.Get("code").Int())
+	}
+	if decRes.Get("comments").String() != "hi" {
+		t.Fatalf("comments=%q; want %q", decRes.Get("comments").String(), "hi")
+	}
+	out := decRes.Get("data")
+	got := make([]byte, out.Get("length").Int())
+	js.CopyBytesToGo(got, out)
+	if string(got) != string(plain) {
+		t.Fatalf("round-trip data=%q; want %q", got, plain)
+	}
+}

--- a/src/internal/wasm/decrypt.go
+++ b/src/internal/wasm/decrypt.go
@@ -21,13 +21,20 @@ const (
 	ErrRandomFailure   = 5 // Random generation failed (encrypt only)
 )
 
+// DecryptResult is the successful output of DecryptVolume. On error the int
+// code is non-zero and the result is the zero value.
+type DecryptResult struct {
+	Plaintext []byte
+	Comments  string // plaintext header comments ("" if none)
+}
+
 // DecryptVolume decrypts a Picocrypt volume from memory.
-// Returns (plaintext, 0) on success, or (nil, errorCode) on failure.
-func DecryptVolume(volumeData, password []byte) ([]byte, int) {
+// Returns (DecryptResult, 0) on success, or (zero, errorCode) on failure.
+func DecryptVolume(volumeData, password []byte) (DecryptResult, int) {
 	// Initialize RS codecs
 	rsCodecs, err := encoding.NewRSCodecs()
 	if err != nil {
-		return nil, ErrCorruptedHeader
+		return DecryptResult{}, ErrCorruptedHeader
 	}
 
 	// Create reader from volume data
@@ -37,13 +44,13 @@ func DecryptVolume(volumeData, password []byte) ([]byte, int) {
 	headerReader := header.NewReader(reader, rsCodecs)
 	result, err := headerReader.ReadHeader()
 	if err != nil {
-		return nil, ErrCorruptedHeader
+		return DecryptResult{}, ErrCorruptedHeader
 	}
 	hdr := result.Header
 
 	// Check for unsupported features
 	if hasUnsupportedWASMFeature(hdr.Flags) {
-		return nil, ErrUnsupported
+		return DecryptResult{}, ErrUnsupported
 	}
 
 	// Prepare keyfile hash (zeros since no keyfiles)
@@ -61,12 +68,12 @@ func DecryptVolume(volumeData, password []byte) ([]byte, int) {
 		k, err := crypto.DeriveKey(cand, hdr.Salt, hdr.Flags.Paranoid)
 		zeroWASMSensitiveBuffer(wasmZeroingDecryptPasswordBytes, cand)
 		if err != nil {
-			return nil, ErrCorruptedHeader
+			return DecryptResult{}, ErrCorruptedHeader
 		}
 		valid, sr, errCode := verifyWASMHeader(k, hdr, keyfileHash, isLegacyV1)
 		if errCode != 0 {
 			crypto.SecureZero(k)
-			return nil, errCode
+			return DecryptResult{}, errCode
 		}
 		if valid {
 			key = k
@@ -76,26 +83,26 @@ func DecryptVolume(volumeData, password []byte) ([]byte, int) {
 		crypto.SecureZero(k)
 	}
 	if key == nil {
-		return nil, ErrWrongPassword
+		return DecryptResult{}, ErrWrongPassword
 	}
 	defer crypto.SecureZero(key)
 
 	// Read remaining subkeys
 	macSubkey, err := subkeyReader.MACSubkey()
 	if err != nil {
-		return nil, ErrCorruptedHeader
+		return DecryptResult{}, ErrCorruptedHeader
 	}
 
 	serpentKey, err := subkeyReader.SerpentKey()
 	if err != nil {
-		return nil, ErrCorruptedHeader
+		return DecryptResult{}, ErrCorruptedHeader
 	}
 
 	// Create MAC
 	mac, err := crypto.NewMAC(macSubkey, hdr.Flags.Paranoid)
 	zeroWASMSensitiveBuffer(wasmZeroingDecryptMACSubkey, macSubkey)
 	if err != nil {
-		return nil, ErrCorruptedHeader
+		return DecryptResult{}, ErrCorruptedHeader
 	}
 
 	// Create cipher suite
@@ -110,7 +117,7 @@ func DecryptVolume(volumeData, password []byte) ([]byte, int) {
 	)
 	zeroWASMSensitiveBuffer(wasmZeroingDecryptSerpentKey, serpentKey)
 	if err != nil {
-		return nil, ErrCorruptedHeader
+		return DecryptResult{}, ErrCorruptedHeader
 	}
 	defer cipherSuite.Close()
 
@@ -118,7 +125,7 @@ func DecryptVolume(volumeData, password []byte) ([]byte, int) {
 	headerSize := header.HeaderSize(len(hdr.Comments))
 	payloadSize := len(volumeData) - headerSize
 	if payloadSize <= 0 {
-		return nil, ErrCorruptedHeader
+		return DecryptResult{}, ErrCorruptedHeader
 	}
 
 	// Read payload from remaining bytes
@@ -129,7 +136,7 @@ func DecryptVolume(volumeData, password []byte) ([]byte, int) {
 	var counter int64
 	plaintext, err := decryptPlainPayload(payload, cipherSuite, &counter)
 	if err != nil {
-		return nil, ErrModifiedData
+		return DecryptResult{}, ErrModifiedData
 	}
 
 	// Verify MAC
@@ -138,10 +145,10 @@ func DecryptVolume(volumeData, password []byte) ([]byte, int) {
 	zeroWASMSensitiveBuffer(wasmZeroingDecryptComputedMAC, computedMAC)
 	if !macValid {
 		zeroWASMSensitiveBuffer(wasmZeroingDecryptPlaintextChunk, plaintext)
-		return nil, ErrModifiedData
+		return DecryptResult{}, ErrModifiedData
 	}
 
-	return plaintext, 0
+	return DecryptResult{Plaintext: plaintext, Comments: hdr.Comments}, 0
 }
 
 // verifyWASMHeader checks whether key authenticates the volume header and, on
@@ -175,8 +182,7 @@ func verifyWASMHeader(key []byte, hdr *header.VolumeHeader, keyfileHash []byte, 
 }
 
 func hasUnsupportedWASMFeature(flags header.Flags) bool {
-	return flags.Paranoid ||
-		flags.UseKeyfiles ||
+	return flags.UseKeyfiles ||
 		flags.KeyfileOrdered ||
 		flags.ReedSolomon ||
 		flags.Padded

--- a/src/internal/wasm/encrypt.go
+++ b/src/internal/wasm/encrypt.go
@@ -88,10 +88,16 @@ func (w byteSliceWriterAt) WriteAt(p []byte, off int64) (int, error) {
 	return len(p), nil
 }
 
+// EncryptOptions configures an in-memory encryption. Zero value = normal,
+// no-comment volume (the pre-P0 behavior).
+type EncryptOptions struct {
+	Paranoid bool   // 8 Argon2 passes, Serpent-CTR + XChaCha20, HMAC-SHA3
+	Comments string // plaintext header comments (NOT encrypted); len <= header.MaxCommentLen
+}
+
 // EncryptVolume encrypts plaintext data into a Picocrypt volume.
 // Returns (ciphertext, 0) on success, or (nil, errorCode) on failure.
-// Web version: password-only, no keyfiles, no paranoid mode, no RS on payload.
-func EncryptVolume(plaintext, password []byte) ([]byte, int) {
+func EncryptVolume(plaintext, password []byte, opts EncryptOptions) ([]byte, int) {
 	// Initialize RS codecs
 	rsCodecs, err := encoding.NewRSCodecs()
 	if err != nil {
@@ -119,20 +125,21 @@ func EncryptVolume(plaintext, password []byte) ([]byte, int) {
 		return nil, ErrRandomFailure
 	}
 
-	// Create header (normal mode, no keyfiles, no RS on payload)
+	// Create header; flags/comments come from opts.
 	hdr := header.NewVolumeHeader(salt, hkdfSalt, serpentIV, nonce)
 	hdr.Flags = header.Flags{
-		Paranoid:       false,
-		UseKeyfiles:    false,
-		KeyfileOrdered: false,
-		ReedSolomon:    false, // No RS on payload for web version (simpler, smaller)
-		Padded:         false,
+		Paranoid:       opts.Paranoid,
+		UseKeyfiles:    false, // P1
+		KeyfileOrdered: false, // P1
+		ReedSolomon:    false, // P2
+		Padded:         false, // P2
 	}
+	hdr.Comments = opts.Comments
 
 	// Derive key from the NFC-normalized password (#19) so web-encrypted
 	// volumes are cross-platform-decryptable regardless of how it was typed.
 	passwordBytes := pwnorm.EncodeForKDF(password)
-	key, err := crypto.DeriveKey(passwordBytes, salt, false)
+	key, err := crypto.DeriveKey(passwordBytes, salt, opts.Paranoid)
 	zeroWASMSensitiveBuffer(wasmZeroingPasswordBytes, passwordBytes)
 	if err != nil {
 		return nil, ErrRandomFailure
@@ -179,14 +186,14 @@ func EncryptVolume(plaintext, password []byte) ([]byte, int) {
 		return nil, ErrRandomFailure
 	}
 
-	// Create MAC (normal mode = BLAKE2b)
-	mac, err := crypto.NewMAC(macSubkey, false)
+	// Create MAC
+	mac, err := crypto.NewMAC(macSubkey, opts.Paranoid)
 	zeroWASMSensitiveBuffer(wasmZeroingMACSubkey, macSubkey)
 	if err != nil {
 		return nil, ErrRandomFailure
 	}
 
-	// Create cipher suite (normal mode, no Serpent)
+	// Create cipher suite
 	cipherSuite, err := crypto.NewCipherSuite(
 		key,
 		nonce,
@@ -194,7 +201,7 @@ func EncryptVolume(plaintext, password []byte) ([]byte, int) {
 		serpentIV,
 		mac,
 		subkeyReader.Reader(),
-		false, // not paranoid
+		opts.Paranoid,
 	)
 	zeroWASMSensitiveBuffer(wasmZeroingSerpentKey, serpentKey)
 	if err != nil {
@@ -229,9 +236,13 @@ func EncryptVolume(plaintext, password []byte) ([]byte, int) {
 	for offset := 0; offset < len(plaintext); offset += chunkSize {
 		end := min(offset+chunkSize, len(plaintext))
 
-		chunk := plaintext[offset:end]
+		// Copy chunk: paranoid Encrypt mutates src (Serpent intermediate), which
+		// would corrupt the caller's plaintext buffer if we passed a slice of it.
+		chunk := make([]byte, end-offset)
+		copy(chunk, plaintext[offset:end])
 		dst := make([]byte, len(chunk))
 		cipherSuite.Encrypt(dst, chunk)
+		crypto.SecureZero(chunk)
 		ciphertextBuf.Write(dst)
 		zeroWASMSensitiveBuffer(wasmZeroingCiphertextChunk, dst)
 

--- a/src/internal/wasm/normalization_test.go
+++ b/src/internal/wasm/normalization_test.go
@@ -20,7 +20,7 @@ var (
 func TestWASMEncryptNormalizesPassword(t *testing.T) {
 	original := []byte("cross-platform web volume")
 
-	ciphertext, errCode := EncryptVolume(original, []byte(nfdPassword))
+	ciphertext, errCode := EncryptVolume(original, []byte(nfdPassword), EncryptOptions{})
 	if errCode != 0 {
 		t.Fatalf("encrypt failed with error code %d", errCode)
 	}
@@ -50,7 +50,7 @@ func TestWASMDecryptTriesNormalizationForms(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			original := []byte("web cross-form payload")
-			ciphertext, errCode := EncryptVolume(original, []byte(tc.encrypt))
+			ciphertext, errCode := EncryptVolume(original, []byte(tc.encrypt), EncryptOptions{})
 			if errCode != 0 {
 				t.Fatalf("encrypt failed with error code %d", errCode)
 			}

--- a/src/internal/wasm/normalization_test.go
+++ b/src/internal/wasm/normalization_test.go
@@ -25,12 +25,12 @@ func TestWASMEncryptNormalizesPassword(t *testing.T) {
 		t.Fatalf("encrypt failed with error code %d", errCode)
 	}
 
-	plaintext, errCode := DecryptVolume(ciphertext, []byte(nfcPassword))
+	res, errCode := DecryptVolume(ciphertext, []byte(nfcPassword))
 	if errCode != 0 {
 		t.Fatalf("decrypt with composed form failed (code %d): encrypt did not normalize to NFC", errCode)
 	}
-	if !bytes.Equal(plaintext, original) {
-		t.Errorf("roundtrip mismatch\ngot:  %q\nwant: %q", plaintext, original)
+	if !bytes.Equal(res.Plaintext, original) {
+		t.Errorf("roundtrip mismatch\ngot:  %q\nwant: %q", res.Plaintext, original)
 	}
 }
 
@@ -54,12 +54,12 @@ func TestWASMDecryptTriesNormalizationForms(t *testing.T) {
 			if errCode != 0 {
 				t.Fatalf("encrypt failed with error code %d", errCode)
 			}
-			plaintext, errCode := DecryptVolume(ciphertext, []byte(tc.decrypt))
+			res, errCode := DecryptVolume(ciphertext, []byte(tc.decrypt))
 			if errCode != 0 {
 				t.Fatalf("decrypt failed with error code %d (try-both not applied?)", errCode)
 			}
-			if !bytes.Equal(plaintext, original) {
-				t.Errorf("roundtrip mismatch\ngot:  %q\nwant: %q", plaintext, original)
+			if !bytes.Equal(res.Plaintext, original) {
+				t.Errorf("roundtrip mismatch\ngot:  %q\nwant: %q", res.Plaintext, original)
 			}
 		})
 	}

--- a/src/internal/wasm/wasm_test.go
+++ b/src/internal/wasm/wasm_test.go
@@ -21,7 +21,7 @@ func TestDecryptV1(t *testing.T) {
 	}
 
 	// Decrypt with password "test"
-	plaintext, errCode := DecryptVolume(volumeData, []byte("test"))
+	res, errCode := DecryptVolume(volumeData, []byte("test"))
 	if errCode != 0 {
 		t.Fatalf("decrypt failed with error code %d", errCode)
 	}
@@ -34,8 +34,8 @@ func TestDecryptV1(t *testing.T) {
 
 	// Normalize line endings: git may convert \n → \r\n on Windows checkout
 	expected = bytes.ReplaceAll(expected, []byte("\r\n"), []byte("\n"))
-	if !bytes.Equal(plaintext, expected) {
-		t.Errorf("decrypted content doesn't match expected\ngot: %q\nwant: %q", plaintext, expected)
+	if !bytes.Equal(res.Plaintext, expected) {
+		t.Errorf("decrypted content doesn't match expected\ngot: %q\nwant: %q", res.Plaintext, expected)
 	}
 }
 
@@ -47,7 +47,7 @@ func TestDecryptV2(t *testing.T) {
 	}
 
 	// Decrypt with password "test"
-	plaintext, errCode := DecryptVolume(volumeData, []byte("test"))
+	res, errCode := DecryptVolume(volumeData, []byte("test"))
 	if errCode != 0 {
 		t.Fatalf("decrypt failed with error code %d", errCode)
 	}
@@ -59,8 +59,8 @@ func TestDecryptV2(t *testing.T) {
 	}
 
 	expected = bytes.ReplaceAll(expected, []byte("\r\n"), []byte("\n"))
-	if !bytes.Equal(plaintext, expected) {
-		t.Errorf("decrypted content doesn't match expected\ngot: %q\nwant: %q", plaintext, expected)
+	if !bytes.Equal(res.Plaintext, expected) {
+		t.Errorf("decrypted content doesn't match expected\ngot: %q\nwant: %q", res.Plaintext, expected)
 	}
 }
 
@@ -87,13 +87,13 @@ func TestEncryptDecryptRoundtrip(t *testing.T) {
 	}
 
 	// Decrypt
-	plaintext, errCode := DecryptVolume(ciphertext, []byte(password))
+	res, errCode := DecryptVolume(ciphertext, []byte(password))
 	if errCode != 0 {
 		t.Fatalf("decrypt failed with error code %d", errCode)
 	}
 
-	if !bytes.Equal(plaintext, original) {
-		t.Errorf("roundtrip failed\ngot: %q\nwant: %q", plaintext, original)
+	if !bytes.Equal(res.Plaintext, original) {
+		t.Errorf("roundtrip failed\ngot: %q\nwant: %q", res.Plaintext, original)
 	}
 }
 
@@ -112,12 +112,12 @@ func TestEncryptDecryptLargerFile(t *testing.T) {
 	}
 
 	// Decrypt
-	plaintext, errCode := DecryptVolume(ciphertext, []byte(password))
+	res, errCode := DecryptVolume(ciphertext, []byte(password))
 	if errCode != 0 {
 		t.Fatalf("decrypt failed with error code %d", errCode)
 	}
 
-	if !bytes.Equal(plaintext, original) {
+	if !bytes.Equal(res.Plaintext, original) {
 		t.Errorf("roundtrip failed for larger file")
 	}
 }
@@ -320,10 +320,6 @@ func TestWASMUnsupportedFeatureFlagsReturnUnsupported(t *testing.T) {
 			name:  "reed_solomon_padding",
 			flags: header.Flags{Padded: true},
 		},
-		{
-			name:  "paranoid",
-			flags: header.Flags{Paranoid: true},
-		},
 	}
 
 	for _, tc := range cases {
@@ -352,10 +348,11 @@ func TestWASMDecryptBuffersZeroed(t *testing.T) {
 	})
 	defer restore()
 
-	plaintext, errCode := DecryptVolume(volumeData, []byte(password))
+	res, errCode := DecryptVolume(volumeData, []byte(password))
 	if errCode != 0 {
 		t.Fatalf("DecryptVolume returned error code %d", errCode)
 	}
+	plaintext := res.Plaintext
 	if !bytes.Equal(plaintext, original) {
 		t.Fatalf("plaintext mismatch\ngot:  %q\nwant: %q", plaintext, original)
 	}
@@ -442,6 +439,49 @@ func TestWASMParanoidCommentsDesktopDecrypt(t *testing.T) {
 	}
 	if !bytes.Equal(got, original) {
 		t.Fatalf("desktop decrypt mismatch\ngot:  %q\nwant: %q", got, original)
+	}
+}
+
+func TestWASMDecryptParanoidAndComments(t *testing.T) {
+	original := []byte("P0: desktop paranoid volume decrypts in WASM and yields comments.")
+	password := "p0-desktop-to-wasm"
+	comments := "round-trip comment"
+
+	// Desktop-encrypt a paranoid volume with comments to a temp file.
+	tmpDir := t.TempDir()
+	inPath := filepath.Join(tmpDir, "plain.txt")
+	outPath := filepath.Join(tmpDir, "vol.pcv")
+	if err := os.WriteFile(inPath, original, 0600); err != nil {
+		t.Fatalf("write plaintext: %v", err)
+	}
+	rs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("NewRSCodecs failed: %v", err)
+	}
+	if err := volume.Encrypt(context.Background(), &volume.EncryptRequest{
+		InputFile:  inPath,
+		OutputFile: outPath,
+		Password:   []byte(password),
+		Paranoid:   true,
+		Comments:   comments,
+		RSCodecs:   rs,
+	}); err != nil {
+		t.Fatalf("volume.Encrypt failed: %v", err)
+	}
+	volumeData, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read volume: %v", err)
+	}
+
+	got, errCode := DecryptVolume(volumeData, []byte(password))
+	if errCode != 0 {
+		t.Fatalf("DecryptVolume error code %d", errCode)
+	}
+	if !bytes.Equal(got.Plaintext, original) {
+		t.Fatalf("plaintext mismatch\ngot:  %q\nwant: %q", got.Plaintext, original)
+	}
+	if got.Comments != comments {
+		t.Fatalf("comments = %q; want %q", got.Comments, comments)
 	}
 }
 

--- a/src/internal/wasm/wasm_test.go
+++ b/src/internal/wasm/wasm_test.go
@@ -81,7 +81,7 @@ func TestEncryptDecryptRoundtrip(t *testing.T) {
 	password := "testpassword123"
 
 	// Encrypt
-	ciphertext, errCode := EncryptVolume(original, []byte(password))
+	ciphertext, errCode := EncryptVolume(original, []byte(password), EncryptOptions{})
 	if errCode != 0 {
 		t.Fatalf("encrypt failed with error code %d", errCode)
 	}
@@ -106,7 +106,7 @@ func TestEncryptDecryptLargerFile(t *testing.T) {
 	password := "testpassword123"
 
 	// Encrypt
-	ciphertext, errCode := EncryptVolume(original, []byte(password))
+	ciphertext, errCode := EncryptVolume(original, []byte(password), EncryptOptions{})
 	if errCode != 0 {
 		t.Fatalf("encrypt failed with error code %d", errCode)
 	}
@@ -151,7 +151,7 @@ func TestWASMUsesWriteAuthValues(t *testing.T) {
 		return originalWriteAuthValues(w, offset, sentinelKeyHash, sentinelKeyfileHash, sentinelAuthTag, rs)
 	}
 
-	volumeData, errCode := EncryptVolume([]byte("phase 6 wasm auth writer guard"), []byte("phase6-password"))
+	volumeData, errCode := EncryptVolume([]byte("phase 6 wasm auth writer guard"), []byte("phase6-password"), EncryptOptions{})
 	if errCode != 0 {
 		t.Fatalf("EncryptVolume returned error code %d", errCode)
 	}
@@ -183,7 +183,7 @@ func TestWASMRoundtripDesktopDecrypt(t *testing.T) {
 	original := []byte("Phase 6 WASM standard volume decrypts through the shared desktop volume path.")
 	password := "phase6-desktop-interop"
 
-	volumeData, errCode := EncryptVolume(original, []byte(password))
+	volumeData, errCode := EncryptVolume(original, []byte(password), EncryptOptions{})
 	if errCode != 0 {
 		t.Fatalf("EncryptVolume returned error code %d", errCode)
 	}
@@ -236,7 +236,7 @@ func TestWASMBuffersZeroed(t *testing.T) {
 	})
 	defer restore()
 
-	volumeData, errCode := EncryptVolume(plaintext, []byte(password))
+	volumeData, errCode := EncryptVolume(plaintext, []byte(password), EncryptOptions{})
 	if errCode != 0 {
 		t.Fatalf("EncryptVolume returned error code %d", errCode)
 	}
@@ -341,7 +341,7 @@ func TestWASMUnsupportedFeatureFlagsReturnUnsupported(t *testing.T) {
 func TestWASMDecryptBuffersZeroed(t *testing.T) {
 	original := []byte("Phase 6 decrypt zeroing coverage needs returned plaintext intact.")
 	password := "phase6-decrypt-zeroing"
-	volumeData, errCode := EncryptVolume(original, []byte(password))
+	volumeData, errCode := EncryptVolume(original, []byte(password), EncryptOptions{})
 	if errCode != 0 {
 		t.Fatalf("EncryptVolume returned error code %d", errCode)
 	}
@@ -395,10 +395,60 @@ func TestWASMDecryptBuffersZeroed(t *testing.T) {
 	}
 }
 
+func TestWASMParanoidCommentsDesktopDecrypt(t *testing.T) {
+	original := []byte("P0: paranoid + comments interop through the desktop volume path.")
+	password := "p0-paranoid-interop"
+	comments := "made in the browser"
+
+	volumeData, errCode := EncryptVolume(original, []byte(password), EncryptOptions{Paranoid: true, Comments: comments})
+	if errCode != 0 {
+		t.Fatalf("EncryptVolume returned error code %d", errCode)
+	}
+
+	// Header must record paranoid + the plaintext comments.
+	rs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("NewRSCodecs failed: %v", err)
+	}
+	res, err := header.NewReader(bytes.NewReader(volumeData), rs).ReadHeader()
+	if err != nil {
+		t.Fatalf("ReadHeader failed: %v", err)
+	}
+	if !res.Header.Flags.Paranoid {
+		t.Fatal("paranoid flag not set in WASM-produced header")
+	}
+	if res.Header.Comments != comments {
+		t.Fatalf("header comments = %q; want %q", res.Header.Comments, comments)
+	}
+
+	// Desktop must decrypt the WASM paranoid volume to identical plaintext.
+	tmpDir := t.TempDir()
+	encPath := filepath.Join(tmpDir, "wasm.pcv")
+	decPath := filepath.Join(tmpDir, "desktop.txt")
+	if err := os.WriteFile(encPath, volumeData, 0600); err != nil {
+		t.Fatalf("write volume: %v", err)
+	}
+	if err := volume.Decrypt(context.Background(), &volume.DecryptRequest{
+		InputFile:  encPath,
+		OutputFile: decPath,
+		Password:   []byte(password),
+		RSCodecs:   rs,
+	}); err != nil {
+		t.Fatalf("volume.Decrypt failed: %v", err)
+	}
+	got, err := os.ReadFile(decPath)
+	if err != nil {
+		t.Fatalf("read decrypted: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("desktop decrypt mismatch\ngot:  %q\nwant: %q", got, original)
+	}
+}
+
 func wasmVolumeWithFlags(t *testing.T, flags header.Flags) []byte {
 	t.Helper()
 
-	volumeData, errCode := EncryptVolume([]byte("unsupported wasm feature flags"), []byte("phase6-unsupported-flags"))
+	volumeData, errCode := EncryptVolume([]byte("unsupported wasm feature flags"), []byte("phase6-unsupported-flags"), EncryptOptions{})
 	if errCode != 0 {
 		t.Fatalf("EncryptVolume returned error code %d", errCode)
 	}


### PR DESCRIPTION
## Summary
P0 of bringing desktop features to the WASM/browser build. Adds **paranoid mode** and **plaintext header comments** to the in-memory WASM pipeline, and replaces the positional JS bridge with an **options-object / structured-result** contract.

This extends the in-memory `internal/wasm` pipeline (reusing the shared `crypto`/`header`/`encoding` primitives); the filesystem-coupled `internal/volume` is untouched.

## Commits
- `EncryptVolume(plaintext, password, EncryptOptions{Paranoid, Comments})`
- `DecryptVolume → DecryptResult{Plaintext, Comments}`; accepts paranoid volumes (dropped from the reject-set)
- `cmd/wasm/main.go`: options-object bridge → `{code,data,comments}`; defensive parsing; 1 GiB cap

## New bridge contract (breaking — sole consumer is our own web UI)
```
picocryptEncrypt({data,password,paranoid?,comments?}) -> {code:0,data} | {code:N}
picocryptDecrypt({data,password})                     -> {code:0,data,comments} | {code:N}
```

## Security
- Defensive bridge: every JS field type-guarded before access; `recover()` in both callbacks → no panic escapes `js.FuncOf`; malformed input → code 6.
- All secrets zeroed (`crypto.SecureZero`): input data, password bytes, output volume/plaintext, per-chunk buffers.
- Fail-closed: constant-time MAC compare preserved; MAC failure returns an error with **no** plaintext (force-decrypt is a later phase).
- Independent security review: no newly-introduced vulnerabilities.

## Tests
- **Byte-compatibility gate** (runs in CI via `go test ./...`): WASM-encrypted paranoid+comments volume decrypts through desktop `internal/volume`, and a desktop-encrypted paranoid+comments volume decrypts in WASM with comments surfaced.
- Bridge tests (`//go:build js && wasm`, run locally under the JS shim): malformed-input rejection, over-long-comments rejection, full round-trip.

## Scope / follow-ups
- Out of scope (later phases): keyfiles (P1), Reed-Solomon payload (P2), force-decrypt (P3), deniability (P4).
- The companion UI change lives in `picocrypt-ng.github.io` and consumes this via a Picocrypt-NG **release** (build.sh), so this should merge + release first.
- Note: the `//go:build js && wasm` bridge tests are not currently run in CI (pre-existing) — a candidate CI follow-up.