### PR TITLE
feat(wasm): Reed-Solomon error correction (P2)

### DIFF
--- a/src/cmd/wasm/main.go
+++ b/src/cmd/wasm/main.go
@@ -124,6 +124,7 @@ func encrypt(this js.Value, args []js.Value) (result any) {
 		return errorResult(errInvalidArg)
 	}
 	keyfileOrdered := optBool(opts, "keyfileOrdered")
+	reedSolomon := optBool(opts, "reedSolomon")
 
 	passwordBytes := []byte(pw.String())
 	defer crypto.SecureZero(passwordBytes)
@@ -137,6 +138,7 @@ func encrypt(this js.Value, args []js.Value) (result any) {
 		Comments:       comments,
 		Keyfiles:       keyfiles,
 		KeyfileOrdered: keyfileOrdered,
+		ReedSolomon:    reedSolomon,
 	})
 	if code != 0 {
 		return errorResult(code)

--- a/src/cmd/wasm/validate_wasm_test.go
+++ b/src/cmd/wasm/validate_wasm_test.go
@@ -3,9 +3,13 @@
 package main
 
 import (
+	"bytes"
 	"strings"
 	"syscall/js"
 	"testing"
+
+	"Picocrypt-NG/internal/encoding"
+	"Picocrypt-NG/internal/header"
 )
 
 // Pins the bridge error code: non-zero and distinct from internal/wasm 1-5.
@@ -131,6 +135,34 @@ func TestBridgeKeyfileRoundTrip(t *testing.T) {
 	})}).(js.Value)
 	if dec.Get("code").Int() != 0 {
 		t.Fatalf("decrypt code=%d; want 0", dec.Get("code").Int())
+	}
+}
+
+func TestBridgeEncryptReedSolomonSetsHeaderFlag(t *testing.T) {
+	opts := js.Global().Get("Object").New()
+	opts.Set("data", js.Global().Get("Uint8Array").New(64))
+	opts.Set("password", "bridge-rs")
+	opts.Set("reedSolomon", true)
+
+	rv := encrypt(js.Undefined(), []js.Value{opts}).(js.Value)
+	if code := rv.Get("code").Int(); code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+
+	out := rv.Get("data")
+	volBytes := make([]byte, out.Get("length").Int())
+	js.CopyBytesToGo(volBytes, out)
+
+	rs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("NewRSCodecs: %v", err)
+	}
+	res, err := header.NewReader(bytes.NewReader(volBytes), rs).ReadHeader()
+	if err != nil {
+		t.Fatalf("ReadHeader: %v", err)
+	}
+	if !res.Header.Flags.ReedSolomon {
+		t.Fatal("reedSolomon option did not set the header RS flag")
 	}
 }
 

--- a/src/cmd/wasm/validate_wasm_test.go
+++ b/src/cmd/wasm/validate_wasm_test.go
@@ -139,10 +139,11 @@ func TestBridgeKeyfileRoundTrip(t *testing.T) {
 }
 
 func TestBridgeEncryptReedSolomonSetsHeaderFlag(t *testing.T) {
-	opts := js.Global().Get("Object").New()
-	opts.Set("data", js.Global().Get("Uint8Array").New(64))
-	opts.Set("password", "bridge-rs")
-	opts.Set("reedSolomon", true)
+	opts := newOpts(map[string]any{
+		"data":        js.Global().Get("Uint8Array").New(64),
+		"password":    "bridge-rs",
+		"reedSolomon": true,
+	})
 
 	rv := encrypt(js.Undefined(), []js.Value{opts}).(js.Value)
 	if code := rv.Get("code").Int(); code != 0 {

--- a/src/internal/encoding/rs.go
+++ b/src/internal/encoding/rs.go
@@ -112,6 +112,117 @@ func EncodeInto(dst []byte, rs *infectious.FEC, data []byte) error {
 	return nil
 }
 
+// ErrCorruptData is returned by DecodeRSPayloadBlock when a block has more
+// errors than Reed-Solomon can correct and forceDecode is false. Callers in the
+// volume layer translate this to perrors.ErrCorruptData to preserve errors.Is
+// behavior; encoding stays free of the app error layer.
+var ErrCorruptData = errors.New("rs payload: data corrupted")
+
+// RSEncodedBlockSize is the on-disk byte size of one Reed-Solomon-encoded 1 MiB
+// payload block: each 128-byte (RS128DataSize) chunk encodes to 136 bytes
+// (RS128EncodedSize), so a 1 MiB block expands to 1,114,112 bytes. The 1<<20 is
+// util.MiB inlined (encoding must not import util). Untyped const: byte-identical
+// in int and int64 contexts, keeping the write format frozen.
+const RSEncodedBlockSize = (1 << 20) / RS128DataSize * RS128EncodedSize
+
+// EncodeRSPayloadBlock RS128-encodes one already-encrypted payload block (<= 1 MiB).
+// For partial blocks (< 1 MiB) it ALWAYS appends one PKCS#7-padded chunk, even when
+// the data is a multiple of 128, because decode ALWAYS unpads the last chunk of a
+// partial block. Output is byte-identical to the original desktop encoder.
+func EncodeRSPayloadBlock(data []byte, rs *RSCodecs) ([]byte, error) {
+	const miB = 1 << 20
+	chunks := (len(data) + RS128DataSize - 1) / RS128DataSize
+	if len(data) < miB {
+		chunks++ // extra chunk for padding in partial blocks
+	}
+	result := make([]byte, 0, chunks*RS128EncodedSize)
+
+	encodeChunk := func(chunk []byte) error {
+		start := len(result)
+		result = result[:start+RS128EncodedSize]
+		return EncodeInto(result[start:], rs.RS128, chunk)
+	}
+
+	if len(data) == miB {
+		for i := 0; i < miB; i += RS128DataSize {
+			if err := encodeChunk(data[i : i+RS128DataSize]); err != nil {
+				return nil, err
+			}
+		}
+		return result, nil
+	}
+
+	fullChunks := len(data) / RS128DataSize
+	for i := range fullChunks {
+		if err := encodeChunk(data[i*RS128DataSize : (i+1)*RS128DataSize]); err != nil {
+			return nil, err
+		}
+	}
+	remaining := data[fullChunks*RS128DataSize:]
+	if err := encodeChunk(Pad(remaining)); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// DecodeRSPayloadBlock decodes one RS128-encoded payload block. fastDecode=true
+// strips parity without correction (fast path); false applies full RS correction.
+// forceDecode=true returns raw bytes on uncorrectable input (desktop ForceDecrypt);
+// false returns ErrCorruptData. isLast+padded control unpadding of the final chunk.
+func DecodeRSPayloadBlock(data []byte, rs *RSCodecs, isLast, padded, forceDecode, fastDecode bool) ([]byte, error) {
+	result := make([]byte, 0, len(data)/RS128EncodedSize*RS128DataSize)
+	fullBlockEncodedSize := RSEncodedBlockSize
+
+	if len(data) == fullBlockEncodedSize {
+		for i := 0; i < fullBlockEncodedSize; i += RS128EncodedSize {
+			decoded, err := Decode(rs.RS128, data[i:i+RS128EncodedSize], fastDecode)
+			if err != nil {
+				if forceDecode {
+					decoded = data[i : i+RS128DataSize]
+				} else {
+					return nil, ErrCorruptData
+				}
+			}
+			if isLast && i == fullBlockEncodedSize-RS128EncodedSize && padded {
+				decoded = Unpad(decoded)
+			}
+			result = append(result, decoded...)
+		}
+	} else {
+		if len(data) < RS128EncodedSize {
+			if forceDecode {
+				return data, nil
+			}
+			return nil, ErrCorruptData
+		}
+		chunks := len(data)/RS128EncodedSize - 1
+		for i := range chunks {
+			decoded, err := Decode(rs.RS128, data[i*RS128EncodedSize:(i+1)*RS128EncodedSize], fastDecode)
+			if err != nil {
+				if forceDecode {
+					decoded = data[i*RS128EncodedSize : i*RS128EncodedSize+RS128DataSize]
+				} else {
+					return nil, ErrCorruptData
+				}
+			}
+			result = append(result, decoded...)
+		}
+		lastChunkStart := chunks * RS128EncodedSize
+		lastChunkEnd := min(lastChunkStart+RS128EncodedSize, len(data))
+		decoded, err := Decode(rs.RS128, data[lastChunkStart:lastChunkEnd], fastDecode)
+		if err != nil {
+			if forceDecode {
+				safeEnd := min(lastChunkStart+RS128DataSize, len(data))
+				decoded = data[lastChunkStart:safeEnd]
+			} else {
+				return nil, ErrCorruptData
+			}
+		}
+		result = append(result, Unpad(decoded)...)
+	}
+	return result, nil
+}
+
 // Decode attempts to decode and repair Reed-Solomon encoded data.
 //
 // Parameters:

--- a/src/internal/encoding/rs_payload_test.go
+++ b/src/internal/encoding/rs_payload_test.go
@@ -1,0 +1,81 @@
+package encoding
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func mustCodecs(t *testing.T) *RSCodecs {
+	t.Helper()
+	rs, err := NewRSCodecs()
+	if err != nil {
+		t.Fatalf("NewRSCodecs: %v", err)
+	}
+	return rs
+}
+
+func TestRSPayloadBlockRoundtrip(t *testing.T) {
+	rs := mustCodecs(t)
+	const miB = 1 << 20
+	sizes := []int{1, 127, 128, 129, 255, miB - 129, miB - 128, miB - 1, miB}
+	for _, n := range sizes {
+		data := make([]byte, n)
+		for i := range data {
+			data[i] = byte(i*7 + 3)
+		}
+		enc, err := EncodeRSPayloadBlock(data, rs)
+		if err != nil {
+			t.Fatalf("encode n=%d: %v", n, err)
+		}
+		// Desktop convention: a partial block whose padded chunks reach 8192 fills a
+		// full RSEncodedBlockSize; the caller signals that via the Padded flag.
+		padded := n < miB && len(enc) == RSEncodedBlockSize
+		dec, err := DecodeRSPayloadBlock(enc, rs, true, padded, false, false)
+		if err != nil {
+			t.Fatalf("decode n=%d: %v", n, err)
+		}
+		if !bytes.Equal(dec, data) {
+			t.Fatalf("roundtrip mismatch n=%d: got %d bytes want %d", n, len(dec), n)
+		}
+	}
+}
+
+func TestRSPayloadBlockRepairsCorrectableErrors(t *testing.T) {
+	rs := mustCodecs(t)
+	data := make([]byte, 256) // two full 128-byte chunks
+	for i := range data {
+		data[i] = byte(i)
+	}
+	enc, err := EncodeRSPayloadBlock(data, rs)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	// Flip 4 bytes in the first 136-byte chunk's data region (RS128 corrects <=4).
+	for i := 0; i < 4; i++ {
+		enc[i] ^= 0xFF
+	}
+	dec, err := DecodeRSPayloadBlock(enc, rs, true, false, false, false) // full correction
+	if err != nil {
+		t.Fatalf("full decode of correctable damage failed: %v", err)
+	}
+	if !bytes.Equal(dec, data) {
+		t.Fatal("full RS decode did not repair correctable damage")
+	}
+}
+
+func TestRSPayloadBlockUncorrectableReturnsErrCorruptData(t *testing.T) {
+	rs := mustCodecs(t)
+	data := make([]byte, 256)
+	enc, err := EncodeRSPayloadBlock(data, rs)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	for i := 0; i < 9; i++ { // > 4 errors in one chunk: beyond RS budget
+		enc[i] ^= 0xFF
+	}
+	_, err = DecodeRSPayloadBlock(enc, rs, true, false, false, false)
+	if !errors.Is(err, ErrCorruptData) {
+		t.Fatalf("want ErrCorruptData, got %v", err)
+	}
+}

--- a/src/internal/encoding/rs_payload_test.go
+++ b/src/internal/encoding/rs_payload_test.go
@@ -52,7 +52,7 @@ func TestRSPayloadBlockRepairsCorrectableErrors(t *testing.T) {
 		t.Fatalf("encode: %v", err)
 	}
 	// Flip 4 bytes in the first 136-byte chunk's data region (RS128 corrects <=4).
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		enc[i] ^= 0xFF
 	}
 	dec, err := DecodeRSPayloadBlock(enc, rs, true, false, false, false) // full correction
@@ -71,7 +71,7 @@ func TestRSPayloadBlockUncorrectableReturnsErrCorruptData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
-	for i := 0; i < 9; i++ { // > 4 errors in one chunk: beyond RS budget
+	for i := range 9 { // > 4 errors in one chunk: beyond RS budget
 		enc[i] ^= 0xFF
 	}
 	_, err = DecodeRSPayloadBlock(enc, rs, true, false, false, false)

--- a/src/internal/encoding/rs_payload_test.go
+++ b/src/internal/encoding/rs_payload_test.go
@@ -31,12 +31,46 @@ func TestRSPayloadBlockRoundtrip(t *testing.T) {
 		// Desktop convention: a partial block whose padded chunks reach 8192 fills a
 		// full RSEncodedBlockSize; the caller signals that via the Padded flag.
 		padded := n < miB && len(enc) == RSEncodedBlockSize
-		dec, err := DecodeRSPayloadBlock(enc, rs, true, padded, false, false)
+		// fastDecode=true: this test covers framing + padding across the boundary
+		// sizes (incl. 1 MiB), and parity-strip reconstructs UNDAMAGED data
+		// identically to full decode while staying O(n). The full RS correction
+		// path is covered (on bounded sizes) by the two tests below — full
+		// Berlekamp-Welch on 1 MiB blocks is ~8192 decodes/size and times out slow
+		// CI runners.
+		dec, err := DecodeRSPayloadBlock(enc, rs, true, padded, false, true)
 		if err != nil {
 			t.Fatalf("decode n=%d: %v", n, err)
 		}
 		if !bytes.Equal(dec, data) {
 			t.Fatalf("roundtrip mismatch n=%d: got %d bytes want %d", n, len(dec), n)
+		}
+	}
+}
+
+// TestRSPayloadBlockFullDecodeRoundtrip exercises the full RS correction path
+// (fastDecode=false) on UNDAMAGED data across partial/full-chunk boundaries,
+// proving error correction reconstructs intact data and unpads the final chunk
+// without falsely "correcting" good bytes. Sizes are kept small on purpose: full
+// Berlekamp-Welch on a 1 MiB block is ~8192 decodes and is far too slow for CI;
+// the framing/padding boundaries at 1 MiB are covered (fast) by the test above.
+func TestRSPayloadBlockFullDecodeRoundtrip(t *testing.T) {
+	rs := mustCodecs(t)
+	sizes := []int{1, 127, 128, 129, 255, 256, 1000}
+	for _, n := range sizes {
+		data := make([]byte, n)
+		for i := range data {
+			data[i] = byte(i*7 + 3)
+		}
+		enc, err := EncodeRSPayloadBlock(data, rs)
+		if err != nil {
+			t.Fatalf("encode n=%d: %v", n, err)
+		}
+		dec, err := DecodeRSPayloadBlock(enc, rs, true, false, false, false) // full correction
+		if err != nil {
+			t.Fatalf("full decode n=%d: %v", n, err)
+		}
+		if !bytes.Equal(dec, data) {
+			t.Fatalf("full-decode roundtrip mismatch n=%d: got %d bytes want %d", n, len(dec), n)
 		}
 	}
 }

--- a/src/internal/volume/decrypt.go
+++ b/src/internal/volume/decrypt.go
@@ -3,6 +3,7 @@ package volume
 import (
 	"context"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,18 +27,6 @@ var unpackArchive = fileops.Unpack
 // reads and check that the io.ReadFull loops reassemble full blocks.
 var newPayloadReader = func(r io.Reader) io.Reader { return r }
 
-// rsEncodedBlockSize is the on-disk byte size of a single Reed-Solomon-encoded
-// 1 MiB payload block: each 128-byte (RS128DataSize) plaintext chunk encodes to
-// 136 bytes (RS128EncodedSize), so a 1 MiB block expands to 1,114,112 bytes.
-//
-// IN-01: this single source of truth replaces the previously-duplicated
-// `util.MiB / encoding.RS128DataSize * encoding.RS128EncodedSize` expression at
-// the verify buffer sizing, the decrypt buffer sizing, the decrypt-pass progress
-// increment, and decodeWithRSFast's full-block detection. It is an untyped integer
-// const, so the computed value is byte-identical to the inline expression in every
-// context (int buffer sizes, int64 progress, full-block length comparison) — this
-// keeps the write-format and golden vectors frozen.
-const rsEncodedBlockSize = util.MiB / encoding.RS128DataSize * encoding.RS128EncodedSize
 
 // Decrypt performs a complete volume decryption operation.
 // This is the main entry point for decryption.
@@ -508,7 +497,7 @@ func decryptVerifyMACFirstWithDecode(ctx *OperationContext, req *DecryptRequest,
 	// Pre-allocate buffer outside loop to reduce GC pressure
 	var srcBufSize int
 	if reedsolo {
-		srcBufSize = rsEncodedBlockSize
+		srcBufSize = encoding.RSEncodedBlockSize
 	} else {
 		srcBufSize = util.MiB
 	}
@@ -685,7 +674,7 @@ func decryptPayloadWithFastDecode(ctx *OperationContext, req *DecryptRequest, fa
 	// RS-encoded buffer is larger: 1 MiB * 136/128 = ~1.0625 MiB
 	var srcBufSize int
 	if reedsolo {
-		srcBufSize = rsEncodedBlockSize
+		srcBufSize = encoding.RSEncodedBlockSize
 	} else {
 		srcBufSize = util.MiB
 	}
@@ -726,7 +715,7 @@ func decryptPayloadWithFastDecode(ctx *OperationContext, req *DecryptRequest, fa
 			}
 
 			if reedsolo {
-				done += int64(rsEncodedBlockSize)
+				done += int64(encoding.RSEncodedBlockSize)
 			} else {
 				done += int64(n)
 			}
@@ -916,71 +905,13 @@ func cleanupDecrypt(ctx *OperationContext, req *DecryptRequest) {
 	// Note: ctx.Close() is called via defer in Decrypt()
 }
 
-// decodeWithRSFast decodes Reed-Solomon encoded data with optional fast decode.
-// When fastDecode is true, it skips RS error correction and just returns the data bytes.
-// This matches the original Picocrypt behavior for performance.
+// decodeWithRSFast delegates to the shared encoding codec, translating the
+// encoding-layer sentinel to perrors.ErrCorruptData so existing volume callers
+// and IsCorrupt() keep matching. forceDecode is honored (desktop ForceDecrypt).
 func decodeWithRSFast(data []byte, rs *encoding.RSCodecs, isLast, padded, forceDecode, fastDecode bool) ([]byte, error) {
-	// Pre-allocate once: each 136-byte encoded chunk yields <= 128 decoded bytes.
-	// Mirrors the encode side (encrypt.go:498). Unpad only shrinks the last chunk.
-	result := make([]byte, 0, len(data)/encoding.RS128EncodedSize*encoding.RS128DataSize)
-	fullBlockEncodedSize := rsEncodedBlockSize
-
-	// Full 1 MiB block
-	if len(data) == fullBlockEncodedSize {
-		for i := 0; i < fullBlockEncodedSize; i += encoding.RS128EncodedSize {
-			decoded, err := encoding.Decode(rs.RS128, data[i:i+encoding.RS128EncodedSize], fastDecode)
-			if err != nil {
-				if forceDecode {
-					decoded = data[i : i+encoding.RS128DataSize] // Use raw data
-				} else {
-					return nil, perrors.ErrCorruptData
-				}
-			}
-
-			// Unpad last chunk if needed
-			if isLast && i == fullBlockEncodedSize-encoding.RS128EncodedSize && padded {
-				decoded = encoding.Unpad(decoded)
-			}
-
-			result = append(result, decoded...)
-		}
-	} else {
-		// Partial block - must have at least one RS128 chunk
-		if len(data) < encoding.RS128EncodedSize {
-			if forceDecode {
-				return data, nil // Return raw data for severely truncated input
-			}
-			return nil, perrors.ErrCorruptData
-		}
-
-		chunks := len(data)/encoding.RS128EncodedSize - 1
-		for i := range chunks {
-			decoded, err := encoding.Decode(rs.RS128, data[i*encoding.RS128EncodedSize:(i+1)*encoding.RS128EncodedSize], fastDecode)
-			if err != nil {
-				if forceDecode {
-					decoded = data[i*encoding.RS128EncodedSize : i*encoding.RS128EncodedSize+encoding.RS128DataSize]
-				} else {
-					return nil, perrors.ErrCorruptData
-				}
-			}
-			result = append(result, decoded...)
-		}
-
-		// Last chunk (always unpad)
-		lastChunkStart := chunks * encoding.RS128EncodedSize
-		lastChunkEnd := min(lastChunkStart+encoding.RS128EncodedSize, len(data))
-		decoded, err := encoding.Decode(rs.RS128, data[lastChunkStart:lastChunkEnd], fastDecode)
-		if err != nil {
-			if forceDecode {
-				// Safely extract what we can
-				safeEnd := min(lastChunkStart+encoding.RS128DataSize, len(data))
-				decoded = data[lastChunkStart:safeEnd]
-			} else {
-				return nil, perrors.ErrCorruptData
-			}
-		}
-		result = append(result, encoding.Unpad(decoded)...)
+	out, err := encoding.DecodeRSPayloadBlock(data, rs, isLast, padded, forceDecode, fastDecode)
+	if errors.Is(err, encoding.ErrCorruptData) {
+		return out, perrors.ErrCorruptData
 	}
-
-	return result, nil
+	return out, err
 }

--- a/src/internal/volume/decrypt.go
+++ b/src/internal/volume/decrypt.go
@@ -27,7 +27,6 @@ var unpackArchive = fileops.Unpack
 // reads and check that the io.ReadFull loops reassemble full blocks.
 var newPayloadReader = func(r io.Reader) io.Reader { return r }
 
-
 // Decrypt performs a complete volume decryption operation.
 // This is the main entry point for decryption.
 // If ctx is nil, a background context is used.

--- a/src/internal/volume/encode_golden_test.go
+++ b/src/internal/volume/encode_golden_test.go
@@ -8,13 +8,13 @@ import (
 	"Picocrypt-NG/internal/encoding"
 )
 
-// TestEncodeWithRSGolden pins the output of encodeWithRS — the production RS128
-// payload encoder modified by the EncodeInto optimization — to a frozen byte
-// vector. This guards the encode-side on-disk format end to end: chunk
-// iteration order, the systematic RS128 data bytes, the always-pad-the-last-
-// chunk rule for partial blocks (PKCS#7), and the parity bytes. A regression in
-// any of those (e.g. a buffer-reuse bug in EncodeInto) is caught directly here,
-// not only transitively via roundtrip self-consistency.
+// TestEncodeWithRSGolden pins the output of encoding.EncodeRSPayloadBlock — the
+// shared RS128 payload encoder — to a frozen byte vector. This guards the
+// encode-side on-disk format end to end: chunk iteration order, the systematic
+// RS128 data bytes, the always-pad-the-last-chunk rule for partial blocks
+// (PKCS#7), and the parity bytes. A regression in any of those (e.g. a
+// buffer-reuse bug in EncodeInto) is caught directly here, not only transitively
+// via roundtrip self-consistency.
 //
 // The 200-byte input exercises the partial-block path: one full 128-byte chunk
 // plus a padded final chunk (72 data bytes + 56 bytes of 0x38 PKCS#7 padding).
@@ -31,9 +31,9 @@ func TestEncodeWithRSGolden(t *testing.T) {
 		input[i] = byte(i*7 + 1)
 	}
 
-	got, err := encodeWithRS(input, rs)
+	got, err := encoding.EncodeRSPayloadBlock(input, rs)
 	if err != nil {
-		t.Fatalf("encodeWithRS: %v", err)
+		t.Fatalf("EncodeRSPayloadBlock: %v", err)
 	}
 
 	// 200 bytes -> 1 full chunk + 1 padded chunk -> 2 * 136 = 272 bytes.
@@ -53,6 +53,6 @@ func TestEncodeWithRSGolden(t *testing.T) {
 	}
 
 	if !bytes.Equal(got, want) {
-		t.Errorf("encodeWithRS golden mismatch (encode format drift):\n got  %x\nwant %x", got, want)
+		t.Errorf("EncodeRSPayloadBlock golden mismatch (encode format drift):\n got  %x\nwant %x", got, want)
 	}
 }

--- a/src/internal/volume/encrypt.go
+++ b/src/internal/volume/encrypt.go
@@ -385,7 +385,7 @@ func encryptPayload(ctx *OperationContext, req *EncryptRequest) error {
 			// Apply Reed-Solomon if enabled
 			var writeData []byte
 			if req.ReedSolomon {
-				enc, err := encodeWithRS(dstData, req.RSCodecs)
+				enc, err := encoding.EncodeRSPayloadBlock(dstData, req.RSCodecs)
 				if err != nil {
 					return fmt.Errorf("rs encode payload: %w", err)
 				}
@@ -513,54 +513,3 @@ func cleanupEncrypt(ctx *OperationContext, req *EncryptRequest) {
 	// Note: ctx.Close() is called via defer in Encrypt()
 }
 
-// encodeWithRS encodes data with Reed-Solomon (rs128)
-// For partial blocks (< 1 MiB), this ALWAYS adds a padding chunk, even if data
-// is exactly divisible by 128, because the original Picocrypt always unpads
-// the last chunk of partial blocks.
-func encodeWithRS(data []byte, rs *encoding.RSCodecs) ([]byte, error) {
-	// Pre-allocate result slice to avoid repeated reallocations
-	// Each RS128DataSize-byte input chunk becomes RS128EncodedSize bytes (128 data + 8 parity)
-	// For partial blocks, we add one more chunk for padding
-	chunks := (len(data) + encoding.RS128DataSize - 1) / encoding.RS128DataSize
-	if len(data) < util.MiB {
-		chunks++ // Extra chunk for padding in partial blocks
-	}
-	result := make([]byte, 0, chunks*encoding.RS128EncodedSize)
-
-	// encodeChunk RS-encodes one 128-byte input chunk directly into the tail of
-	// the pre-sized result buffer, avoiding a per-chunk allocation and copy.
-	// Output is byte-identical to encoding.Encode + append (golden-vector gated).
-	encodeChunk := func(chunk []byte) error {
-		start := len(result)
-		result = result[:start+encoding.RS128EncodedSize]
-		return encoding.EncodeInto(result[start:], rs.RS128, chunk)
-	}
-
-	// Full 1 MiB block - no padding needed within the block
-	if len(data) == util.MiB {
-		for i := 0; i < util.MiB; i += encoding.RS128DataSize {
-			if err := encodeChunk(data[i : i+encoding.RS128DataSize]); err != nil {
-				return nil, err
-			}
-		}
-		return result, nil
-	}
-
-	// Partial block (< 1 MiB) - need to handle padding
-	// Encode full 128-byte chunks
-	fullChunks := len(data) / encoding.RS128DataSize
-	for i := range fullChunks {
-		if err := encodeChunk(data[i*encoding.RS128DataSize : (i+1)*encoding.RS128DataSize]); err != nil {
-			return nil, err
-		}
-	}
-
-	// ALWAYS add a padded chunk for partial blocks (matches original line 2071-2072)
-	// This is because decryption always unpads the last chunk of partial blocks
-	remaining := data[fullChunks*encoding.RS128DataSize:]
-	if err := encodeChunk(encoding.Pad(remaining)); err != nil {
-		return nil, err
-	}
-
-	return result, nil
-}

--- a/src/internal/volume/encrypt.go
+++ b/src/internal/volume/encrypt.go
@@ -512,4 +512,3 @@ func cleanupEncrypt(ctx *OperationContext, req *EncryptRequest) {
 	_ = os.Remove(req.OutputFile + ".incomplete")
 	// Note: ctx.Close() is called via defer in Encrypt()
 }
-

--- a/src/internal/volume/verifyfirst_progress_test.go
+++ b/src/internal/volume/verifyfirst_progress_test.go
@@ -66,7 +66,7 @@ func (r *recordingReporter) pass1Fractions() []float32 {
 // BEFORE the clamp, so it fails RED against the fixed-block bug and passes only once
 // the increment is `int64(n)` (faithful to ctx.Total's raw-byte basis).
 func TestVerifyFirstProgressDeltaFaithful(t *testing.T) {
-	const fixedBlock = int64(rsEncodedBlockSize)
+	const fixedBlock = int64(encoding.RSEncodedBlockSize)
 
 	tests := []struct {
 		name string

--- a/src/internal/wasm/decrypt.go
+++ b/src/internal/wasm/decrypt.go
@@ -179,18 +179,42 @@ func DecryptVolume(volumeData, password []byte, opts DecryptOptions) (DecryptRes
 	// Read payload from remaining bytes
 	payload := volumeData[headerSize:]
 
-	// Decrypt payload. RS-encoded volumes are rejected by
-	// hasUnsupportedWASMFeature above, so only the plain path exists here.
+	// Pass 1: decrypt with the fast path (RS strips parity without correction).
+	reedSolomon := hdr.Flags.ReedSolomon
 	var counter int64
-	plaintext, err := decryptPlainPayload(payload, cipherSuite, &counter)
+	var plaintext []byte
+	if reedSolomon {
+		plaintext, err = decryptRSPayload(payload, cipherSuite, rsCodecs, hdr.Flags.Padded, true)
+	} else {
+		plaintext, err = decryptPlainPayload(payload, cipherSuite, &counter)
+	}
 	if err != nil {
 		return DecryptResult{}, ErrModifiedData
 	}
 
-	// Verify MAC
 	computedMAC := cipherSuite.Sum()
 	macValid := subtle.ConstantTimeCompare(computedMAC, hdr.AuthTag) == 1
 	zeroWASMSensitiveBuffer(wasmZeroingDecryptComputedMAC, computedMAC)
+
+	// RS guarded retry: correctable damage makes the fast pass yield a wrong MAC.
+	// Rebuild the cipher suite and re-decrypt ONCE with full RS correction before
+	// rejecting. cipherKey is still live here (its wipe is deferred to return).
+	if !macValid && reedSolomon {
+		zeroWASMSensitiveBuffer(wasmZeroingDecryptPlaintextChunk, plaintext)
+		retryCS, code := buildDecryptCipherSuite(key, cipherKey, hdr, isLegacyV1)
+		if code != 0 {
+			return DecryptResult{}, code
+		}
+		defer retryCS.Close()
+		plaintext, err = decryptRSPayload(payload, retryCS, rsCodecs, hdr.Flags.Padded, false)
+		if err != nil {
+			return DecryptResult{}, ErrModifiedData
+		}
+		retryMAC := retryCS.Sum()
+		macValid = subtle.ConstantTimeCompare(retryMAC, hdr.AuthTag) == 1
+		zeroWASMSensitiveBuffer(wasmZeroingDecryptComputedMAC, retryMAC)
+	}
+
 	if !macValid {
 		zeroWASMSensitiveBuffer(wasmZeroingDecryptPlaintextChunk, plaintext)
 		return DecryptResult{}, ErrModifiedData
@@ -229,8 +253,80 @@ func verifyWASMHeader(key []byte, hdr *header.VolumeHeader, keyfileHash []byte, 
 	return true, reader, 0
 }
 
+// hasUnsupportedWASMFeature flags header combinations the WASM path cannot handle.
+// Reed-Solomon (and its companion Padded flag) are now supported. A Padded flag
+// WITHOUT ReedSolomon is a combination desktop never emits -> treat as corrupt.
 func hasUnsupportedWASMFeature(flags header.Flags) bool {
-	return flags.ReedSolomon || flags.Padded
+	return flags.Padded && !flags.ReedSolomon
+}
+
+// decryptRSPayload decrypts an RS128-framed payload block-by-block. fastDecode=true
+// strips parity without correction (fast first pass); false applies full RS
+// correction (repairs <=4 errors per 136-byte block). forceDecode is false (P2
+// fails closed): an uncorrectable block returns the error from the shared codec.
+// DecodeRSPayloadBlock returns a freshly-allocated slice, so paranoid Decrypt
+// (which mutates src) never touches the caller's payload, keeping it pristine for
+// a retry pass.
+func decryptRSPayload(payload []byte, cs *crypto.CipherSuite, rs *encoding.RSCodecs, padded, fastDecode bool) ([]byte, error) {
+	plaintext := make([]byte, 0, len(payload))
+	var counter int64
+	blockSize := encoding.RSEncodedBlockSize
+	for offset := 0; offset < len(payload); offset += blockSize {
+		end := min(offset+blockSize, len(payload))
+		isLast := end >= len(payload)
+		data, err := encoding.DecodeRSPayloadBlock(payload[offset:end], rs, isLast, padded, false, fastDecode)
+		if err != nil {
+			return nil, err
+		}
+		dst := make([]byte, len(data))
+		cs.Decrypt(dst, data)
+		plaintext = append(plaintext, dst...)
+		zeroWASMSensitiveBuffer(wasmZeroingDecryptPlaintextChunk, dst)
+		counter += int64(util.MiB)
+		if counter >= crypto.RekeyThreshold {
+			if err := cs.Rekey(); err != nil {
+				return nil, err
+			}
+			counter = 0
+		}
+	}
+	return plaintext, nil
+}
+
+// buildDecryptCipherSuite re-derives the HKDF subkeys from the authenticated key
+// and constructs a fresh cipher suite for a (re)decrypt pass. v2 consumes the
+// header subkey first; v1 does not. cipherKey is aliased by the returned suite
+// (its Close zeroes it). Returns a non-zero code on any derivation failure.
+func buildDecryptCipherSuite(key, cipherKey []byte, hdr *header.VolumeHeader, isLegacyV1 bool) (*crypto.CipherSuite, int) {
+	sr := crypto.NewSubkeyReader(crypto.NewHKDFStream(key, hdr.HKDFSalt))
+	if !isLegacyV1 {
+		subkeyHeader, err := sr.HeaderSubkey()
+		if err != nil {
+			return nil, ErrCorruptedHeader
+		}
+		zeroWASMSensitiveBuffer(wasmZeroingDecryptHeaderSubkey, subkeyHeader)
+	}
+	macSubkey, err := sr.MACSubkey()
+	if err != nil {
+		return nil, ErrCorruptedHeader
+	}
+	serpentKey, err := sr.SerpentKey()
+	if err != nil {
+		zeroWASMSensitiveBuffer(wasmZeroingDecryptMACSubkey, macSubkey)
+		return nil, ErrCorruptedHeader
+	}
+	mac, err := crypto.NewMAC(macSubkey, hdr.Flags.Paranoid)
+	zeroWASMSensitiveBuffer(wasmZeroingDecryptMACSubkey, macSubkey)
+	if err != nil {
+		zeroWASMSensitiveBuffer(wasmZeroingDecryptSerpentKey, serpentKey)
+		return nil, ErrCorruptedHeader
+	}
+	cs, err := newCipherSuite(cipherKey, hdr.Nonce, serpentKey, hdr.SerpentIV, mac, sr.Reader(), hdr.Flags.Paranoid)
+	zeroWASMSensitiveBuffer(wasmZeroingDecryptSerpentKey, serpentKey)
+	if err != nil {
+		return nil, ErrCorruptedHeader
+	}
+	return cs, 0
 }
 
 // decryptPlainPayload decrypts non-RS payload in chunks

--- a/src/internal/wasm/encrypt.go
+++ b/src/internal/wasm/encrypt.go
@@ -101,6 +101,7 @@ type EncryptOptions struct {
 	Comments       string   // plaintext header comments (NOT encrypted); len <= header.MaxCommentLen
 	Keyfiles       [][]byte // each element is one keyfile's full contents
 	KeyfileOrdered bool     // true = order matters (sequential hash); false = XOR
+	ReedSolomon    bool     // RS128 error-correction framing of the payload
 }
 
 // EncryptVolume encrypts plaintext data into a Picocrypt volume.
@@ -134,13 +135,14 @@ func EncryptVolume(plaintext, password []byte, opts EncryptOptions) ([]byte, int
 	}
 
 	// Create header; flags/comments come from opts.
+	const miB = 1 << 20
 	hdr := header.NewVolumeHeader(salt, hkdfSalt, serpentIV, nonce)
 	hdr.Flags = header.Flags{
 		Paranoid:       opts.Paranoid,
 		UseKeyfiles:    len(opts.Keyfiles) > 0,
 		KeyfileOrdered: len(opts.Keyfiles) > 0 && opts.KeyfileOrdered,
-		ReedSolomon:    false, // P2
-		Padded:         false, // P2
+		ReedSolomon:    opts.ReedSolomon,
+		Padded:         opts.ReedSolomon && len(plaintext)%miB >= miB-128,
 	}
 	hdr.Comments = opts.Comments
 
@@ -277,7 +279,17 @@ func EncryptVolume(plaintext, password []byte, opts EncryptOptions) ([]byte, int
 		dst := make([]byte, len(chunk))
 		cipherSuite.Encrypt(dst, chunk)
 		crypto.SecureZero(chunk)
-		ciphertextBuf.Write(dst)
+		if opts.ReedSolomon {
+			enc, encErr := encoding.EncodeRSPayloadBlock(dst, rsCodecs)
+			if encErr != nil {
+				zeroWASMSensitiveBuffer(wasmZeroingCiphertextChunk, dst)
+				return nil, ErrRandomFailure
+			}
+			ciphertextBuf.Write(enc)
+			zeroWASMSensitiveBuffer(wasmZeroingCiphertextChunk, enc)
+		} else {
+			ciphertextBuf.Write(dst)
+		}
 		zeroWASMSensitiveBuffer(wasmZeroingCiphertextChunk, dst)
 
 		counter += int64(len(chunk))

--- a/src/internal/wasm/reedsolomon_test.go
+++ b/src/internal/wasm/reedsolomon_test.go
@@ -79,3 +79,147 @@ func readHeaderForTest(t *testing.T, volumeData []byte) *header.VolumeHeader {
 	}
 	return res.Header
 }
+
+func TestWASMReedSolomonRoundtrip(t *testing.T) {
+	const miB = 1 << 20
+	password := "rs-roundtrip"
+	for _, n := range []int{1, 200, miB - 128, miB - 1, miB, miB + 5, 2 * miB} {
+		plaintext := make([]byte, n)
+		for i := range plaintext {
+			plaintext[i] = byte(i*5 + 9)
+		}
+		vol, code := EncryptVolume(plaintext, []byte(password), EncryptOptions{ReedSolomon: true})
+		if code != 0 {
+			t.Fatalf("n=%d encrypt code %d", n, code)
+		}
+		res, code := DecryptVolume(vol, []byte(password), DecryptOptions{})
+		if code != 0 {
+			t.Fatalf("n=%d decrypt code %d", n, code)
+		}
+		if !bytes.Equal(res.Plaintext, plaintext) {
+			t.Fatalf("n=%d roundtrip mismatch", n)
+		}
+	}
+}
+
+func TestWASMReedSolomonRepairsCorrectableDamage(t *testing.T) {
+	password := "rs-repair"
+	plaintext := make([]byte, 4096)
+	for i := range plaintext {
+		plaintext[i] = byte(i)
+	}
+	vol, code := EncryptVolume(plaintext, []byte(password), EncryptOptions{ReedSolomon: true})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	// Corrupt 4 bytes inside the first payload chunk's DATA region (first 128 of the
+	// first 136-byte block) so the fast pass yields a wrong MAC and the full-RS retry
+	// must repair it. RS128 corrects up to 4 errors per 136-byte block.
+	payloadStart := header.HeaderSize(0)
+	for i := 0; i < 4; i++ {
+		vol[payloadStart+i] ^= 0xFF
+	}
+	res, code := DecryptVolume(vol, []byte(password), DecryptOptions{})
+	if code != 0 {
+		t.Fatalf("expected repair, got code %d", code)
+	}
+	if !bytes.Equal(res.Plaintext, plaintext) {
+		t.Fatal("repaired plaintext mismatch")
+	}
+}
+
+func TestWASMReedSolomonUncorrectableFailsClosed(t *testing.T) {
+	password := "rs-uncorrectable"
+	plaintext := make([]byte, 4096)
+	vol, code := EncryptVolume(plaintext, []byte(password), EncryptOptions{ReedSolomon: true})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	// 9 byte-errors in one 136-byte block: beyond the RS budget -> unrecoverable.
+	payloadStart := header.HeaderSize(0)
+	for i := 0; i < 9; i++ {
+		vol[payloadStart+i] ^= 0xFF
+	}
+	_, code = DecryptVolume(vol, []byte(password), DecryptOptions{})
+	if code != ErrModifiedData {
+		t.Fatalf("want ErrModifiedData(%d), got %d", ErrModifiedData, code)
+	}
+}
+
+func TestWASMReedSolomonDesktopEncryptWASMDecrypt(t *testing.T) {
+	password := "desktop-rs-to-wasm"
+	plaintext := []byte("Desktop-encrypted RS volume must decrypt in WASM unchanged.")
+	tmp := t.TempDir()
+	in := filepath.Join(tmp, "p.txt")
+	out := filepath.Join(tmp, "p.pcv")
+	if err := os.WriteFile(in, plaintext, 0600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	rs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("NewRSCodecs: %v", err)
+	}
+	if err := volume.Encrypt(context.Background(), &volume.EncryptRequest{
+		InputFile: in, OutputFile: out, Password: []byte(password),
+		ReedSolomon: true, RSCodecs: rs,
+	}); err != nil {
+		t.Fatalf("desktop Encrypt: %v", err)
+	}
+	vol, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read volume: %v", err)
+	}
+	res, code := DecryptVolume(vol, []byte(password), DecryptOptions{})
+	if code != 0 {
+		t.Fatalf("WASM decrypt code %d", code)
+	}
+	if !bytes.Equal(res.Plaintext, plaintext) {
+		t.Fatal("desktop->WASM RS decrypt mismatch")
+	}
+}
+
+func TestWASMReedSolomonParanoidRoundtrip(t *testing.T) {
+	password := "rs-paranoid"
+	plaintext := make([]byte, 5000)
+	for i := range plaintext {
+		plaintext[i] = byte(i * 3)
+	}
+	vol, code := EncryptVolume(plaintext, []byte(password), EncryptOptions{ReedSolomon: true, Paranoid: true})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	res, code := DecryptVolume(vol, []byte(password), DecryptOptions{})
+	if code != 0 {
+		t.Fatalf("decrypt code %d", code)
+	}
+	if !bytes.Equal(res.Plaintext, plaintext) {
+		t.Fatal("paranoid RS roundtrip mismatch")
+	}
+}
+
+func TestWASMReedSolomonWithKeyfiles(t *testing.T) {
+	password := "rs-keyfiles"
+	kf := [][]byte{[]byte("keyfile-alpha-contents"), []byte("keyfile-beta-contents")}
+	plaintext := make([]byte, 3000)
+	for i := range plaintext {
+		plaintext[i] = byte(i + 7)
+	}
+	clone := func(in [][]byte) [][]byte {
+		out := make([][]byte, len(in))
+		for i, b := range in {
+			out[i] = append([]byte(nil), b...)
+		}
+		return out
+	}
+	vol, code := EncryptVolume(plaintext, []byte(password), EncryptOptions{ReedSolomon: true, Keyfiles: clone(kf)})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	res, code := DecryptVolume(vol, []byte(password), DecryptOptions{Keyfiles: clone(kf)})
+	if code != 0 {
+		t.Fatalf("decrypt code %d", code)
+	}
+	if !bytes.Equal(res.Plaintext, plaintext) {
+		t.Fatal("RS+keyfiles roundtrip mismatch")
+	}
+}

--- a/src/internal/wasm/reedsolomon_test.go
+++ b/src/internal/wasm/reedsolomon_test.go
@@ -3,6 +3,7 @@ package wasm
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,27 +44,29 @@ func TestWASMReedSolomonEncryptDesktopDecrypt(t *testing.T) {
 	password := "rs-encrypt-interop"
 	sizes := []int{1, 200, miB - 129, miB - 128, miB - 1, miB, miB + 17, 2*miB - 1}
 	for _, n := range sizes {
-		plaintext := make([]byte, n)
-		for i := range plaintext {
-			plaintext[i] = byte(i*13 + 1)
-		}
-		vol, code := EncryptVolume(plaintext, []byte(password), EncryptOptions{ReedSolomon: true})
-		if code != 0 {
-			t.Fatalf("n=%d EncryptVolume code %d", n, code)
-		}
-		// Header must advertise RS; Padded iff the final partial block fills a full block.
-		hdr := readHeaderForTest(t, vol)
-		if !hdr.Flags.ReedSolomon {
-			t.Fatalf("n=%d: ReedSolomon flag not set", n)
-		}
-		wantPadded := n%miB >= miB-128
-		if hdr.Flags.Padded != wantPadded {
-			t.Fatalf("n=%d: Padded=%v want %v", n, hdr.Flags.Padded, wantPadded)
-		}
-		got := desktopDecrypt(t, vol, password)
-		if !bytes.Equal(got, plaintext) {
-			t.Fatalf("n=%d: desktop decrypt mismatch (%d vs %d bytes)", n, len(got), n)
-		}
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			plaintext := make([]byte, n)
+			for i := range plaintext {
+				plaintext[i] = byte(i*13 + 1)
+			}
+			vol, code := EncryptVolume(plaintext, []byte(password), EncryptOptions{ReedSolomon: true})
+			if code != 0 {
+				t.Fatalf("n=%d EncryptVolume code %d", n, code)
+			}
+			// Header must advertise RS; Padded iff the final partial block fills a full block.
+			hdr := readHeaderForTest(t, vol)
+			if !hdr.Flags.ReedSolomon {
+				t.Fatalf("n=%d: ReedSolomon flag not set", n)
+			}
+			wantPadded := n%miB >= miB-128
+			if hdr.Flags.Padded != wantPadded {
+				t.Fatalf("n=%d: Padded=%v want %v", n, hdr.Flags.Padded, wantPadded)
+			}
+			got := desktopDecrypt(t, vol, password)
+			if !bytes.Equal(got, plaintext) {
+				t.Fatalf("n=%d: desktop decrypt mismatch (%d vs %d bytes)", n, len(got), n)
+			}
+		})
 	}
 }
 
@@ -84,21 +87,23 @@ func TestWASMReedSolomonRoundtrip(t *testing.T) {
 	const miB = 1 << 20
 	password := "rs-roundtrip"
 	for _, n := range []int{1, 200, miB - 128, miB - 1, miB, miB + 5, 2 * miB} {
-		plaintext := make([]byte, n)
-		for i := range plaintext {
-			plaintext[i] = byte(i*5 + 9)
-		}
-		vol, code := EncryptVolume(plaintext, []byte(password), EncryptOptions{ReedSolomon: true})
-		if code != 0 {
-			t.Fatalf("n=%d encrypt code %d", n, code)
-		}
-		res, code := DecryptVolume(vol, []byte(password), DecryptOptions{})
-		if code != 0 {
-			t.Fatalf("n=%d decrypt code %d", n, code)
-		}
-		if !bytes.Equal(res.Plaintext, plaintext) {
-			t.Fatalf("n=%d roundtrip mismatch", n)
-		}
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			plaintext := make([]byte, n)
+			for i := range plaintext {
+				plaintext[i] = byte(i*5 + 9)
+			}
+			vol, code := EncryptVolume(plaintext, []byte(password), EncryptOptions{ReedSolomon: true})
+			if code != 0 {
+				t.Fatalf("n=%d encrypt code %d", n, code)
+			}
+			res, code := DecryptVolume(vol, []byte(password), DecryptOptions{})
+			if code != 0 {
+				t.Fatalf("n=%d decrypt code %d", n, code)
+			}
+			if !bytes.Equal(res.Plaintext, plaintext) {
+				t.Fatalf("n=%d roundtrip mismatch", n)
+			}
+		})
 	}
 }
 
@@ -221,5 +226,38 @@ func TestWASMReedSolomonWithKeyfiles(t *testing.T) {
 	}
 	if !bytes.Equal(res.Plaintext, plaintext) {
 		t.Fatal("RS+keyfiles roundtrip mismatch")
+	}
+}
+
+// TestWASMReedSolomonRepairsMultiBlockDamage proves that RS repair works when
+// damage falls in the SECOND on-disk RS block (i.e. > 1 MiB of plaintext so
+// at least two full RS blocks exist). This forces the full-RS retry (Pass-2)
+// to walk past the first block and repair the second, which the
+// single-block repair test cannot exercise.
+func TestWASMReedSolomonRepairsMultiBlockDamage(t *testing.T) {
+	const miB = 1 << 20
+	password := "rs-multi-block-repair"
+	plaintext := make([]byte, miB+50000)
+	for i := range plaintext {
+		plaintext[i] = byte(i*7 + 3)
+	}
+	vol, code := EncryptVolume(plaintext, []byte(password), EncryptOptions{ReedSolomon: true})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	// Corrupt 4 bytes inside the DATA region of the second on-disk RS block.
+	// The second block starts immediately after the header and the first RS block.
+	// Flipping bytes here causes the fast-pass MAC to mismatch, forcing Pass-2
+	// (full RS correction) which repairs the damage and recovers the plaintext.
+	secondBlockStart := header.HeaderSize(0) + encoding.RSEncodedBlockSize
+	for i := range 4 {
+		vol[secondBlockStart+i] ^= 0xFF
+	}
+	res, code := DecryptVolume(vol, []byte(password), DecryptOptions{})
+	if code != 0 {
+		t.Fatalf("expected repair of second-block damage, got code %d", code)
+	}
+	if !bytes.Equal(res.Plaintext, plaintext) {
+		t.Fatal("repaired multi-block plaintext mismatch")
 	}
 }

--- a/src/internal/wasm/reedsolomon_test.go
+++ b/src/internal/wasm/reedsolomon_test.go
@@ -1,0 +1,81 @@
+package wasm
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"Picocrypt-NG/internal/encoding"
+	"Picocrypt-NG/internal/header"
+	"Picocrypt-NG/internal/volume"
+)
+
+// desktopDecrypt decrypts a WASM-produced volume via the shared desktop engine,
+// proving the on-disk RS framing is byte-compatible.
+func desktopDecrypt(t *testing.T, volumeData []byte, password string) []byte {
+	t.Helper()
+	tmp := t.TempDir()
+	in := filepath.Join(tmp, "v.pcv")
+	out := filepath.Join(tmp, "v.out")
+	if err := os.WriteFile(in, volumeData, 0600); err != nil {
+		t.Fatalf("write volume: %v", err)
+	}
+	rs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("NewRSCodecs: %v", err)
+	}
+	if err := volume.Decrypt(context.Background(), &volume.DecryptRequest{
+		InputFile: in, OutputFile: out, Password: []byte(password), RSCodecs: rs,
+	}); err != nil {
+		t.Fatalf("desktop Decrypt: %v", err)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	return got
+}
+
+func TestWASMReedSolomonEncryptDesktopDecrypt(t *testing.T) {
+	const miB = 1 << 20
+	password := "rs-encrypt-interop"
+	sizes := []int{1, 200, miB - 129, miB - 128, miB - 1, miB, miB + 17, 2*miB - 1}
+	for _, n := range sizes {
+		plaintext := make([]byte, n)
+		for i := range plaintext {
+			plaintext[i] = byte(i*13 + 1)
+		}
+		vol, code := EncryptVolume(plaintext, []byte(password), EncryptOptions{ReedSolomon: true})
+		if code != 0 {
+			t.Fatalf("n=%d EncryptVolume code %d", n, code)
+		}
+		// Header must advertise RS; Padded iff the final partial block fills a full block.
+		hdr := readHeaderForTest(t, vol)
+		if !hdr.Flags.ReedSolomon {
+			t.Fatalf("n=%d: ReedSolomon flag not set", n)
+		}
+		wantPadded := n%miB >= miB-128
+		if hdr.Flags.Padded != wantPadded {
+			t.Fatalf("n=%d: Padded=%v want %v", n, hdr.Flags.Padded, wantPadded)
+		}
+		got := desktopDecrypt(t, vol, password)
+		if !bytes.Equal(got, plaintext) {
+			t.Fatalf("n=%d: desktop decrypt mismatch (%d vs %d bytes)", n, len(got), n)
+		}
+	}
+}
+
+func readHeaderForTest(t *testing.T, volumeData []byte) *header.VolumeHeader {
+	t.Helper()
+	rs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("NewRSCodecs: %v", err)
+	}
+	res, err := header.NewReader(bytes.NewReader(volumeData), rs).ReadHeader()
+	if err != nil {
+		t.Fatalf("ReadHeader: %v", err)
+	}
+	return res.Header
+}

--- a/src/internal/wasm/wasm_test.go
+++ b/src/internal/wasm/wasm_test.go
@@ -304,14 +304,12 @@ func TestWASMBuffersZeroed(t *testing.T) {
 }
 
 func TestWASMUnsupportedFeatureFlagsReturnUnsupported(t *testing.T) {
+	// Padded-without-ReedSolomon is a combination desktop never emits; treated as corrupt.
+	// ReedSolomon (with or without Padded) is now supported and is no longer in this list.
 	cases := []struct {
 		name  string
 		flags header.Flags
 	}{
-		{
-			name:  "reed_solomon_payload",
-			flags: header.Flags{ReedSolomon: true},
-		},
 		{
 			name:  "reed_solomon_padding",
 			flags: header.Flags{Padded: true},


### PR DESCRIPTION
## P2 — Reed-Solomon error correction in the WASM module

Brings RS forward error correction to the web (WASM) path, byte-compatible with desktop Picocrypt and the on-disk `.pcv` format.

### What
- **Shared codec** — extracted the format-critical RS payload block codec (`EncodeRSPayloadBlock` / `DecodeRSPayloadBlock` / `RSEncodedBlockSize`) from `internal/volume` into `internal/encoding`, so desktop and WASM use one implementation. `encoding` stays a leaf package (own `ErrCorruptData`; `volume` maps it to `perrors.ErrCorruptData`, preserving `errors.Is`). Golden vectors prove byte-identical desktop output.
- **WASM encrypt** — `EncryptOptions.ReedSolomon`; sets the `ReedSolomon`/`Padded` header flags (`Padded = RS && len%MiB >= MiB-128`) and RS-frames the payload.
- **WASM decrypt** — guarded two-pass: fast parity-strip, then a single full-correction retry on MAC mismatch (repairs ≤4 errors per 136-byte block). **Fail-closed** (`ErrModifiedData`) on uncorrectable damage; no force/raw path (deferred to a later phase). Key-aliasing across the retry is safe (deferred cipher-key wipe keeps it live through Pass 2); all sensitive buffers zeroed on every path; constant-time MAC.
- **Bridge** — parses the `reedSolomon` encrypt option.

### Tests
- desktop↔WASM interop **both directions** across all padding-boundary sizes (`MiB-129/-128/-1`, `MiB`, multi-block)
- correctable repair (single- **and** multi-block) + uncorrectable fail-closed (`code 4`)
- paranoid×RS, keyfiles×RS
- `go test ./...`, js/wasm bridge test, `go vet` (native + js/wasm), `golangci-lint` — all green; golden vectors unchanged

### Not in this PR (deploy-gated)
No `VERSION` bump / release. Ships together with the unreleased P0+P1 at the next release.

Part of the WASM tier-1 series: P0 (paranoid/comments) · P1 (keyfiles) · **P2 (Reed-Solomon)**.
