### PR TITLE
feat(wasm): force-decrypt (raw-byte recovery) (P3)

### DIFF
--- a/src/cmd/wasm/forcedecrypt_wasm_test.go
+++ b/src/cmd/wasm/forcedecrypt_wasm_test.go
@@ -1,0 +1,72 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"syscall/js"
+	"testing"
+
+	"Picocrypt-NG/internal/header"
+)
+
+func mkU8FD(b []byte) js.Value {
+	u := js.Global().Get("Uint8Array").New(len(b))
+	js.CopyBytesToJS(u, b)
+	return u
+}
+
+func bytesOf(v any) []byte {
+	jv := v.(js.Value)
+	d := jv.Get("data")
+	if d.Type() != js.TypeObject {
+		return nil
+	}
+	out := make([]byte, d.Get("length").Int())
+	js.CopyBytesToGo(out, d)
+	return out
+}
+
+// forceDecrypt:true over a tampered volume must return code 10 WITH data; the same
+// volume with force off returns code 4 (no data). Proves the bridge forwards the
+// flag and special-cases the kept code to carry bytes.
+func TestBridgeForceDecryptKeepsDataCode10(t *testing.T) {
+	plaintext := []byte("bridge force decrypt payload, long enough")
+	password := "bridge-force-pw"
+
+	enc := encrypt(js.Undefined(), []js.Value{newOpts(map[string]any{
+		"data": mkU8FD(plaintext), "password": password,
+	})})
+	if codeOf(enc) != 0 {
+		t.Fatalf("encrypt code %d", codeOf(enc))
+	}
+	vol := bytesOf(enc)
+	vol[header.HeaderSize(0)+3] ^= 0xFF // break the MAC
+
+	off := decrypt(js.Undefined(), []js.Value{newOpts(map[string]any{
+		"data": mkU8FD(vol), "password": password,
+	})})
+	if codeOf(off) != 4 {
+		t.Fatalf("force=off: code %d, want 4", codeOf(off))
+	}
+
+	on := decrypt(js.Undefined(), []js.Value{newOpts(map[string]any{
+		"data": mkU8FD(vol), "password": password, "forceDecrypt": true,
+	})})
+	if codeOf(on) != 10 {
+		t.Fatalf("force=on: code %d, want 10", codeOf(on))
+	}
+	got := bytesOf(on)
+	if len(got) != len(plaintext) {
+		t.Fatalf("kept data len %d, want %d", len(got), len(plaintext))
+	}
+	// Anti-vacuity: exactly the flipped byte differs.
+	for i := range plaintext {
+		want := plaintext[i]
+		if i == 3 {
+			want ^= 0xFF
+		}
+		if got[i] != want {
+			t.Fatalf("kept byte %d = %#x, want %#x", i, got[i], want)
+		}
+	}
+}

--- a/src/cmd/wasm/main.go
+++ b/src/cmd/wasm/main.go
@@ -179,8 +179,13 @@ func decrypt(this js.Value, args []js.Value) (result any) {
 		defer crypto.SecureZero(kf)
 	}
 
-	res, code := wasm.DecryptVolume(data, passwordBytes, wasm.DecryptOptions{Keyfiles: keyfiles})
-	if code != 0 {
+	res, code := wasm.DecryptVolume(data, passwordBytes, wasm.DecryptOptions{
+		Keyfiles: keyfiles,
+		Force:    optBool(opts, "forceDecrypt"),
+	})
+	// code 0 = verified; code 10 = kept-but-unverified (force). Both carry data;
+	// every other non-zero code is a plain failure with no payload.
+	if code != 0 && code != wasm.ErrModifiedButKept {
 		return errorResult(code)
 	}
 	defer crypto.SecureZero(res.Plaintext)
@@ -188,7 +193,7 @@ func decrypt(this js.Value, args []js.Value) (result any) {
 	out := js.Global().Get("Uint8Array").New(len(res.Plaintext))
 	js.CopyBytesToJS(out, res.Plaintext)
 	o := js.Global().Get("Object").New()
-	o.Set("code", 0)
+	o.Set("code", code)
 	o.Set("data", out)
 	o.Set("comments", res.Comments)
 	return o

--- a/src/internal/wasm/decrypt.go
+++ b/src/internal/wasm/decrypt.go
@@ -231,6 +231,10 @@ func DecryptVolume(volumeData, password []byte, opts DecryptOptions) (DecryptRes
 	}
 
 	// Forced best-effort recovery — UNTRUSTED output under a distinct code.
+	// A non-nil plaintext here is the best effort already computed: pass-1 bytes
+	// (non-RS) or the full-RS-corrected-but-unauthenticated retry; both are kept
+	// as-is. Only a nil plaintext (RS uncorrectable, or a stream error) needs a
+	// dedicated forceDecode salvage pass.
 	if plaintext == nil {
 		// Nothing coherent yet: a non-RS stream error cannot be recovered; an RS
 		// payload gets one forceDecode pass (raw bytes on uncorrectable blocks).

--- a/src/internal/wasm/decrypt.go
+++ b/src/internal/wasm/decrypt.go
@@ -15,14 +15,15 @@ import (
 
 // Error codes matching website convention
 const (
-	ErrUnsupported       = 1 // Keyfiles required, deniability, split chunks
-	ErrCorruptedHeader   = 2 // RS decode failure
-	ErrWrongPassword     = 3 // Auth verification failed
-	ErrModifiedData      = 4 // Payload MAC mismatch
-	ErrRandomFailure     = 5 // Random generation failed (encrypt only)
-	ErrKeyfilesRequired  = 7 // volume needs keyfiles, none provided
-	ErrKeyfilesIncorrect = 8 // provided keyfiles don't match the stored hash
-	ErrKeyfilesDuplicate = 9 // keyfiles XOR to an all-zero key
+	ErrUnsupported       = 1  // Keyfiles required, deniability, split chunks
+	ErrCorruptedHeader   = 2  // RS decode failure
+	ErrWrongPassword     = 3  // Auth verification failed
+	ErrModifiedData      = 4  // Payload MAC mismatch
+	ErrRandomFailure     = 5  // Random generation failed (encrypt only)
+	ErrKeyfilesRequired  = 7  // volume needs keyfiles, none provided
+	ErrKeyfilesIncorrect = 8  // provided keyfiles don't match the stored hash
+	ErrKeyfilesDuplicate = 9  // keyfiles XOR to an all-zero key
+	ErrModifiedButKept   = 10 // payload MAC failed; output kept on user-forced decrypt (untrusted)
 )
 
 // DecryptResult is the successful output of DecryptVolume. On error the int
@@ -30,11 +31,13 @@ const (
 type DecryptResult struct {
 	Plaintext []byte
 	Comments  string // plaintext header comments ("" if none)
+	Kept      bool   // true iff returned under ErrModifiedButKept (untrusted, force-decrypt)
 }
 
 // DecryptOptions configures an in-memory decryption.
 type DecryptOptions struct {
 	Keyfiles [][]byte // required iff the volume's header sets UseKeyfiles
+	Force    bool     // keep best-effort output despite a payload MAC failure (untrusted)
 }
 
 // DecryptVolume decrypts a Picocrypt volume from memory.
@@ -179,48 +182,72 @@ func DecryptVolume(volumeData, password []byte, opts DecryptOptions) (DecryptRes
 	// Read payload from remaining bytes
 	payload := volumeData[headerSize:]
 
-	// Pass 1: decrypt with the fast path (RS strips parity without correction).
+	// Pass 1: fast path (RS strips parity without correction; plain stream decrypt).
 	reedSolomon := hdr.Flags.ReedSolomon
 	var counter int64
 	var plaintext []byte
 	if reedSolomon {
-		plaintext, err = decryptRSPayload(payload, cipherSuite, rsCodecs, hdr.Flags.Padded, true)
+		plaintext, err = decryptRSPayload(payload, cipherSuite, rsCodecs, hdr.Flags.Padded, false, true)
 	} else {
 		plaintext, err = decryptPlainPayload(payload, cipherSuite, &counter)
 	}
-	if err != nil {
+
+	if err == nil {
+		computedMAC := cipherSuite.Sum()
+		macValid := subtle.ConstantTimeCompare(computedMAC, hdr.AuthTag) == 1
+		zeroWASMSensitiveBuffer(wasmZeroingDecryptComputedMAC, computedMAC)
+		if macValid {
+			return DecryptResult{Plaintext: plaintext, Comments: hdr.Comments}, 0
+		}
+		// RS guarded retry: correctable damage makes the fast pass yield a wrong
+		// MAC. Rebuild the cipher suite and re-decrypt ONCE with full correction.
+		if reedSolomon {
+			zeroWASMSensitiveBuffer(wasmZeroingDecryptPlaintextChunk, plaintext)
+			retryCS, code := buildDecryptCipherSuite(key, cipherKey, hdr, isLegacyV1)
+			if code != 0 {
+				return DecryptResult{}, code
+			}
+			defer retryCS.Close()
+			plaintext, err = decryptRSPayload(payload, retryCS, rsCodecs, hdr.Flags.Padded, false, false)
+			if err == nil {
+				retryMAC := retryCS.Sum()
+				macValid = subtle.ConstantTimeCompare(retryMAC, hdr.AuthTag) == 1
+				zeroWASMSensitiveBuffer(wasmZeroingDecryptComputedMAC, retryMAC)
+				if macValid {
+					return DecryptResult{Plaintext: plaintext, Comments: hdr.Comments}, 0
+				}
+			} else {
+				plaintext = nil // uncorrectable; only a forced salvage can recover
+			}
+		}
+	}
+
+	// Payload did not verify. Without force, fail closed (unchanged behavior).
+	if !opts.Force {
+		if plaintext != nil {
+			zeroWASMSensitiveBuffer(wasmZeroingDecryptPlaintextChunk, plaintext)
+		}
 		return DecryptResult{}, ErrModifiedData
 	}
 
-	computedMAC := cipherSuite.Sum()
-	macValid := subtle.ConstantTimeCompare(computedMAC, hdr.AuthTag) == 1
-	zeroWASMSensitiveBuffer(wasmZeroingDecryptComputedMAC, computedMAC)
-
-	// RS guarded retry: correctable damage makes the fast pass yield a wrong MAC.
-	// Rebuild the cipher suite and re-decrypt ONCE with full RS correction before
-	// rejecting. cipherKey is still live here (its wipe is deferred to return).
-	if !macValid && reedSolomon {
-		zeroWASMSensitiveBuffer(wasmZeroingDecryptPlaintextChunk, plaintext)
-		retryCS, code := buildDecryptCipherSuite(key, cipherKey, hdr, isLegacyV1)
+	// Forced best-effort recovery — UNTRUSTED output under a distinct code.
+	if plaintext == nil {
+		// Nothing coherent yet: a non-RS stream error cannot be recovered; an RS
+		// payload gets one forceDecode pass (raw bytes on uncorrectable blocks).
+		if !reedSolomon {
+			return DecryptResult{}, ErrModifiedData
+		}
+		salvageCS, code := buildDecryptCipherSuite(key, cipherKey, hdr, isLegacyV1)
 		if code != 0 {
 			return DecryptResult{}, code
 		}
-		defer retryCS.Close()
-		plaintext, err = decryptRSPayload(payload, retryCS, rsCodecs, hdr.Flags.Padded, false)
+		defer salvageCS.Close()
+		plaintext, err = decryptRSPayload(payload, salvageCS, rsCodecs, hdr.Flags.Padded, true, false)
 		if err != nil {
 			return DecryptResult{}, ErrModifiedData
 		}
-		retryMAC := retryCS.Sum()
-		macValid = subtle.ConstantTimeCompare(retryMAC, hdr.AuthTag) == 1
-		zeroWASMSensitiveBuffer(wasmZeroingDecryptComputedMAC, retryMAC)
 	}
-
-	if !macValid {
-		zeroWASMSensitiveBuffer(wasmZeroingDecryptPlaintextChunk, plaintext)
-		return DecryptResult{}, ErrModifiedData
-	}
-
-	return DecryptResult{Plaintext: plaintext, Comments: hdr.Comments}, 0
+	return DecryptResult{Plaintext: plaintext, Comments: hdr.Comments, Kept: true}, ErrModifiedButKept
 }
 
 // verifyWASMHeader checks whether key authenticates the volume header and, on
@@ -262,19 +289,19 @@ func hasUnsupportedWASMFeature(flags header.Flags) bool {
 
 // decryptRSPayload decrypts an RS128-framed payload block-by-block. fastDecode=true
 // strips parity without correction (fast first pass); false applies full RS
-// correction (repairs <=4 errors per 136-byte block). forceDecode is false (P2
-// fails closed): an uncorrectable block returns the error from the shared codec.
+// correction (repairs <=4 errors per 136-byte block). forceDecode=true returns raw
+// bytes on uncorrectable blocks (user force-decrypt) instead of erroring.
 // DecodeRSPayloadBlock returns a freshly-allocated slice, so paranoid Decrypt
 // (which mutates src) never touches the caller's payload, keeping it pristine for
 // a retry pass.
-func decryptRSPayload(payload []byte, cs *crypto.CipherSuite, rs *encoding.RSCodecs, padded, fastDecode bool) ([]byte, error) {
+func decryptRSPayload(payload []byte, cs *crypto.CipherSuite, rs *encoding.RSCodecs, padded, forceDecode, fastDecode bool) ([]byte, error) {
 	plaintext := make([]byte, 0, len(payload))
 	var counter int64
 	blockSize := encoding.RSEncodedBlockSize
 	for offset := 0; offset < len(payload); offset += blockSize {
 		end := min(offset+blockSize, len(payload))
 		isLast := end >= len(payload)
-		data, err := encoding.DecodeRSPayloadBlock(payload[offset:end], rs, isLast, padded, false, fastDecode)
+		data, err := encoding.DecodeRSPayloadBlock(payload[offset:end], rs, isLast, padded, forceDecode, fastDecode)
 		if err != nil {
 			return nil, err
 		}

--- a/src/internal/wasm/forcedecrypt_test.go
+++ b/src/internal/wasm/forcedecrypt_test.go
@@ -124,3 +124,74 @@ func TestForceDecryptRSOverBudgetKeeps(t *testing.T) {
 		t.Fatal("first RS chunk should reflect corruption, not be pristine")
 	}
 }
+
+// RS + keyfiles + force: the salvage cipher suite must be rebuilt with the
+// keyfile-XOR'd cipher key and v2 subkey ordering. Also proves force does NOT
+// bypass the keyfile requirement (invariant: force gates only the payload MAC).
+func TestForceDecryptRSKeyfilesKeeps(t *testing.T) {
+	plaintext := []byte(strings.Repeat("rs-kf-force-", 1500))
+	pw := []byte("pw-rs-kf-force")
+	kfs := [][]byte{
+		[]byte(strings.Repeat("keyfile-alpha-", 8)),
+		[]byte(strings.Repeat("keyfile-beta--", 8)),
+	}
+	vol, code := EncryptVolume(plaintext, pw, EncryptOptions{ReedSolomon: true, Keyfiles: kfs})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	payloadStart := header.HeaderSize(0)
+	tampered := append([]byte(nil), vol...)
+	for i := range 9 { // > RS128 budget -> uncorrectable -> salvage path
+		tampered[payloadStart+i] ^= 0xFF
+	}
+
+	// force=on but keyfiles missing: must still demand keyfiles, not salvage.
+	if _, c := DecryptVolume(tampered, pw, DecryptOptions{Force: true}); c != ErrKeyfilesRequired {
+		t.Fatalf("force + no keyfiles: got %d, want ErrKeyfilesRequired(%d)", c, ErrKeyfilesRequired)
+	}
+	// force=off with correct keyfiles: fail closed.
+	if _, c := DecryptVolume(tampered, pw, DecryptOptions{Keyfiles: kfs}); c != ErrModifiedData {
+		t.Fatalf("force=off: got %d, want ErrModifiedData(%d)", c, ErrModifiedData)
+	}
+	// force=on with correct keyfiles: best-effort salvage through the keyfile suite.
+	res, c := DecryptVolume(tampered, pw, DecryptOptions{Keyfiles: kfs, Force: true})
+	if c != ErrModifiedButKept {
+		t.Fatalf("force=on: got %d, want ErrModifiedButKept(%d)", c, ErrModifiedButKept)
+	}
+	if !res.Kept || len(res.Plaintext) != len(plaintext) {
+		t.Fatalf("kept=%v len=%d (want true, %d)", res.Kept, len(res.Plaintext), len(plaintext))
+	}
+	if !bytes.Equal(res.Plaintext[128:], plaintext[128:]) {
+		t.Fatal("undamaged region must be intact (keyfile salvage subkey ordering)")
+	}
+}
+
+// RS + paranoid + force: exercises the salvage path with the paranoid cipher
+// cascade (Serpent-CTR + XChaCha20, HMAC-SHA3) re-derived for the salvage suite.
+func TestForceDecryptParanoidRSKeeps(t *testing.T) {
+	plaintext := []byte(strings.Repeat("paranoid-rs-force-", 1200))
+	pw := []byte("pw-paranoid-rs-force")
+	vol, code := EncryptVolume(plaintext, pw, EncryptOptions{Paranoid: true, ReedSolomon: true})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	payloadStart := header.HeaderSize(0)
+	tampered := append([]byte(nil), vol...)
+	for i := range 9 { // > RS128 budget -> uncorrectable -> salvage path
+		tampered[payloadStart+i] ^= 0xFF
+	}
+
+	if _, c := DecryptVolume(tampered, pw, DecryptOptions{}); c != ErrModifiedData {
+		t.Fatalf("force=off: got %d, want ErrModifiedData(%d)", c, ErrModifiedData)
+	}
+	res, c := DecryptVolume(tampered, pw, DecryptOptions{Force: true})
+	if c != ErrModifiedButKept {
+		t.Fatalf("force=on: got %d, want ErrModifiedButKept(%d)", c, ErrModifiedButKept)
+	}
+	if !res.Kept || len(res.Plaintext) != len(plaintext) {
+		t.Fatalf("kept=%v len=%d (want true, %d)", res.Kept, len(res.Plaintext), len(plaintext))
+	}
+	if !bytes.Equal(res.Plaintext[128:], plaintext[128:]) {
+		t.Fatal("undamaged region must be intact (paranoid RS salvage)")
+	}
+}

--- a/src/internal/wasm/forcedecrypt_test.go
+++ b/src/internal/wasm/forcedecrypt_test.go
@@ -1,0 +1,126 @@
+package wasm
+
+import (
+	"Picocrypt-NG/internal/header"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Force must NOT turn a wrong password into kept garbage: header auth gates it.
+func TestForceDecryptDoesNotBypassWrongPassword(t *testing.T) {
+	vol, code := EncryptVolume([]byte("secret payload"), []byte("correct-horse"), EncryptOptions{})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	res, c := DecryptVolume(vol, []byte("wrong-password"), DecryptOptions{Force: true})
+	if c != ErrWrongPassword {
+		t.Fatalf("got code %d, want ErrWrongPassword(%d); force must not bypass auth", c, ErrWrongPassword)
+	}
+	if res.Plaintext != nil {
+		t.Fatal("no plaintext may be returned for a wrong password, even with force")
+	}
+	if res.Kept {
+		t.Fatal("Kept must be false when auth fails")
+	}
+}
+
+// A clean volume verifies normally even with force on (force never degrades the happy path).
+func TestForceDecryptCleanVolumeUnaffected(t *testing.T) {
+	plaintext := []byte("clean volume, force flag on")
+	pw := []byte("pw-clean-force")
+	vol, code := EncryptVolume(plaintext, pw, EncryptOptions{})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	res, c := DecryptVolume(vol, pw, DecryptOptions{Force: true})
+	if c != 0 {
+		t.Fatalf("clean+force: got code %d, want 0", c)
+	}
+	if res.Kept {
+		t.Fatal("Kept must be false for a cleanly verified volume")
+	}
+	if !bytes.Equal(res.Plaintext, plaintext) {
+		t.Fatal("plaintext mismatch on clean decrypt")
+	}
+}
+
+// Non-RS: a flipped payload byte breaks the MAC. force=off fails closed; force=on
+// keeps the ACTUAL corrupted decryption (stream cipher => exactly one plaintext
+// byte flips by the same mask). Anti-vacuity: fails if salvage returns zeros, the
+// pristine plaintext, or garbage.
+func TestForceDecryptNonRSKeepsCorruptedBytes(t *testing.T) {
+	plaintext := []byte(strings.Repeat("force-decrypt-nonrs-", 50))
+	pw := []byte("pw-force-nonrs")
+	vol, code := EncryptVolume(plaintext, pw, EncryptOptions{})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	const flipIdx = 5
+	const mask = 0xFF
+	tampered := append([]byte(nil), vol...)
+	tampered[header.HeaderSize(0)+flipIdx] ^= mask
+
+	if _, c := DecryptVolume(tampered, pw, DecryptOptions{}); c != ErrModifiedData {
+		t.Fatalf("force=off: got code %d, want ErrModifiedData(%d)", c, ErrModifiedData)
+	}
+
+	res, c := DecryptVolume(tampered, pw, DecryptOptions{Force: true})
+	if c != ErrModifiedButKept {
+		t.Fatalf("force=on: got code %d, want ErrModifiedButKept(%d)", c, ErrModifiedButKept)
+	}
+	if !res.Kept {
+		t.Fatal("Kept must be true on a forced keep")
+	}
+	if len(res.Plaintext) != len(plaintext) {
+		t.Fatalf("kept len %d, want %d", len(res.Plaintext), len(plaintext))
+	}
+	for i := range plaintext {
+		want := plaintext[i]
+		if i == flipIdx {
+			want ^= mask
+		}
+		if res.Plaintext[i] != want {
+			t.Fatalf("kept byte %d = %#x, want %#x", i, res.Plaintext[i], want)
+		}
+	}
+}
+
+// RS volume, damage beyond the RS128 budget (>4 byte-errors in one 136-byte block):
+// force=off fails closed; force=on salvages best-effort. Anti-vacuity: the
+// undamaged region (beyond the first 128-byte data chunk) matches the original
+// exactly, while the damaged first chunk does NOT equal the pristine plaintext.
+func TestForceDecryptRSOverBudgetKeeps(t *testing.T) {
+	plaintext := []byte(strings.Repeat("rs-force-", 2000)) // 18000 bytes, multi-chunk
+	pw := []byte("pw-force-rs")
+	vol, code := EncryptVolume(plaintext, pw, EncryptOptions{ReedSolomon: true})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	payloadStart := header.HeaderSize(0)
+	tampered := append([]byte(nil), vol...)
+	for i := range 9 { // 9 > 4 -> uncorrectable in the first RS block
+		tampered[payloadStart+i] ^= 0xFF
+	}
+
+	if _, c := DecryptVolume(tampered, pw, DecryptOptions{}); c != ErrModifiedData {
+		t.Fatalf("force=off: got code %d, want ErrModifiedData(%d)", c, ErrModifiedData)
+	}
+
+	res, c := DecryptVolume(tampered, pw, DecryptOptions{Force: true})
+	if c != ErrModifiedButKept {
+		t.Fatalf("force=on: got code %d, want ErrModifiedButKept(%d)", c, ErrModifiedButKept)
+	}
+	if !res.Kept {
+		t.Fatal("Kept must be true on a forced keep")
+	}
+	if len(res.Plaintext) != len(plaintext) {
+		t.Fatalf("kept len %d, want %d", len(res.Plaintext), len(plaintext))
+	}
+	if !bytes.Equal(res.Plaintext[128:], plaintext[128:]) {
+		t.Fatal("undamaged region beyond the first RS data chunk must be intact")
+	}
+	if bytes.Equal(res.Plaintext[:128], plaintext[:128]) {
+		t.Fatal("first RS chunk should reflect corruption, not be pristine")
+	}
+}


### PR DESCRIPTION
## P3 — Force-decrypt (raw-byte recovery) in the WASM module

Mirrors desktop `ForceDecrypt`: opt-in best-effort recovery of plaintext from a
damaged/tampered volume, returned under a **distinct code (10)** and flagged untrusted.
Without the flag the WASM path fails closed exactly as before.

**Invariants**
- `code == 0` ⇔ payload MAC verified. Untrusted (kept) output uses code 10, never 0.
- Force engages **only** at the payload stage — never bypasses wrong password / keyfiles / corrupted header.
- Best-effort for both payload kinds: non-RS (stream) and RS (`forceDecode` → raw bytes on uncorrectable blocks).
- No `.pcv` format change; no desktop changes.

**Tests:** native `internal/wasm` + `js && wasm` bridge, all keep/security tests mutation-proven non-vacuous.

Web UI (IO repo) is template-only, deploy-gated (`index.html` regenerated at release).
Spec: `docs/superpowers/specs/2026-06-20-p3-wasm-force-decrypt-design.md` (untracked).
Base for the stacked P4 PR.
