### PR TITLE
feat(wasm): plausible deniability (P4)

### DIFF
--- a/src/cmd/wasm/deniability_wasm_test.go
+++ b/src/cmd/wasm/deniability_wasm_test.go
@@ -1,0 +1,70 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"bytes"
+	"syscall/js"
+	"testing"
+
+	"Picocrypt-NG/internal/encoding"
+	"Picocrypt-NG/internal/header"
+)
+
+func mkU8Den(b []byte) js.Value {
+	u := js.Global().Get("Uint8Array").New(len(b))
+	js.CopyBytesToJS(u, b)
+	return u
+}
+
+func dataBytesDen(t *testing.T, res any) []byte {
+	t.Helper()
+	jv := res.(js.Value)
+	d := jv.Get("data")
+	out := make([]byte, d.Get("length").Int())
+	js.CopyBytesToGo(out, d)
+	return out
+}
+
+// The bridge must forward `deniability:true`: the produced volume must have NO
+// readable header (disguised as random data) AND still decrypt back to the
+// original through the same bridge. The no-readable-header assertion is what
+// makes this fail if the bridge silently drops the option (a normal volume,
+// which has a decodable version, would otherwise also roundtrip).
+func TestBridgeDeniabilityRoundtrip(t *testing.T) {
+	original := []byte("bridge deniability roundtrip payload")
+	password := "bridge-deniability-pw"
+
+	encOpts := js.Global().Get("Object").New()
+	encOpts.Set("data", mkU8Den(original))
+	encOpts.Set("password", password)
+	encOpts.Set("deniability", true)
+
+	encRes := encrypt(js.Undefined(), []js.Value{encOpts})
+	if code := encRes.(js.Value).Get("code").Int(); code != 0 {
+		t.Fatalf("encrypt code %d; want 0", code)
+	}
+	wrapped := dataBytesDen(t, encRes)
+
+	// A deniable volume has no readable header: the first 15 bytes must NOT decode
+	// to a valid version (decode may succeed on random bytes, so check MatchVersion).
+	rs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("NewRSCodecs: %v", err)
+	}
+	if vd, derr := encoding.Decode(rs.RS5, append([]byte(nil), wrapped[:15]...), false); derr == nil && header.MatchVersion(vd) {
+		t.Fatal("bridge produced a decodable header — deniability option was not forwarded")
+	}
+
+	decOpts := js.Global().Get("Object").New()
+	decOpts.Set("data", mkU8Den(wrapped))
+	decOpts.Set("password", password)
+
+	decRes := decrypt(js.Undefined(), []js.Value{decOpts})
+	if code := decRes.(js.Value).Get("code").Int(); code != 0 {
+		t.Fatalf("decrypt code %d; want 0", code)
+	}
+	if got := dataBytesDen(t, decRes); !bytes.Equal(got, original) {
+		t.Fatalf("bridge roundtrip mismatch\ngot:  %q\nwant: %q", got, original)
+	}
+}

--- a/src/cmd/wasm/main.go
+++ b/src/cmd/wasm/main.go
@@ -124,6 +124,7 @@ func encrypt(this js.Value, args []js.Value) (result any) {
 	}
 	keyfileOrdered := optBool(opts, "keyfileOrdered")
 	reedSolomon := optBool(opts, "reedSolomon")
+	deniability := optBool(opts, "deniability")
 
 	passwordBytes := []byte(pw.String())
 	defer crypto.SecureZero(passwordBytes)
@@ -138,6 +139,7 @@ func encrypt(this js.Value, args []js.Value) (result any) {
 		Keyfiles:       keyfiles,
 		KeyfileOrdered: keyfileOrdered,
 		ReedSolomon:    reedSolomon,
+		Deniability:    deniability,
 	})
 	if code != 0 {
 		return errorResult(code)

--- a/src/internal/wasm/decrypt.go
+++ b/src/internal/wasm/decrypt.go
@@ -15,7 +15,7 @@ import (
 
 // Error codes matching website convention
 const (
-	ErrUnsupported       = 1  // Keyfiles required, deniability, split chunks
+	ErrUnsupported       = 1  // split chunks, or legacy-v1 keyfile volumes
 	ErrCorruptedHeader   = 2  // RS decode failure
 	ErrWrongPassword     = 3  // Auth verification failed
 	ErrModifiedData      = 4  // Payload MAC mismatch
@@ -47,6 +47,21 @@ func DecryptVolume(volumeData, password []byte, opts DecryptOptions) (DecryptRes
 	rsCodecs, err := encoding.NewRSCodecs()
 	if err != nil {
 		return DecryptResult{}, ErrCorruptedHeader
+	}
+
+	// Deniability: a wrapped volume has no readable header (random salt/nonce
+	// prefix), so detect it first, strip the outer XChaCha20 layer, and decrypt
+	// the recovered inner .pcv. Force is intentionally ignored for deniable
+	// volumes (desktop convention: the unauthenticated wrapper has no payload MAC
+	// to force). Recursion is one level: inner is a real .pcv whose leading bytes
+	// decode to a valid version, so isDeniable(inner) is false.
+	if isDeniable(volumeData, rsCodecs) {
+		inner, code := unwrapDeniability(volumeData, password, rsCodecs)
+		if code != 0 {
+			return DecryptResult{}, code
+		}
+		defer crypto.SecureZero(inner)
+		return DecryptVolume(inner, password, DecryptOptions{Keyfiles: opts.Keyfiles})
 	}
 
 	// Create reader from volume data

--- a/src/internal/wasm/deniability.go
+++ b/src/internal/wasm/deniability.go
@@ -1,0 +1,69 @@
+package wasm
+
+import (
+	"Picocrypt-NG/internal/crypto"
+	"Picocrypt-NG/internal/util"
+
+	pwnorm "Picocrypt-NG/internal/password"
+
+	"golang.org/x/crypto/chacha20"
+)
+
+// Outer deniability-wrapper sizes (distinct from the inner volume's header
+// salt/nonce). Frozen to match desktop volume.AddDeniability.
+const (
+	deniabilitySaltSize  = 16
+	deniabilityNonceSize = 24
+)
+
+// wrapDeniability wraps a finished inner .pcv in the outer XChaCha20 deniability
+// layer: salt(16) ‖ nonce(24) ‖ keystream-XOR(inner). The outer key is derived
+// with normal-params Argon2id over the NFC-normalized password — byte-identical
+// to desktop volume.AddDeniability. Returns (wrapped, 0) or (nil, ErrRandomFailure).
+func wrapDeniability(inner, password []byte) ([]byte, int) {
+	salt, err := crypto.RandomBytes(deniabilitySaltSize)
+	if err != nil {
+		return nil, ErrRandomFailure
+	}
+	nonce, err := crypto.RandomBytes(deniabilityNonceSize)
+	if err != nil {
+		return nil, ErrRandomFailure
+	}
+
+	kdfInput := pwnorm.EncodeForKDF(password)
+	key, err := crypto.DeriveKey(kdfInput, salt, false)
+	zeroWASMSensitiveBuffer(wasmZeroingDeniabilityKDFInput, kdfInput)
+	if err != nil {
+		return nil, ErrRandomFailure
+	}
+	defer zeroWASMSensitiveBuffer(wasmZeroingDeniabilityKey, key)
+
+	cipher, err := chacha20.NewUnauthenticatedCipher(key, nonce)
+	if err != nil {
+		return nil, ErrRandomFailure
+	}
+
+	out := make([]byte, 0, len(salt)+len(nonce)+len(inner))
+	out = append(out, salt...)
+	out = append(out, nonce...)
+
+	// XOR the inner volume in MiB chunks, mirroring desktop's rekey boundary.
+	// Under the WASM 1 GiB size cap the 60 GiB rekey threshold is never reached;
+	// the counter/rekey branch is kept only for byte-format fidelity with desktop.
+	var counter int64
+	for offset := 0; offset < len(inner); offset += util.MiB {
+		end := min(offset+util.MiB, len(inner))
+		dst := make([]byte, end-offset)
+		cipher.XORKeyStream(dst, inner[offset:end])
+		out = append(out, dst...)
+		counter += int64(end - offset)
+		if counter >= crypto.RekeyThreshold {
+			cipher, nonce, err = crypto.DeniabilityRekey(key, nonce)
+			if err != nil {
+				return nil, ErrRandomFailure
+			}
+			counter = 0
+		}
+	}
+	return out, 0
+}

--- a/src/internal/wasm/deniability.go
+++ b/src/internal/wasm/deniability.go
@@ -177,7 +177,7 @@ func selectDeniabilityKey(password, salt, nonce, probe []byte, rs *encoding.RSCo
 
 // unwrapDeniability strips the outer deniability layer and returns the inner .pcv
 // bytes. salt(16) ‖ nonce(24) prefix selects the key (via selectDeniabilityKey);
-// the rest is XOR-decrypted. A defensive inner-version re-check guards the result.
+// the rest is XOR-decrypted. selectDeniabilityKey is the sole auth guard.
 func unwrapDeniability(volume, password []byte, rs *encoding.RSCodecs) ([]byte, int) {
 	if len(volume) < deniabilitySaltSize+deniabilityNonceSize+header.VersionEncSize {
 		return nil, ErrWrongPassword
@@ -216,15 +216,5 @@ func unwrapDeniability(volume, password []byte, rs *encoding.RSCodecs) ([]byte, 
 		}
 	}
 
-	// Defensive: selectDeniabilityKey already matched the probe (same keystream),
-	// so this re-confirms the inner header decoded coherently before we recurse.
-	if len(inner) < header.VersionEncSize {
-		return nil, ErrWrongPassword
-	}
-	versionEnc := append([]byte(nil), inner[:header.VersionEncSize]...)
-	versionDec, derr := encoding.Decode(rs.RS5, versionEnc, false)
-	if derr != nil || !header.MatchVersion(versionDec) {
-		return nil, ErrWrongPassword
-	}
 	return inner, 0
 }

--- a/src/internal/wasm/deniability.go
+++ b/src/internal/wasm/deniability.go
@@ -147,3 +147,84 @@ func headerFlagsBytesPlausible(b []byte) bool {
 	}
 	return true
 }
+
+// selectDeniabilityKey returns the outer key for the first password normalization
+// form (NFC/NFD/raw) whose keystream decodes a valid inner volume version from
+// probe (the encrypted version field at offset salt+nonce). The deniable wrapper
+// has no MAC, so the inner-version match is the only key check. Non-winning keys
+// and every candidate buffer are zeroed. Returns ErrWrongPassword if none match.
+func selectDeniabilityKey(password, salt, nonce, probe []byte, rs *encoding.RSCodecs) ([]byte, int) {
+	for _, cand := range pwnorm.Candidates(password) {
+		key, err := crypto.DeriveKey(cand, salt, false)
+		zeroWASMSensitiveBuffer(wasmZeroingDeniabilityKDFInput, cand)
+		if err != nil {
+			continue // degenerate all-zero key (effectively never); treat as non-match
+		}
+		cipher, cerr := chacha20.NewUnauthenticatedCipher(key, nonce)
+		if cerr != nil {
+			zeroWASMSensitiveBuffer(wasmZeroingDeniabilityKey, key)
+			continue
+		}
+		dec := make([]byte, len(probe))
+		cipher.XORKeyStream(dec, probe)
+		if versionDec, derr := encoding.Decode(rs.RS5, dec, false); derr == nil && header.MatchVersion(versionDec) {
+			return key, 0
+		}
+		zeroWASMSensitiveBuffer(wasmZeroingDeniabilityKey, key)
+	}
+	return nil, ErrWrongPassword
+}
+
+// unwrapDeniability strips the outer deniability layer and returns the inner .pcv
+// bytes. salt(16) ‖ nonce(24) prefix selects the key (via selectDeniabilityKey);
+// the rest is XOR-decrypted. A defensive inner-version re-check guards the result.
+func unwrapDeniability(volume, password []byte, rs *encoding.RSCodecs) ([]byte, int) {
+	if len(volume) < deniabilitySaltSize+deniabilityNonceSize+header.VersionEncSize {
+		return nil, ErrWrongPassword
+	}
+	salt := volume[:deniabilitySaltSize]
+	nonce := append([]byte(nil), volume[deniabilitySaltSize:deniabilitySaltSize+deniabilityNonceSize]...)
+	probeStart := deniabilitySaltSize + deniabilityNonceSize
+	probe := append([]byte(nil), volume[probeStart:probeStart+header.VersionEncSize]...)
+
+	key, code := selectDeniabilityKey(password, salt, nonce, probe, rs)
+	if code != 0 {
+		return nil, code
+	}
+	defer zeroWASMSensitiveBuffer(wasmZeroingDeniabilityKey, key)
+
+	cipher, err := chacha20.NewUnauthenticatedCipher(key, nonce)
+	if err != nil {
+		return nil, ErrCorruptedHeader
+	}
+
+	encrypted := volume[probeStart:]
+	inner := make([]byte, 0, len(encrypted))
+	var counter int64
+	for offset := 0; offset < len(encrypted); offset += util.MiB {
+		end := min(offset+util.MiB, len(encrypted))
+		dst := make([]byte, end-offset)
+		cipher.XORKeyStream(dst, encrypted[offset:end])
+		inner = append(inner, dst...)
+		counter += int64(end - offset)
+		if counter >= crypto.RekeyThreshold { // dead under the 1 GiB cap (fidelity only)
+			cipher, nonce, err = crypto.DeniabilityRekey(key, nonce)
+			if err != nil {
+				return nil, ErrCorruptedHeader
+			}
+			counter = 0
+		}
+	}
+
+	// Defensive: selectDeniabilityKey already matched the probe (same keystream),
+	// so this re-confirms the inner header decoded coherently before we recurse.
+	if len(inner) < header.VersionEncSize {
+		return nil, ErrWrongPassword
+	}
+	versionEnc := append([]byte(nil), inner[:header.VersionEncSize]...)
+	versionDec, derr := encoding.Decode(rs.RS5, versionEnc, false)
+	if derr != nil || !header.MatchVersion(versionDec) {
+		return nil, ErrWrongPassword
+	}
+	return inner, 0
+}

--- a/src/internal/wasm/deniability.go
+++ b/src/internal/wasm/deniability.go
@@ -2,6 +2,8 @@ package wasm
 
 import (
 	"Picocrypt-NG/internal/crypto"
+	"Picocrypt-NG/internal/encoding"
+	"Picocrypt-NG/internal/header"
 	"Picocrypt-NG/internal/util"
 
 	pwnorm "Picocrypt-NG/internal/password"
@@ -66,4 +68,82 @@ func wrapDeniability(inner, password []byte) ([]byte, int) {
 		}
 	}
 	return out, 0
+}
+
+// isDeniable reports whether volume looks like a deniability-wrapped volume.
+// A regular volume starts with an RS5-encoded version; a deniable wrapper starts
+// with random salt/nonce. A version-decode failure is ambiguous (deniable wrapper
+// vs. a damaged regular header), resolved by checking whether the following
+// comment-length and flags fields still look like a regular header.
+// Byte-slice port of volume.IsDeniable (no file I/O).
+func isDeniable(volume []byte, rs *encoding.RSCodecs) bool {
+	const minDeniableSize = deniabilitySaltSize + deniabilityNonceSize + header.BaseHeaderSize
+	if len(volume) < minDeniableSize {
+		return false
+	}
+	// Copy before Decode: the FEC codec may operate on its input buffer.
+	versionEnc := append([]byte(nil), volume[:header.VersionEncSize]...)
+	versionDec, err := encoding.Decode(rs.RS5, versionEnc, false)
+	if err != nil {
+		return !looksLikeRegularHeaderAfterDamagedVersion(volume, rs)
+	}
+	if header.MatchVersion(versionDec) {
+		return false
+	}
+	return !looksLikeRegularHeaderAfterDamagedVersion(volume, rs)
+}
+
+func looksLikeRegularHeaderAfterDamagedVersion(volume []byte, rs *encoding.RSCodecs) bool {
+	commentLenOff := header.VersionEncSize
+	if len(volume) < commentLenOff+header.CommentLenEncSize {
+		return false
+	}
+	commentLenEnc := append([]byte(nil), volume[commentLenOff:commentLenOff+header.CommentLenEncSize]...)
+	commentLenDec, err := encoding.Decode(rs.RS5, commentLenEnc, false)
+	if err != nil {
+		return false
+	}
+	commentsLen, ok := parseHeaderCommentLen(commentLenDec)
+	if !ok {
+		return false
+	}
+	flagsOff := header.VersionEncSize + header.CommentLenEncSize + commentsLen*3
+	if len(volume) < flagsOff+header.FlagsEncSize {
+		return false
+	}
+	flagsEnc := append([]byte(nil), volume[flagsOff:flagsOff+header.FlagsEncSize]...)
+	flagsDec, err := encoding.Decode(rs.RS5, flagsEnc, false)
+	if err != nil {
+		return false
+	}
+	return headerFlagsBytesPlausible(flagsDec)
+}
+
+func parseHeaderCommentLen(b []byte) (int, bool) {
+	if len(b) != 5 {
+		return 0, false
+	}
+	n := 0
+	for _, c := range b {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		n = n*10 + int(c-'0')
+	}
+	if n > header.MaxCommentLen {
+		return 0, false
+	}
+	return n, true
+}
+
+func headerFlagsBytesPlausible(b []byte) bool {
+	if len(b) < 5 {
+		return false
+	}
+	for _, c := range b[:5] {
+		if c != 0 && c != 1 {
+			return false
+		}
+	}
+	return true
 }

--- a/src/internal/wasm/deniability_test.go
+++ b/src/internal/wasm/deniability_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -55,5 +56,48 @@ func TestDeniabilityWrapDesktopUnwrap(t *testing.T) {
 	}
 	if !bytes.Equal(res.Plaintext, original) {
 		t.Fatalf("plaintext mismatch\ngot:  %q\nwant: %q", res.Plaintext, original)
+	}
+}
+
+// isDeniable must be TRUE for a wrapped volume and FALSE for every normal volume
+// variant (no false positives — a valid header decodes to a version immediately).
+func TestIsDeniableDetection(t *testing.T) {
+	rs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("NewRSCodecs: %v", err)
+	}
+	pw := []byte("p4-detect")
+	plain := []byte(strings.Repeat("detect-", 300))
+
+	deniable, code := EncryptVolume(plain, pw, EncryptOptions{Deniability: true})
+	if code != 0 {
+		t.Fatalf("encrypt deniable code %d", code)
+	}
+	if !isDeniable(deniable, rs) {
+		t.Fatal("wrapped volume must be detected as deniable")
+	}
+
+	regulars := map[string]EncryptOptions{
+		"plain":    {},
+		"paranoid": {Paranoid: true},
+		"rs":       {ReedSolomon: true},
+		"keyfiles": {Keyfiles: [][]byte{[]byte("kf-one"), []byte("kf-two-longer")}},
+		"comments": {Comments: "a deniable-looking comment"},
+	}
+	for name, opts := range regulars {
+		t.Run(name, func(t *testing.T) {
+			vol, code := EncryptVolume(plain, pw, opts)
+			if code != 0 {
+				t.Fatalf("encrypt %s code %d", name, code)
+			}
+			if isDeniable(vol, rs) {
+				t.Fatalf("regular %s volume misclassified as deniable", name)
+			}
+		})
+	}
+
+	// Too-short input cannot be deniable.
+	if isDeniable([]byte("short"), rs) {
+		t.Fatal("sub-minimum-size input must not be deniable")
 	}
 }

--- a/src/internal/wasm/deniability_test.go
+++ b/src/internal/wasm/deniability_test.go
@@ -59,6 +59,93 @@ func TestDeniabilityWrapDesktopUnwrap(t *testing.T) {
 	}
 }
 
+// Full WASM roundtrip: encrypt with deniability, decrypt back byte-exact.
+func TestDeniabilityRoundtrip(t *testing.T) {
+	original := []byte(strings.Repeat("p4-roundtrip-", 400))
+	pw := []byte("p4-roundtrip-pw")
+	vol, code := EncryptVolume(original, pw, EncryptOptions{Deniability: true})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	res, code := DecryptVolume(vol, pw, DecryptOptions{})
+	if code != 0 {
+		t.Fatalf("decrypt code %d", code)
+	}
+	if !bytes.Equal(res.Plaintext, original) {
+		t.Fatalf("roundtrip mismatch\ngot:  %q\nwant: %q", res.Plaintext, original)
+	}
+}
+
+// Desktop-wrapped deniable volume must open in WASM (reverse cross-compat).
+func TestDeniabilityDesktopWrapWASMUnwrap(t *testing.T) {
+	original := []byte("P4: desktop-wrapped deniable volume opens in WASM.")
+	pw := []byte("p4-desktop-wrap")
+
+	// WASM produces the inner .pcv; desktop wraps it in deniability in place.
+	inner, code := EncryptVolume(original, pw, EncryptOptions{})
+	if code != 0 {
+		t.Fatalf("encrypt inner code %d", code)
+	}
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "vol.pcv")
+	if err := os.WriteFile(path, inner, 0o600); err != nil {
+		t.Fatalf("write inner: %v", err)
+	}
+	if err := volume.AddDeniability(path, pw, nil); err != nil {
+		t.Fatalf("desktop AddDeniability: %v", err)
+	}
+	wrapped, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read wrapped: %v", err)
+	}
+
+	res, code := DecryptVolume(wrapped, pw, DecryptOptions{})
+	if code != 0 {
+		t.Fatalf("WASM decrypt of desktop-wrapped deniable code %d", code)
+	}
+	if !bytes.Equal(res.Plaintext, original) {
+		t.Fatalf("plaintext mismatch\ngot:  %q\nwant: %q", res.Plaintext, original)
+	}
+}
+
+// Wrong password on a deniable volume → ErrWrongPassword, no plaintext.
+// The unauthenticated wrapper must not leak inner bytes without the right key.
+func TestDeniabilityWrongPassword(t *testing.T) {
+	vol, code := EncryptVolume([]byte("secret deniable payload"), []byte("right-pw"), EncryptOptions{Deniability: true})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	res, c := DecryptVolume(vol, []byte("wrong-pw"), DecryptOptions{})
+	if c != ErrWrongPassword {
+		t.Fatalf("got code %d, want ErrWrongPassword(%d)", c, ErrWrongPassword)
+	}
+	if res.Plaintext != nil {
+		t.Fatal("no plaintext may be returned for a wrong password on a deniable volume")
+	}
+}
+
+// Force is ignored for deniable volumes: result is identical with/without Force.
+func TestDeniabilityIgnoresForce(t *testing.T) {
+	original := []byte("p4 force-ignored on deniable")
+	pw := []byte("p4-force-ignored")
+	vol, code := EncryptVolume(original, pw, EncryptOptions{Deniability: true})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	// Right pw + Force: still a clean code 0, never code 10.
+	res, c := DecryptVolume(vol, pw, DecryptOptions{Force: true})
+	if c != 0 || res.Kept {
+		t.Fatalf("force on deniable: code %d kept %v; want 0/false", c, res.Kept)
+	}
+	if !bytes.Equal(res.Plaintext, original) {
+		t.Fatal("plaintext mismatch with force on")
+	}
+	// Wrong pw + Force: still ErrWrongPassword, never a forced keep.
+	if _, c := DecryptVolume(vol, []byte("nope"), DecryptOptions{Force: true}); c != ErrWrongPassword {
+		t.Fatalf("force + wrong pw on deniable: code %d; want ErrWrongPassword(%d)", c, ErrWrongPassword)
+	}
+}
+
 // isDeniable must be TRUE for a wrapped volume and FALSE for every normal volume
 // variant (no false positives — a valid header decodes to a version immediately).
 func TestIsDeniableDetection(t *testing.T) {

--- a/src/internal/wasm/deniability_test.go
+++ b/src/internal/wasm/deniability_test.go
@@ -146,6 +146,100 @@ func TestDeniabilityIgnoresForce(t *testing.T) {
 	}
 }
 
+// Deniability composes with every inner option (the wrapper is outermost).
+// keyfiles case also asserts the inner keyfile requirement still applies.
+func TestDeniabilityCombos(t *testing.T) {
+	original := []byte(strings.Repeat("p4-combo-", 500))
+	pw := []byte("p4-combo-pw")
+	kfs := [][]byte{[]byte("kf-combo-alpha-content"), []byte("kf-combo-beta-content")}
+
+	cases := []struct {
+		name string
+		enc  EncryptOptions
+		dec  DecryptOptions
+	}{
+		{"paranoid", EncryptOptions{Deniability: true, Paranoid: true}, DecryptOptions{}},
+		{"rs", EncryptOptions{Deniability: true, ReedSolomon: true}, DecryptOptions{}},
+		{"comments", EncryptOptions{Deniability: true, Comments: "hidden note"}, DecryptOptions{}},
+		{"keyfiles", EncryptOptions{Deniability: true, Keyfiles: kfs}, DecryptOptions{Keyfiles: kfs}},
+		{"kf_ordered", EncryptOptions{Deniability: true, Keyfiles: kfs, KeyfileOrdered: true}, DecryptOptions{Keyfiles: kfs}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vol, code := EncryptVolume(original, pw, tc.enc)
+			if code != 0 {
+				t.Fatalf("encrypt code %d", code)
+			}
+			res, code := DecryptVolume(vol, pw, tc.dec)
+			if code != 0 {
+				t.Fatalf("decrypt code %d", code)
+			}
+			if !bytes.Equal(res.Plaintext, original) {
+				t.Fatalf("plaintext mismatch for %s", tc.name)
+			}
+			if tc.name == "comments" && res.Comments != "hidden note" {
+				t.Fatalf("comments = %q; want %q", res.Comments, "hidden note")
+			}
+		})
+	}
+
+	// Deniable + keyfiles, keyfiles omitted on decrypt → inner ErrKeyfilesRequired.
+	vol, code := EncryptVolume(original, pw, EncryptOptions{Deniability: true, Keyfiles: kfs})
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+	if _, c := DecryptVolume(vol, pw, DecryptOptions{}); c != ErrKeyfilesRequired {
+		t.Fatalf("deniable+keyfiles, none provided: code %d; want ErrKeyfilesRequired(%d)", c, ErrKeyfilesRequired)
+	}
+}
+
+// The deniability key and KDF input must be zeroed on both encrypt and decrypt.
+func TestDeniabilitySecretsZeroed(t *testing.T) {
+	original := []byte("p4 deniability secret zeroing coverage")
+	pw := []byte("p4-zeroing-pw")
+
+	var encEvents []wasmZeroingEvent
+	restoreEnc := observeWASMZeroingForTest(func(e wasmZeroingEvent) { encEvents = append(encEvents, e) })
+	vol, code := EncryptVolume(original, pw, EncryptOptions{Deniability: true})
+	restoreEnc()
+	if code != 0 {
+		t.Fatalf("encrypt code %d", code)
+	}
+
+	var decEvents []wasmZeroingEvent
+	restoreDec := observeWASMZeroingForTest(func(e wasmZeroingEvent) { decEvents = append(decEvents, e) })
+	res, code := DecryptVolume(vol, pw, DecryptOptions{})
+	restoreDec()
+	if code != 0 {
+		t.Fatalf("decrypt code %d", code)
+	}
+	if !bytes.Equal(res.Plaintext, original) {
+		t.Fatal("plaintext mismatch")
+	}
+
+	for _, tc := range []struct {
+		phase  string
+		events []wasmZeroingEvent
+	}{{"encrypt", encEvents}, {"decrypt", decEvents}} {
+		seen := make(map[wasmZeroingBufferKind]wasmZeroingEvent)
+		for _, e := range tc.events {
+			seen[e.Kind] = e
+		}
+		for _, kind := range []wasmZeroingBufferKind{wasmZeroingDeniabilityKey, wasmZeroingDeniabilityKDFInput} {
+			e, ok := seen[kind]
+			if !ok {
+				t.Fatalf("%s: missing zeroing event for %s", tc.phase, kind)
+			}
+			if !e.Zeroed {
+				t.Fatalf("%s: %s not zeroed after cleanup", tc.phase, kind)
+			}
+			if !e.WasNonZero {
+				t.Fatalf("%s: %s already zero before cleanup; vacuity guard failed", tc.phase, kind)
+			}
+		}
+	}
+}
+
 // isDeniable must be TRUE for a wrapped volume and FALSE for every normal volume
 // variant (no false positives — a valid header decodes to a version immediately).
 func TestIsDeniableDetection(t *testing.T) {

--- a/src/internal/wasm/deniability_test.go
+++ b/src/internal/wasm/deniability_test.go
@@ -1,0 +1,59 @@
+package wasm
+
+import (
+	"Picocrypt-NG/internal/encoding"
+	"Picocrypt-NG/internal/header"
+	"Picocrypt-NG/internal/volume"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// WASM-produced deniable volume must (a) have no readable header and (b) be
+// stripped by the REAL desktop deniability code, with the recovered inner .pcv
+// decrypting back in WASM. This pins the outer-layer byte format against desktop.
+func TestDeniabilityWrapDesktopUnwrap(t *testing.T) {
+	original := []byte("P4: WASM-wrapped deniable volume, stripped by desktop.")
+	password := []byte("p4-wrap-interop")
+
+	vol, code := EncryptVolume(original, password, EncryptOptions{Deniability: true})
+	if code != 0 {
+		t.Fatalf("encrypt(deniability) code %d", code)
+	}
+
+	rs, err := encoding.NewRSCodecs()
+	if err != nil {
+		t.Fatalf("NewRSCodecs: %v", err)
+	}
+	// No readable header: the first 15 bytes must NOT decode to a VALID version.
+	// (RS5 decode can "succeed" on random bytes by correcting to a non-version
+	// codeword, so the MatchVersion check is required — mirrors volume.IsDeniable.)
+	if vd, derr := encoding.Decode(rs.RS5, append([]byte(nil), vol[:15]...), false); derr == nil && header.MatchVersion(vd) {
+		t.Fatal("deniable volume leaked a decodable version header (not deniable)")
+	}
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "deniable.pcv")
+	if err := os.WriteFile(path, vol, 0o600); err != nil {
+		t.Fatalf("write deniable volume: %v", err)
+	}
+	if !volume.IsDeniable(path, rs) {
+		t.Fatal("desktop did not recognize the WASM volume as deniable")
+	}
+	innerPath, err := volume.RemoveDeniability(path, password, nil, rs)
+	if err != nil {
+		t.Fatalf("desktop RemoveDeniability: %v", err)
+	}
+	innerBytes, err := os.ReadFile(innerPath)
+	if err != nil {
+		t.Fatalf("read inner: %v", err)
+	}
+	res, code := DecryptVolume(innerBytes, password, DecryptOptions{})
+	if code != 0 {
+		t.Fatalf("decrypt inner code %d", code)
+	}
+	if !bytes.Equal(res.Plaintext, original) {
+		t.Fatalf("plaintext mismatch\ngot:  %q\nwant: %q", res.Plaintext, original)
+	}
+}

--- a/src/internal/wasm/encrypt.go
+++ b/src/internal/wasm/encrypt.go
@@ -41,6 +41,8 @@ const (
 	wasmZeroingCipherKey             wasmZeroingBufferKind = "keyfile cipher key"
 	wasmZeroingDecryptKeyfileKey     wasmZeroingBufferKind = "decrypt keyfile key"
 	wasmZeroingDecryptCipherKey      wasmZeroingBufferKind = "decrypt keyfile cipher key"
+	wasmZeroingDeniabilityKey        wasmZeroingBufferKind = "deniability key"
+	wasmZeroingDeniabilityKDFInput   wasmZeroingBufferKind = "deniability kdf input"
 )
 
 type wasmZeroingEvent struct {
@@ -104,6 +106,7 @@ type EncryptOptions struct {
 	Keyfiles       [][]byte // each element is one keyfile's full contents
 	KeyfileOrdered bool     // true = order matters (sequential hash); false = XOR
 	ReedSolomon    bool     // RS128 error-correction framing of the payload
+	Deniability    bool     // wrap the finished volume in an outer deniability layer
 }
 
 // EncryptVolume encrypts plaintext data into a Picocrypt volume.
@@ -345,5 +348,13 @@ func EncryptVolume(plaintext, password []byte, opts EncryptOptions) ([]byte, int
 	zeroWASMSensitiveBuffer(wasmZeroingCiphertextBuffer, ciphertextBytes)
 	ciphertextBufferZeroed = true
 
+	if opts.Deniability {
+		wrapped, code := wrapDeniability(result, password)
+		crypto.SecureZero(result) // inner .pcv ciphertext, no longer needed
+		if code != 0 {
+			return nil, code
+		}
+		return wrapped, 0
+	}
 	return result, 0
 }


### PR DESCRIPTION
## P4 — Plausible deniability in the WASM module

In-memory port of desktop deniability: **create** deniable volumes (encrypt wrap) and
**auto-detect + open** them (decrypt). A deniable volume wraps the inner `.pcv` in an
outer **unauthenticated** XChaCha20 layer — `salt(16) ‖ nonce(24) ‖ keystream-XOR(inner)`,
keyed by Argon2id normal params — so it is byte-indistinguishable from random data.

**Invariants (verified by a whole-branch security review)**
- **Byte-format fidelity:** cross-compat both directions, pinned against the real desktop `volume` package (WASM→desktop `RemoveDeniability`, desktop `AddDeniability`→WASM).
- `code == 0` ⇔ inner volume MAC verified; the unauthenticated outer layer never reports success on its own.
- Wrong password on a deniable volume → `ErrWrongPassword (3)`, no plaintext — `selectDeniabilityKey` is the **sole** auth guard (a provably-dead redundant re-check was removed so the wrong-pw test is non-vacuous).
- Force-decrypt **ignored** on detected-deniable (desktop convention); recursion is provably one level.
- No `.pcv`/deniability format change; **no new error codes**; **no desktop changes** (reuses `crypto.DeriveKey(pw, salt, false)`).

**Tests (all keep/security tests mutation-proven non-vacuous):** roundtrip, bidirectional cross-compat, detection matrix (no false positives), wrong-pw, force-ignored, composition (× paranoid/keyfiles/RS/comments), secret-zeroing; plus a `js && wasm` bridge test.

**Gate:** `go test ./...` (21 pkgs) green, `go vet` clean, `golangci-lint` 0 issues, js/wasm build + bridge tests pass.

Stacked on #169 (P3). Web UI (IO repo) is template-only, deploy-gated.
Spec: `docs/superpowers/specs/2026-06-20-p4-wasm-deniability-design.md` (untracked).
