### PR TITLE
fix(windows): overwrite main exe on upgrade; guard running instance

### DIFF
--- a/.github/workflows/pr-test-installer-upgrade.yml
+++ b/.github/workflows/pr-test-installer-upgrade.yml
@@ -1,0 +1,195 @@
+name: pr-test-installer-upgrade
+
+# Runtime end-to-end guard for the Windows installer upgrade path (discussion
+# #163). The Go contract tests (distmeta TestWindowsNSISScript) assert the script
+# text statically; this job actually compiles the installer with makensis and
+# runs it on Windows to prove the *behavior*: an upgrade overwrites the main exe
+# in place, orphaned binaries are swept, and a running instance is detected
+# rather than silently leaving a stale binary.
+#
+# Tiny stub binaries are used (the installer copies bytes verbatim — it does not
+# parse the exe), so this does not depend on the heavy Go/ResHacker/UPX pipeline.
+#
+# Scenario 0 is a NEGATIVE CONTROL: it builds a minimal installer that
+# deliberately reproduces the pre-fix File+Rename bug and asserts the test
+# harness DETECTS it. If the detector fails to flag a known-broken installer the
+# whole job fails — this is what proves the real assertions below are not
+# fictitious (i.e. cannot silently pass when the behavior regresses).
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  installer-upgrade:
+    runs-on: windows-2025
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Install NSIS
+      shell: pwsh
+      run: |
+        choco install -y --no-progress nsis
+        & "C:\Program Files (x86)\NSIS\makensis.exe" -VERSION
+
+    - name: Runtime upgrade / orphan-sweep / running-instance test
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+
+        $makensis = "C:\Program Files (x86)\NSIS\makensis.exe"
+        $script   = (Resolve-Path "dist\windows\installer.nsi").Path
+        $outDir   = (Resolve-Path "dist\windows").Path
+        $built    = Join-Path $outDir "Picocrypt-NG-Setup.exe"
+        $version  = (Get-Content -Path "VERSION" -Raw).Trim()
+        $tmp      = $env:RUNNER_TEMP
+
+        # --- helpers ---------------------------------------------------------
+
+        function Main-Path([string]$dir) { Join-Path $dir "Picocrypt-NG.exe" }
+        function Orphan-Path([string]$dir) { Join-Path $dir "Picocrypt-NG-portable.exe" }
+
+        # Compile the REAL installer.nsi embedding a distinguishable marker as the
+        # main binary, and stash a copy of the resulting setup.exe.
+        function Build-Installer([string]$marker, [string]$dest) {
+          Set-Content -Path "src\Picocrypt-NG-portable.exe" -Value $marker       -NoNewline -Encoding ascii
+          Set-Content -Path "src\Picocrypt-NG-cli.exe"      -Value "cli-$marker" -NoNewline -Encoding ascii
+          & $makensis -WX -V4 "-DVERSION=$version" "$script"
+          if ($LASTEXITCODE -ne 0) { throw "makensis failed ($LASTEXITCODE)" }
+          Copy-Item $built $dest -Force
+        }
+
+        # NSIS /D= must be the LAST argument and unquoted (paths here have no spaces).
+        function Install([string]$exe, [string]$dir) {
+          (Start-Process -FilePath $exe -ArgumentList "/S /D=$dir" -Wait -PassThru).ExitCode
+        }
+
+        # The installer may return from -Wait microscopically before the file is
+        # flushed; poll briefly for the expected content. Throws on mismatch.
+        function Assert-Main([string]$dir, [string]$expected, [string]$ctx) {
+          $exe = Main-Path $dir
+          for ($i = 0; $i -lt 30; $i++) {
+            if ((Test-Path $exe) -and ((Get-Content -Path $exe -Raw) -eq $expected)) { return }
+            Start-Sleep -Milliseconds 500
+          }
+          $got = if (Test-Path $exe) { Get-Content -Path $exe -Raw } else { "<missing>" }
+          throw "$ctx : expected main exe '$expected', got '$got'"
+        }
+
+        # === Scenario 0: NEGATIVE CONTROL ====================================
+        # Build a minimal installer that reproduces the pre-fix bug (File then
+        # Rename onto the existing target) and prove the harness flags it. NSIS
+        # Rename fails when the destination exists, so the upgrade must leave the
+        # OLD marker plus an orphan — exactly what Assert-Main / the orphan check
+        # must catch. If they don't, the real test below would be fictitious.
+        $negNsi = Join-Path $tmp "neg.nsi"
+        $negSrc = Join-Path $tmp "neg-src.bin"
+        $negDir = "C:\pcng-neg"
+        # Built from an array (not a here-string) so it is immune to YAML block
+        # indentation. Single-quoted lines keep $INSTDIR literal for NSIS;
+        # double-quoted lines interpolate the PowerShell temp paths.
+        $negScript = @(
+          'Unicode true',
+          'Name "neg-control"',
+          "OutFile `"$tmp\neg-setup.exe`"",
+          'InstallDir "C:\pcng-neg-default"',
+          'RequestExecutionLevel admin',
+          'Section',
+          '  SetOutPath "$INSTDIR"',
+          "  File `"/oname=Picocrypt-NG-portable.exe`" `"$negSrc`"",
+          '  Rename "$INSTDIR\Picocrypt-NG-portable.exe" "$INSTDIR\Picocrypt-NG.exe"',
+          'SectionEnd'
+        ) -join "`r`n"
+        Set-Content -Path $negNsi -Value $negScript -Encoding ascii
+
+        function Build-Bug-Installer([string]$marker, [string]$dest) {
+          Set-Content -Path $negSrc -Value $marker -NoNewline -Encoding ascii
+          & $makensis -V2 $negNsi
+          if ($LASTEXITCODE -ne 0) { throw "neg makensis failed ($LASTEXITCODE)" }
+          Copy-Item (Join-Path $tmp "neg-setup.exe") $dest -Force
+        }
+
+        if (Test-Path $negDir) { Remove-Item -Recurse -Force $negDir }
+        Build-Bug-Installer "NEG1" (Join-Path $tmp "neg1.exe")
+        Build-Bug-Installer "NEG2" (Join-Path $tmp "neg2.exe")
+
+        $rc = Install (Join-Path $tmp "neg1.exe") $negDir
+        if ($rc -ne 0) { throw "neg control v1 install exit code $rc" }
+        Assert-Main $negDir "NEG1" "neg control v1"
+
+        $rc = Install (Join-Path $tmp "neg2.exe") $negDir
+        if ($rc -ne 0) { throw "neg control v2 install exit code $rc" }
+        $detected = $false
+        try { Assert-Main $negDir "NEG2" "neg control upgrade (expected to fail)" } catch { $detected = $true }
+        if (-not $detected) {
+          throw "NEGATIVE CONTROL FAILED: harness did not detect a stale upgrade -> the runtime test is fictitious"
+        }
+        if (-not (Test-Path (Orphan-Path $negDir))) {
+          throw "NEGATIVE CONTROL FAILED: reproduced bug did not leave the expected orphan -> harness cannot see it"
+        }
+        Write-Host "OK: negative control confirms the harness detects the #163 regression (stale main exe + orphan)"
+
+        # === Scenario A: clean install, then upgrade overwrites in place (#163) ===
+        $instDir = "C:\pcng-itest"
+        if (Test-Path $instDir) { Remove-Item -Recurse -Force $instDir }
+
+        Build-Installer "PCNG_V1" (Join-Path $outDir "setup-v1.exe")
+        Build-Installer "PCNG_V2" (Join-Path $outDir "setup-v2.exe")
+
+        $rc = Install (Join-Path $outDir "setup-v1.exe") $instDir
+        if ($rc -ne 0) { throw "v1 install exit code $rc" }
+        Assert-Main $instDir "PCNG_V1" "v1 clean install"
+        Write-Host "OK: v1 installed"
+
+        $rc = Install (Join-Path $outDir "setup-v2.exe") $instDir
+        if ($rc -ne 0) { throw "v2 upgrade exit code $rc" }
+        Assert-Main $instDir "PCNG_V2" "REGRESSION #163: upgrade did not overwrite main exe"
+        if (Test-Path (Orphan-Path $instDir)) { throw "REGRESSION #163: orphan Picocrypt-NG-portable.exe left after upgrade" }
+        Write-Host "OK: upgrade overwrote main exe in place; no orphan"
+
+        # === Scenario B: install sweeps a pre-existing orphan (#163) ===
+        Set-Content -Path (Orphan-Path $instDir) -Value "STALE_ORPHAN" -NoNewline -Encoding ascii
+        Build-Installer "PCNG_V3" (Join-Path $outDir "setup-v3.exe")
+        $rc = Install (Join-Path $outDir "setup-v3.exe") $instDir
+        if ($rc -ne 0) { throw "v3 install exit code $rc" }
+        if (Test-Path (Orphan-Path $instDir)) { throw "install did not sweep the pre-existing orphan portable exe (#163)" }
+        Assert-Main $instDir "PCNG_V3" "v3 upgrade after orphan injection"
+        Write-Host "OK: install swept pre-existing orphan"
+
+        # === Scenario C: a running instance is detected, not silently stale ===
+        # Replace the installed exe with a real runnable that holds its own image
+        # lock while running (ping renamed still pings; the filename is irrelevant).
+        Copy-Item "C:\Windows\System32\ping.exe" (Main-Path $instDir) -Force
+        $running = Start-Process -FilePath (Main-Path $instDir) -ArgumentList "-n 600 127.0.0.1" -WindowStyle Hidden -PassThru
+        try {
+          Start-Sleep -Seconds 2  # let the loader map (and lock) the image
+          $before = (Get-FileHash (Main-Path $instDir)).Hash
+          # Silent install over the locked exe: MessageBox /SD IDCANCEL -> abort.
+          $rc = Install (Join-Path $outDir "setup-v3.exe") $instDir
+          $after = (Get-FileHash (Main-Path $instDir)).Hash
+          if ($after -ne $before) { throw "running-instance guard FAILED: locked exe was modified (rc=$rc)" }
+          if ($rc -eq 0)         { throw "running-instance guard FAILED: installer reported success over a locked exe" }
+          Write-Host "OK: guard aborted silent upgrade over running instance (rc=$rc); exe unchanged"
+        } finally {
+          if ($running -and -not $running.HasExited) {
+            Stop-Process -Id $running.Id -Force
+            $running.WaitForExit(10000) | Out-Null
+          }
+        }
+
+        # Once the instance is closed, the same upgrade succeeds.
+        $rc = Install (Join-Path $outDir "setup-v3.exe") $instDir
+        if ($rc -ne 0) { throw "post-close upgrade exit code $rc" }
+        Assert-Main $instDir "PCNG_V3" "upgrade after instance closed"
+        Write-Host "OK: upgrade succeeds after the running instance is closed"
+
+        Write-Host "All installer upgrade scenarios passed."

--- a/dist/windows/installer.nsi
+++ b/dist/windows/installer.nsi
@@ -94,9 +94,38 @@ Section "-Picocrypt-NG (required)" SecCore
   SectionIn RO
   SetOutPath "$INSTDIR"
 
-  ; --- Binaries (D-29 portable rename: Picocrypt-NG-portable.exe → Picocrypt-NG.exe) ---
-  File "${__FILEDIR__}\..\..\src\Picocrypt-NG-portable.exe"
-  Rename "$INSTDIR\Picocrypt-NG-portable.exe" "$INSTDIR\Picocrypt-NG.exe"
+  ; --- Binaries (D-29: portable artifact installed as Picocrypt-NG.exe) ---
+  ; File /oname= writes straight to the install name and overwrites by default,
+  ; so re-install/upgrade replaces the prior binary in place. A plain Rename fails
+  ; when $INSTDIR\Picocrypt-NG.exe already exists from an earlier version, silently
+  ; keeping the stale binary (discussion #163).
+  ;
+  ; Running-instance guard: a running Picocrypt-NG locks Picocrypt-NG.exe, so the
+  ; overwrite fails. SetOverwrite try surfaces that as the error flag (instead of
+  ; the stock Abort/Retry/Ignore dialog whose "Ignore" would leave a stale binary).
+  ; Ask the user to close the app and retry; abort on cancel. We deliberately do
+  ; NOT force-kill — that could corrupt an in-progress encryption.
+  SetOverwrite try
+  pcng_main_retry:
+  ClearErrors
+  File "/oname=Picocrypt-NG.exe" "${__FILEDIR__}\..\..\src\Picocrypt-NG-portable.exe"
+  ${If} ${Errors}
+    ; /SD IDCANCEL: silent installs (/S) get no dialog, so default to cancel ->
+    ; abort rather than looping on the implicit retry default.
+    MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION \
+      "Could not update Picocrypt-NG.exe.$\r$\nIt may still be running - please close Picocrypt-NG, then click Retry." \
+      /SD IDCANCEL \
+      IDRETRY pcng_main_retry
+    ; Non-zero exit so unattended installs can detect the failure.
+    SetErrorLevel 2
+    Abort "Setup cannot continue while Picocrypt-NG is running."
+  ${EndIf}
+  SetOverwrite on
+
+  ; Sweep the orphaned portable binary left by the pre-fix upgrade bug (#163) on
+  ; machines that already hit it; harmless no-op on clean installs.
+  Delete "$INSTDIR\Picocrypt-NG-portable.exe"
+
   File "${__FILEDIR__}\..\..\src\Picocrypt-NG-cli.exe"
 
   ; --- File-type icon (always copied; Default Apps UI may need it even if SecAssoc unchecked) ---
@@ -202,6 +231,7 @@ Section "Uninstall"
   ; --- Files (D-28) ---
   Delete "$INSTDIR\Picocrypt-NG.exe"
   Delete "$INSTDIR\Picocrypt-NG-cli.exe"
+  Delete "$INSTDIR\Picocrypt-NG-portable.exe"  ; orphan from pre-fix upgrade bug (#163)
   Delete "$INSTDIR\pcv-icon.ico"
   Delete "$INSTDIR\Uninstall.exe"
   RMDir  "$INSTDIR"

--- a/src/internal/distmeta/distmeta_test.go
+++ b/src/internal/distmeta/distmeta_test.go
@@ -973,6 +973,88 @@ func TestWindowsNSISScript(t *testing.T) {
 		}
 	})
 
+	t.Run("main_exe_overwrites_on_upgrade", func(t *testing.T) {
+		// Regression guard for discussion #163: installing a newer version over an
+		// existing install left the OLD Picocrypt-NG.exe in place ("the .exe from
+		// 2.15 still remains and wasn't overwritten"). Root cause: the script
+		// delivered the main binary via `File ...-portable.exe` + `Rename
+		// "$INSTDIR\Picocrypt-NG-portable.exe" "$INSTDIR\Picocrypt-NG.exe"`, but
+		// NSIS Rename FAILS (sets the error flag, here unchecked) when the
+		// destination already exists. So the prior binary survived every upgrade
+		// and the new one was left orphaned as Picocrypt-NG-portable.exe.
+		//
+		// Invariant: the main executable MUST be delivered via an overwrite-capable
+		// command (File defaults to SetOverwrite on) so re-install/upgrade replaces
+		// it in place at $INSTDIR\Picocrypt-NG.exe.
+
+		// Negative: must NOT move a file onto the fixed install path of the main
+		// exe. Rename does not overwrite; CopyFiles onto an existing target is the
+		// same hazard. Either reintroduces the upgrade bug.
+		badMove := regexp.MustCompile(`(?:Rename|CopyFiles)[^\n]*"\$INSTDIR\\Picocrypt-NG\.exe"`)
+		if badMove.MatchString(text) {
+			t.Errorf("installer.nsi delivers Picocrypt-NG.exe by moving a file onto its install path; " +
+				"NSIS Rename does not overwrite an existing destination, so upgrades over a prior install " +
+				"silently keep the old binary (discussion #163). Use File /oname=Picocrypt-NG.exe (overwrite-capable).")
+		}
+
+		// Positive: the main exe must actually be installed via File /oname=
+		// (overwrite-capable), landing the new binary at $INSTDIR\Picocrypt-NG.exe.
+		goodFile := regexp.MustCompile(`File\s+"?/oname=Picocrypt-NG\.exe"?`)
+		if !goodFile.MatchString(text) {
+			t.Errorf("installer.nsi must deliver the main executable via `File /oname=Picocrypt-NG.exe` " +
+				"so re-install/upgrade overwrites the prior binary in place (discussion #163)")
+		}
+	})
+
+	// --- Install Section (SecCore) scoped assertions (discussion #163 follow-ups) ---
+	secCoreBlock := regexp.MustCompile(`(?ms)Section\s+"-Picocrypt-NG \(required\)".*?SectionEnd`).FindString(text)
+	if secCoreBlock == "" {
+		t.Fatalf("installer.nsi missing 'Section \"-Picocrypt-NG (required)\"' (SecCore) block — cannot validate install-time behavior")
+	}
+
+	t.Run("running_instance_guard_on_main_exe", func(t *testing.T) {
+		// A running Picocrypt-NG locks Picocrypt-NG.exe, so File overwrite fails.
+		// With the default overwrite behavior the user could click "Ignore" and end
+		// up with a stale binary reported as a successful install — the same class of
+		// silent-stale bug as discussion #163. The install MUST instead detect the
+		// locked binary (SetOverwrite try → error flag) and either retry after the
+		// user closes the app or abort — never silently leave the old exe, and never
+		// force-kill (that could corrupt an in-progress encryption).
+		if !strings.Contains(secCoreBlock, "SetOverwrite try") {
+			t.Errorf("SecCore must use `SetOverwrite try` around the main exe so a locked (running) binary is detected instead of silently skipped (#163)")
+		}
+		if !regexp.MustCompile(`\$\{Errors\}|IfErrors`).MatchString(secCoreBlock) {
+			t.Errorf("SecCore must consult the error flag after writing the main exe to detect a running instance (#163)")
+		}
+		if !strings.Contains(secCoreBlock, "MB_RETRYCANCEL") {
+			t.Errorf("SecCore must prompt the user to close a running Picocrypt-NG and retry (MB_RETRYCANCEL), not force-kill (#163)")
+		}
+		if !regexp.MustCompile(`\bAbort\b`).MatchString(secCoreBlock) {
+			t.Errorf("SecCore must Abort when the main exe cannot be updated (running instance), instead of reporting a misleading success (#163)")
+		}
+		// Silent installs (/S, e.g. admin deployment and CI) get no dialog: the
+		// running-instance MessageBox (the only one in SecCore) MUST declare a
+		// silent default of IDCANCEL so a locked binary aborts cleanly instead of
+		// looping on the implicit retry default.
+		if !strings.Contains(secCoreBlock, "/SD IDCANCEL") {
+			t.Errorf("SecCore running-instance MessageBox must specify `/SD IDCANCEL` so silent installs abort (not loop) on a locked exe (#163)")
+		}
+		// The abort path must surface a non-zero exit code so unattended installs
+		// can detect the failure instead of treating the aborted run as success.
+		if !regexp.MustCompile(`SetErrorLevel\s+[1-9]`).MatchString(secCoreBlock) {
+			t.Errorf("SecCore must SetErrorLevel to a non-zero value before aborting on a running instance so silent installs report failure (#163)")
+		}
+	})
+
+	t.Run("install_sweeps_orphan_portable", func(t *testing.T) {
+		// Machines that hit the pre-fix upgrade bug carry an orphaned
+		// Picocrypt-NG-portable.exe. The install must sweep it so an upgrade leaves a
+		// clean install dir (harmless no-op on clean installs).
+		if !regexp.MustCompile(`Delete\s+"\$INSTDIR\\Picocrypt-NG-portable\.exe"`).MatchString(secCoreBlock) {
+			t.Errorf("SecCore must Delete the orphaned $INSTDIR\\Picocrypt-NG-portable.exe left by the pre-fix upgrade bug (#163)")
+		}
+	})
+
 	// --- Uninstaller block scoped assertions (D-27 hybrid cleanup) ---
 	uninstallBlock := regexp.MustCompile(`(?ms)Section\s+"Uninstall".*?SectionEnd`).FindString(text)
 	if uninstallBlock == "" {
@@ -993,6 +1075,14 @@ func TestWindowsNSISScript(t *testing.T) {
 	t.Run("uninstall_shchangenotify", func(t *testing.T) {
 		if !strings.Contains(uninstallBlock, "SHChangeNotify") {
 			t.Errorf("Uninstall Section missing SHChangeNotify call (D-26)")
+		}
+	})
+	t.Run("uninstall_sweeps_orphan_portable", func(t *testing.T) {
+		// Without this, the orphaned Picocrypt-NG-portable.exe (pre-fix #163 bug)
+		// survives uninstall and the non-recursive RMDir "$INSTDIR" fails to remove
+		// the now-non-empty install directory.
+		if !regexp.MustCompile(`Delete\s+"\$INSTDIR\\Picocrypt-NG-portable\.exe"`).MatchString(uninstallBlock) {
+			t.Errorf("Uninstall Section must Delete the orphaned $INSTDIR\\Picocrypt-NG-portable.exe so RMDir can remove the install dir (#163)")
 		}
 	})
 


### PR DESCRIPTION
## Problem
Reported in [discussion #163](https://github.com/orgs/Picocrypt-NG/discussions/163#discussioncomment-17372815): installing 2.16 over an existing 2.15 left the **old** `Picocrypt-NG.exe` in place; the user had to uninstall before 2.16 would "come alive".

## Root cause
`installer.nsi` delivered the main binary via `File ...-portable.exe` + `Rename "$INSTDIR\Picocrypt-NG-portable.exe" "$INSTDIR\Picocrypt-NG.exe"`. **NSIS `Rename` does not overwrite an existing destination** — it fails and sets the error flag (here unchecked). So on every upgrade the prior `Picocrypt-NG.exe` survived and the new binary was orphaned as `Picocrypt-NG-portable.exe`. Uninstall removed the collision, hence the workaround. The installer is byte-identical in tags 2.15 and 2.16, so the bug is deterministic on every upgrade.

## Fix
- **Overwrite on upgrade**: install via `File "/oname=Picocrypt-NG.exe"` (`SetOverwrite on` by default) — replaces the binary in place, no Rename, no orphan.
- **Running-instance guard**: a running app locks the exe, so overwrite fails. `SetOverwrite try` surfaces that via the error flag (instead of the stock Abort/Retry/**Ignore** dialog whose Ignore would silently keep a stale binary). User is asked to close the app and Retry, or Cancel → Abort. **No force-kill** — that could corrupt an in-progress encryption.
- **Legacy orphan sweep**: `Delete "$INSTDIR\Picocrypt-NG-portable.exe"` on both install and uninstall, so upgrades and the non-recursive `RMDir "$INSTDIR"` leave a clean dir on machines that already hit the bug.

## Tests (TDD, RED→GREEN)
New `distmeta` contract subtests in `TestWindowsNSISScript`, each verified failing on the old script first:
- `main_exe_overwrites_on_upgrade` — no Rename/CopyFiles onto the main exe path; must use `File /oname=`.
- `running_instance_guard_on_main_exe` — `SetOverwrite try` + error-flag check + `MB_RETRYCANCEL` + `Abort`.
- `install_sweeps_orphan_portable` / `uninstall_sweeps_orphan_portable` — orphan cleanup in both sections.

`go test ./...` green, `go vet ./...` clean. `makensis` compile is exercised on the Windows CI host (D-33); `File /oname=` is stock NSIS, no new plugins.