### PR TITLE
Fix Linux GUI layout and output theming

### DIFF
--- a/src/internal/ui/advanced_section.go
+++ b/src/internal/ui/advanced_section.go
@@ -30,27 +30,21 @@ func (a *App) updateAdvancedSection() {
 			a.advancedLabel.Hide()
 		}
 		// Resize to compact initial height
-		if a.Window != nil {
-			a.Window.Resize(fyne.NewSize(windowWidth, windowHeightInitial))
-		}
+		a.resizeDesktopWindowForCurrentContent(windowHeightInitial)
 	case "encrypt":
 		if a.advancedLabel != nil {
 			a.advancedLabel.Show()
 		}
 		a.buildEncryptOptions()
 		// Resize window for encrypt mode (more options)
-		if a.Window != nil {
-			a.Window.Resize(fyne.NewSize(windowWidth, windowHeightEncrypt))
-		}
+		a.resizeDesktopWindowForCurrentContent(windowHeightEncrypt)
 	case "decrypt":
 		if a.advancedLabel != nil {
 			a.advancedLabel.Show()
 		}
 		a.buildDecryptOptions()
 		// Resize window for decrypt mode (fewer options)
-		if a.Window != nil {
-			a.Window.Resize(fyne.NewSize(windowWidth, windowHeightDecrypt))
-		}
+		a.resizeDesktopWindowForCurrentContent(windowHeightDecrypt)
 	}
 
 	// IMPORTANT: Update disable state for newly created checkboxes

--- a/src/internal/ui/app.go
+++ b/src/internal/ui/app.go
@@ -41,7 +41,6 @@ import (
 
 	"fyne.io/fyne/v2"
 	fyneApp "fyne.io/fyne/v2/app"
-	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/dialog"
@@ -58,7 +57,7 @@ var appIconData []byte
 
 // UI dimensions matching original giu implementation
 const (
-	windowWidth         = 318
+	windowWidth         = 340
 	windowHeightEncrypt = 510 // Full height for encrypt mode (more options)
 	windowHeightDecrypt = 430 // Reduced height for decrypt mode (fewer options)
 	windowHeightInitial = 350 // Compact height for initial state (no advanced options)
@@ -111,7 +110,7 @@ type App struct {
 	commentsEntry     *widget.Entry
 	advancedLabel     *widget.Label
 	advancedContainer *fyne.Container
-	outputEntry       *widget.Label
+	outputEntry       interface{ SetText(string) }
 	startButton       *widget.Button
 	statusLabel       *ColoredLabel
 
@@ -284,6 +283,7 @@ func (a *App) Run(startupPaths []string) {
 		content = fynetooltip.AddWindowToolTipLayer(content, a.Window.Canvas())
 	}
 	a.Window.SetContent(content)
+	a.resizeDesktopWindowForContent(content, preferredDesktopWindowHeight(a.State.Mode))
 	a.Window.ShowAndRun()
 }
 
@@ -331,17 +331,14 @@ func (a *App) showFileDialogWithResize(d dialog.Dialog, dialogSize fyne.Size) {
 	}
 
 	// Calculate current window size to restore later
-	originalHeight := float32(windowHeightEncrypt)
-	if a.State.Mode == "decrypt" {
-		originalHeight = windowHeightDecrypt
-	}
+	originalHeight := preferredDesktopWindowHeight(a.State.Mode)
 
 	// Temporarily allow window resizing and make room for dialog
 	a.Window.SetFixedSize(false)
 	a.Window.Resize(fyne.NewSize(dialogSize.Width+50, dialogSize.Height+50))
 
 	d.SetOnClosed(func() {
-		a.Window.Resize(fyne.NewSize(windowWidth, originalHeight))
+		a.resizeDesktopWindowForCurrentContent(originalHeight)
 		a.Window.SetFixedSize(true)
 	})
 
@@ -450,6 +447,36 @@ func (a *App) buildUI() fyne.CanvasObject {
 	return padded
 }
 
+func preferredDesktopWindowHeight(mode string) float32 {
+	switch mode {
+	case "encrypt":
+		return windowHeightEncrypt
+	case "decrypt":
+		return windowHeightDecrypt
+	default:
+		return windowHeightInitial
+	}
+}
+
+func (a *App) resizeDesktopWindowForCurrentContent(preferredHeight float32) {
+	var content fyne.CanvasObject
+	if a.Window != nil {
+		content = a.Window.Content()
+	}
+	a.resizeDesktopWindowForContent(content, preferredHeight)
+}
+
+func (a *App) resizeDesktopWindowForContent(content fyne.CanvasObject, preferredHeight float32) {
+	if isMobile() || a.Window == nil {
+		return
+	}
+	size := fyne.NewSize(windowWidth, preferredHeight)
+	if content != nil {
+		size = size.Max(content.MinSize())
+	}
+	a.Window.Resize(size)
+}
+
 // buildCommentsSection creates the comments input section.
 func (a *App) buildCommentsSection() fyne.CanvasObject {
 	a.commentsLabel = widget.NewLabel(a.State.CommentsLabel)
@@ -476,20 +503,14 @@ func (a *App) buildCommentsSection() fyne.CanvasObject {
 
 // buildOutputSection creates the output file section.
 func (a *App) buildOutputSection() fyne.CanvasObject {
-	a.outputEntry = widget.NewLabel("")
-	// Truncate long filenames with ellipsis to prevent window resizing
-	a.outputEntry.Truncation = fyne.TextTruncateEllipsis
-
-	// Create a disabled entry style appearance
-	outputBg := canvas.NewRectangle(theme.Color(theme.ColorNameInputBackground))
-	outputBg.CornerRadius = theme.InputRadiusSize()
-	outputWithBg := container.NewStack(outputBg, container.NewPadded(a.outputEntry))
+	outputEntry := NewDisabledEntry()
+	a.outputEntry = outputEntry
 
 	a.changeBtn = widget.NewButton("Change", func() {
 		a.changeOutputFile()
 	})
 
-	row := container.NewBorder(nil, nil, nil, a.changeBtn, outputWithBg)
+	row := container.NewBorder(nil, nil, nil, a.changeBtn, outputEntry)
 
 	// Create bold label for better visual hierarchy
 	outputLabel := widget.NewLabel("Save output as:")

--- a/src/internal/ui/drop.go
+++ b/src/internal/ui/drop.go
@@ -232,9 +232,6 @@ func (a *App) onDrop(names []string) {
 		for _, name := range a.State.OnlyFolders {
 			if filepath.Walk(name, func(path string, info os.FileInfo, err error) error {
 				if err != nil {
-					fyne.DoAndWait(func() {
-						a.applyFolderWalkError()
-					})
 					return err
 				}
 				// If 'path' is a valid regular file, add to 'allFiles'

--- a/src/internal/ui/layout_regression_test.go
+++ b/src/internal/ui/layout_regression_test.go
@@ -1,0 +1,225 @@
+package ui
+
+import (
+	"image/color"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/theme"
+)
+
+type fixedVariantTheme struct {
+	fyne.Theme
+	variant fyne.ThemeVariant
+}
+
+func (t fixedVariantTheme) Color(name fyne.ThemeColorName, _ fyne.ThemeVariant) color.Color {
+	return t.Theme.Color(name, t.variant)
+}
+
+func TestOutputDisplayFollowsThemeChanges(t *testing.T) {
+	if raceEnabled {
+		t.Skip("Fyne v2.7.4 internal cache races under -race; covered on non-race matrices")
+	}
+
+	fyneApp := newTestFyneApp(t)
+	darkTheme := fixedVariantTheme{Theme: NewCompactTheme(), variant: theme.VariantDark}
+	lightTheme := fixedVariantTheme{Theme: NewCompactTheme(), variant: theme.VariantLight}
+	fyneApp.Settings().SetTheme(darkTheme)
+
+	a, err := NewApp("v2.test")
+	if err != nil {
+		t.Fatalf("NewApp returned error: %v", err)
+	}
+	a.fyneApp = fyneApp
+
+	var output fyne.CanvasObject
+	fyne.DoAndWait(func() {
+		output = a.buildOutputSection()
+		output.Resize(output.MinSize())
+	})
+
+	fyneApp.Settings().SetTheme(lightTheme)
+	fyne.DoAndWait(func() {
+		output.Refresh()
+	})
+
+	wantLight := lightTheme.Color(theme.ColorNameInputBackground, theme.VariantLight)
+	staleDark := darkTheme.Color(theme.ColorNameInputBackground, theme.VariantDark)
+	if !hasRectangleFill(output, wantLight) {
+		t.Fatalf("output display did not render the light input background after a theme change")
+	}
+	if hasRectangleFill(output, staleDark) {
+		t.Fatalf("output display kept a stale dark input background after a light theme change")
+	}
+}
+
+func TestDesktopUILayoutFitsWindowAfterBuild(t *testing.T) {
+	if raceEnabled {
+		t.Skip("Fyne v2.7.4 internal cache races under -race; covered on non-race matrices")
+	}
+
+	cases := []struct {
+		name      string
+		configure func(*App)
+	}{
+		{
+			name: "initial",
+		},
+		{
+			name: "encrypt",
+			configure: func(a *App) {
+				a.State.Mode = "encrypt"
+				a.State.OnlyFiles = []string{"input.txt"}
+				a.State.InputLabel = "input.txt"
+				a.State.OutputFile = "input.txt.pcv"
+			},
+		},
+		{
+			name: "decrypt",
+			configure: func(a *App) {
+				a.State.Mode = "decrypt"
+				a.State.OnlyFiles = []string{"input.txt.pcv"}
+				a.State.InputLabel = "input.txt.pcv"
+				a.State.OutputFile = "input.txt"
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fyneApp := newTestFyneApp(t)
+			fyneApp.Settings().SetTheme(fixedVariantTheme{Theme: NewCompactTheme(), variant: theme.VariantLight})
+
+			a, err := NewApp("v2.test")
+			if err != nil {
+				t.Fatalf("NewApp returned error: %v", err)
+			}
+			a.fyneApp = fyneApp
+			if tc.configure != nil {
+				tc.configure(a)
+			}
+
+			fyne.DoAndWait(func() {
+				a.Window = fyneApp.NewWindow("layout-test")
+				a.Window.SetFixedSize(true)
+				a.Window.Resize(fyne.NewSize(windowWidth, windowHeightEncrypt))
+				content := a.buildUI()
+				a.Window.SetContent(content)
+				a.resizeDesktopWindowForContent(content, preferredDesktopWindowHeight(a.State.Mode))
+			})
+
+			assertWindowFitsContent(t, a)
+		})
+	}
+}
+
+func TestDesktopUILayoutFitsWindowAfterModeChange(t *testing.T) {
+	if raceEnabled {
+		t.Skip("Fyne v2.7.4 internal cache races under -race; covered on non-race matrices")
+	}
+
+	fyneApp := newTestFyneApp(t)
+	fyneApp.Settings().SetTheme(fixedVariantTheme{Theme: NewCompactTheme(), variant: theme.VariantLight})
+
+	a, err := NewApp("v2.test")
+	if err != nil {
+		t.Fatalf("NewApp returned error: %v", err)
+	}
+	a.fyneApp = fyneApp
+
+	fyne.DoAndWait(func() {
+		a.Window = fyneApp.NewWindow("layout-test")
+		a.Window.SetFixedSize(true)
+		a.Window.Resize(fyne.NewSize(windowWidth, windowHeightEncrypt))
+		content := a.buildUI()
+		a.Window.SetContent(content)
+		a.resizeDesktopWindowForContent(content, preferredDesktopWindowHeight(a.State.Mode))
+	})
+	assertWindowFitsContent(t, a)
+
+	fyne.DoAndWait(func() {
+		a.State.Mode = "encrypt"
+		a.State.OnlyFiles = []string{"input.txt"}
+		a.State.InputLabel = "input.txt"
+		a.State.OutputFile = "input.txt.pcv"
+		a.updateAdvancedSection()
+		a.updateUIState()
+	})
+	assertWindowFitsContent(t, a)
+}
+
+func TestDesktopOutputDisplayLongNameDoesNotGrowWindow(t *testing.T) {
+	if raceEnabled {
+		t.Skip("Fyne v2.7.4 internal cache races under -race; covered on non-race matrices")
+	}
+
+	fyneApp := newTestFyneApp(t)
+	fyneApp.Settings().SetTheme(fixedVariantTheme{Theme: NewCompactTheme(), variant: theme.VariantLight})
+
+	a, err := NewApp("v2.test")
+	if err != nil {
+		t.Fatalf("NewApp returned error: %v", err)
+	}
+	a.fyneApp = fyneApp
+	a.State.Mode = "encrypt"
+	a.State.OnlyFiles = []string{"input.txt"}
+	a.State.InputLabel = "input.txt"
+	a.State.OutputFile = filepath.Join("/tmp", strings.Repeat("very-long-output-name-", 20)+".pcv")
+
+	var size fyne.Size
+	fyne.DoAndWait(func() {
+		a.Window = fyneApp.NewWindow("layout-test")
+		a.Window.SetFixedSize(true)
+		a.Window.Resize(fyne.NewSize(windowWidth, windowHeightEncrypt))
+		content := a.buildUI()
+		a.Window.SetContent(content)
+		a.resizeDesktopWindowForContent(content, preferredDesktopWindowHeight(a.State.Mode))
+		size = a.Window.Canvas().Size()
+	})
+
+	if size.Width > windowWidth {
+		t.Fatalf("long output basename grew desktop window width to %.1f; want <= %.1f", size.Width, float32(windowWidth))
+	}
+}
+
+func assertWindowFitsContent(t *testing.T, a *App) {
+	t.Helper()
+
+	var min, size fyne.Size
+	fyne.DoAndWait(func() {
+		content := a.Window.Content()
+		min = content.MinSize()
+		size = a.Window.Canvas().Size()
+	})
+
+	if size.Width < min.Width {
+		t.Fatalf("window width %.1f is smaller than content MinSize width %.1f", size.Width, min.Width)
+	}
+	if size.Height < min.Height {
+		t.Fatalf("window height %.1f is smaller than content MinSize height %.1f", size.Height, min.Height)
+	}
+}
+
+func hasRectangleFill(root fyne.CanvasObject, fill color.Color) bool {
+	for _, obj := range test.LaidOutObjects(root) {
+		rect, ok := obj.(*canvas.Rectangle)
+		if !ok {
+			continue
+		}
+		if sameColor(rect.FillColor, fill) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameColor(a, b color.Color) bool {
+	ar, ag, ab, aa := a.RGBA()
+	br, bg, bb, ba := b.RGBA()
+	return ar == br && ag == bg && ab == bb && aa == ba
+}

--- a/src/internal/ui/mobile.go
+++ b/src/internal/ui/mobile.go
@@ -599,9 +599,10 @@ func (a *App) buildMobileDecryptOptions() {
 
 // buildMobileOutputSection creates the output section for mobile
 func (a *App) buildMobileOutputSection() fyne.CanvasObject {
-	a.outputEntry = widget.NewLabel("")
+	outputEntry := widget.NewLabel("")
 	// Truncate long filenames with ellipsis to prevent excessive wrapping
-	a.outputEntry.Truncation = fyne.TextTruncateEllipsis
+	outputEntry.Truncation = fyne.TextTruncateEllipsis
+	a.outputEntry = outputEntry
 
 	a.changeBtn = widget.NewButton("Change", func() {
 		a.changeOutputFile()
@@ -609,7 +610,7 @@ func (a *App) buildMobileOutputSection() fyne.CanvasObject {
 
 	return container.NewVBox(
 		widget.NewLabel("Save output as:"),
-		a.outputEntry,
+		outputEntry,
 		a.changeBtn,
 	)
 }

--- a/src/internal/ui/widgets.go
+++ b/src/internal/ui/widgets.go
@@ -234,6 +234,7 @@ type DisabledEntry struct {
 // NewDisabledEntry creates a new disabled entry.
 func NewDisabledEntry() *DisabledEntry {
 	e := &DisabledEntry{}
+	e.Wrapping = fyne.TextWrap(fyne.TextTruncateClip)
 	e.ExtendBaseWidget(e)
 	e.Disable()
 	return e

--- a/src/internal/ui/widgets_test.go
+++ b/src/internal/ui/widgets_test.go
@@ -315,6 +315,13 @@ func TestDisabledEntry(t *testing.T) {
 		if !entry.Disabled() {
 			t.Error("Expected entry to be disabled")
 		}
+
+		// The output display uses DisabledEntry for long filenames; it must keep
+		// the same single-line clipping default as widget.NewEntry instead of
+		// relying on widget.Entry's zero-value wrapping.
+		if entry.Wrapping != fyne.TextWrap(fyne.TextTruncateClip) {
+			t.Errorf("Wrapping = %v; want TextTruncateClip", entry.Wrapping)
+		}
 	})
 
 	t.Run("SetText", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Replace the desktop output filename display with a disabled Fyne entry so it follows current theme colors instead of keeping a stale custom rectangle fill.
- Resize desktop windows against the actual content minimum size for initial/encrypt/decrypt modes, preventing clipped controls on Linux layouts.
- Keep long output paths clipped in a single-line display and add focused UI regression coverage for theme changes, desktop sizing, mode changes, and long filenames.

## Root Cause
The desktop UI used fixed window sizes that could be smaller than the Fyne content minimum size on some Linux/theme combinations. The output display also painted its own background from the theme at construction time, so theme/runtime variant changes could leave a dark field with unreadable text.

Fixes #174
Fixes #176

## Validation
- `git diff --check`
- `go vet ./internal/ui`
- `go test ./... -count=1`