### PR TITLE
Name compressed payload outputs as .zip.pcv

### DIFF
--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FormData.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/FormData.kt
@@ -158,6 +158,16 @@ data class FormData(
         get() = selectedFilename.isNotEmpty() && isPasswordValid &&
             !areKeyfilesRequiredButMissing && !isSplitVolumeChunk
 
+    fun suggestedOutputNameFor(type: OperationType): String {
+        suggestedOutputName.takeIf { it.isNotEmpty() }?.let { return it }
+        if (selectedFilename.isEmpty()) return ""
+
+        return when (type) {
+            OperationType.ENCRYPT -> encryptedOutputName(selectedFilename, compress)
+            OperationType.DECRYPT -> decryptedOutputName(selectedFilename)
+        }
+    }
+
     companion object {
         // Mirrors Go fileops.splitChunkRE: (?i)\.pcv\.[0-9]+$ matched on the base name.
         private val SPLIT_CHUNK_REGEX = Regex("""(?i)\.pcv\.[0-9]+$""")
@@ -169,5 +179,17 @@ data class FormData(
          */
         fun isSplitVolumeChunkName(filename: String): Boolean =
             SPLIT_CHUNK_REGEX.containsMatchIn(filename.substringAfterLast('/'))
+
+        private fun encryptedOutputName(filename: String, compress: Boolean): String {
+            if (filename.endsWith(".pcv")) return filename
+            return if (compress) "$filename.zip.pcv" else "$filename.pcv"
+        }
+
+        private fun decryptedOutputName(filename: String): String =
+            if (filename.endsWith(".pcv")) {
+                filename.removeSuffix(".pcv")
+            } else {
+                filename
+            }
     }
 }

--- a/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/ProgressCard.kt
+++ b/android/app/src/main/java/io/github/picocrypt_ng/picocrypt_ng/ui/components/ProgressCard.kt
@@ -241,24 +241,10 @@ fun ProgressCard(
             // Data (outputFile/formData) comes from the polled OperationState; the sealed
             // Success state only drives control flow + carries the type.
             val op = operationState
-            val outputFileName = op?.formData?.suggestedOutputName?.takeIf { it.isNotEmpty() }
-                ?: op?.formData?.selectedFilename?.let { selectedFilename ->
-                    if (ui.type == OperationType.ENCRYPT) {
-                        // For encryption: add .pcv if not present
-                        if (selectedFilename.endsWith(".pcv")) {
-                            selectedFilename
-                        } else {
-                            "$selectedFilename.pcv"
-                        }
-                    } else {
-                        // For decryption: remove .pcv if present
-                        if (selectedFilename.endsWith(".pcv")) {
-                            selectedFilename.removeSuffix(".pcv")
-                        } else {
-                            selectedFilename
-                        }
-                    }
-                } ?: op?.let { File(it.outputFile).name } // Fallback to internal storage name if formData is null
+            val outputFileName = op?.formData
+                ?.suggestedOutputNameFor(ui.type)
+                ?.takeIf { it.isNotEmpty() }
+                ?: op?.let { File(it.outputFile).name } // Fallback to internal storage name if formData is null
 
             AlertDialog(
                 modifier = modifier,

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/FormDataTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/FormDataTest.kt
@@ -317,6 +317,30 @@ class FormDataTest {
     }
 
     @Test
+    fun `compressed single-file encrypt suggests zip pcv export name`() {
+        val formData = TestDataBuilders.createEncryptFormData(
+            selectedFilename = "page.html",
+            compress = true
+        )
+
+        assertEquals("page.html.zip.pcv", formData.suggestedOutputNameFor(OperationType.ENCRYPT))
+    }
+
+    @Test
+    fun `legacy pcv decrypt keeps filename-derived export name`() {
+        val formData = TestDataBuilders.createDecryptFormData(selectedFilename = "page.html.pcv")
+
+        assertEquals("page.html", formData.suggestedOutputNameFor(OperationType.DECRYPT))
+    }
+
+    @Test
+    fun `zip pcv decrypt keeps zip export suffix without sniffing`() {
+        val formData = TestDataBuilders.createDecryptFormData(selectedFilename = "page.html.zip.pcv")
+
+        assertEquals("page.html.zip", formData.suggestedOutputNameFor(OperationType.DECRYPT))
+    }
+
+    @Test
     fun `equals and hashCode reflect selection fields`() {
         // The selection model (inputFiles/onlyFolders/onlyFiles/selectionKind/
         // suggestedOutputName) is part of FormData's identity: two forms that differ only
@@ -364,5 +388,3 @@ class FormDataTest {
         assertFalse(fd.hasSelectedInput)
     }
 }
-
-

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/testutils/TestDataBuilders.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/testutils/TestDataBuilders.kt
@@ -24,6 +24,7 @@ object TestDataBuilders {
         reedSolomon: Boolean = false,
         paranoid: Boolean = false,
         deniability: Boolean = false,
+        compress: Boolean = false,
         keyfiles: List<KeyfileInfo> = emptyList(),
         keyfileOrdered: Boolean = false
     ): FormData {
@@ -36,6 +37,7 @@ object TestDataBuilders {
             reedSolomon = reedSolomon,
             paranoid = paranoid,
             deniability = deniability,
+            compress = compress,
             keyfileFilenames = keyfiles,
             keyfileOrdered = keyfileOrdered,
             decryptionInfo = null
@@ -174,5 +176,4 @@ object TestDataBuilders {
         password.fill('\u0000')
     }
 }
-
 

--- a/src/internal/cli/cli_test.go
+++ b/src/internal/cli/cli_test.go
@@ -836,10 +836,10 @@ func TestDefaultEncryptOutput(t *testing.T) {
 		pattern := "/tmp/*.txt"
 		allFiles := []string{"/tmp/a.txt", "/tmp/b.txt"}
 
-		got := defaultEncryptOutput(pattern, allFiles, false)
-		if got != "encrypted.pcv" {
-			t.Fatalf("defaultEncryptOutput(%q, %q, false) = %q, want %q",
-				pattern, allFiles, got, "encrypted.pcv")
+		got := defaultEncryptOutput(pattern, allFiles, nil, false, true)
+		if got != "encrypted.zip.pcv" {
+			t.Fatalf("defaultEncryptOutput(%q, %q, nil, false, true) = %q, want %q",
+				pattern, allFiles, got, "encrypted.zip.pcv")
 		}
 	})
 
@@ -847,12 +847,105 @@ func TestDefaultEncryptOutput(t *testing.T) {
 		pattern := "/tmp/*.txt"
 		allFiles := []string{"/tmp/a.txt"}
 
-		got := defaultEncryptOutput(pattern, allFiles, false)
+		got := defaultEncryptOutput(pattern, allFiles, nil, false, false)
 		if got != "/tmp/a.txt.pcv" {
-			t.Fatalf("defaultEncryptOutput(%q, %q, false) = %q, want %q",
+			t.Fatalf("defaultEncryptOutput(%q, %q, nil, false, false) = %q, want %q",
 				pattern, allFiles, got, "/tmp/a.txt.pcv")
 		}
 	})
+
+	t.Run("compressed stdin", func(t *testing.T) {
+		got := defaultEncryptOutput("", []string{"stdin-temp"}, nil, true, true)
+		if got != "encrypted.zip.pcv" {
+			t.Fatalf("defaultEncryptOutput(%q, %q, nil, true, true) = %q, want %q",
+				"", []string{"stdin-temp"}, got, "encrypted.zip.pcv")
+		}
+	})
+}
+
+func TestDefaultCompressOutputNameUsesZipSuffix(t *testing.T) {
+	resetEncryptFlagsForDirTest()
+	resetDecryptFlagsForDirTest()
+	t.Cleanup(resetEncryptFlagsForDirTest)
+	t.Cleanup(resetDecryptFlagsForDirTest)
+
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "page.html")
+	plaintext := []byte("<!doctype html><h1>compressed</h1>\n")
+	if err := os.WriteFile(inputFile, plaintext, 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	encInput = []string{inputFile}
+	encPassword = "pw"
+	encCompress = true
+	encQuiet = true
+	encYes = true
+
+	if err := encryptCmd.RunE(encryptCmd, []string{}); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	want := inputFile + ".zip.pcv"
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("compressed default output %q missing: %v", want, err)
+	}
+	if _, err := os.Stat(inputFile + ".pcv"); !os.IsNotExist(err) {
+		t.Fatalf("compressed default output should not hide zip payload as %q", inputFile+".pcv")
+	}
+
+	resetDecryptFlagsForDirTest()
+	decInput = want
+	decPassword = "pw"
+	decQuiet = true
+	decYes = true
+
+	if err := decryptCmd.RunE(decryptCmd, []string{}); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	assertZipContainsPlaintext(t, inputFile+".zip", plaintext)
+}
+
+func TestDefaultCompressStdinOutputNameUsesZipSuffix(t *testing.T) {
+	resetEncryptFlagsForDirTest()
+	t.Cleanup(resetEncryptFlagsForDirTest)
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		_ = r.Close()
+	})
+	if _, err := w.Write([]byte("<!doctype html><h1>compressed stdin</h1>\n")); err != nil {
+		t.Fatalf("write stdin pipe: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdin pipe: %v", err)
+	}
+
+	encInput = []string{"-"}
+	encPassword = "pw"
+	encCompress = true
+	encQuiet = true
+	encYes = true
+
+	if err := encryptCmd.RunE(encryptCmd, []string{}); err != nil {
+		t.Fatalf("encrypt stdin: %v", err)
+	}
+
+	if _, err := os.Stat("encrypted.zip.pcv"); err != nil {
+		t.Fatalf("compressed stdin default output missing: %v", err)
+	}
+	if _, err := os.Stat("encrypted.pcv"); !os.IsNotExist(err) {
+		t.Fatal("compressed stdin default output should use encrypted.zip.pcv, not encrypted.pcv")
+	}
 }
 
 func TestEncryptStdinValidation(t *testing.T) {

--- a/src/internal/cli/encrypt.go
+++ b/src/internal/cli/encrypt.go
@@ -117,17 +117,26 @@ func init() {
 	_ = encryptCmd.MarkFlagRequired("input")
 }
 
-func defaultEncryptOutput(rawInput string, allFiles []string, useStdin bool) string {
-	if useStdin {
-		return "encrypted.pcv"
+func defaultEncryptOutput(rawInput string, allFiles []string, onlyFolders []string, useStdin, payloadZip bool) string {
+	extension := ".pcv"
+	if payloadZip {
+		extension = ".zip.pcv"
 	}
-	if len(allFiles) == 1 {
-		return allFiles[0] + ".pcv"
+
+	if useStdin {
+		return "encrypted" + extension
+	}
+
+	if payloadZip && len(onlyFolders) == 1 && len(allFiles) <= 1 && rawInput != "" {
+		return rawInput + extension
+	}
+	if len(allFiles) == 1 && len(onlyFolders) == 0 {
+		return allFiles[0] + extension
 	}
 	if len(allFiles) == 0 && rawInput != "" {
-		return rawInput + ".pcv"
+		return rawInput + extension
 	}
-	return "encrypted.pcv"
+	return "encrypted" + extension
 }
 
 func runEncrypt(cmd *cobra.Command, args []string) error {
@@ -171,6 +180,9 @@ func runEncrypt(cmd *cobra.Command, args []string) error {
 	outputFile := encOutput
 	if outputFile == "" && useStdin {
 		outputFile = "encrypted.pcv"
+		if encCompress {
+			outputFile = "encrypted.zip.pcv"
+		}
 	}
 	if outputFile != "" && !useStdout && !strings.HasSuffix(outputFile, ".pcv") {
 		outputFile += ".pcv"
@@ -270,7 +282,8 @@ func runEncrypt(cmd *cobra.Command, args []string) error {
 		if len(encInput) > 0 {
 			rawInput = encInput[0]
 		}
-		outputFile = defaultEncryptOutput(rawInput, allFiles, useStdin)
+		payloadZip := len(allFiles) > 1 || len(onlyFolders) > 0 || encCompress
+		outputFile = defaultEncryptOutput(rawInput, allFiles, onlyFolders, useStdin, payloadZip)
 	}
 
 	// Add .pcv extension if missing (not for stdout temp)


### PR DESCRIPTION
## Summary
- Name auto-generated compressed CLI outputs as `.zip.pcv` so decrypted ZIP payloads keep a truthful `.zip` suffix.
- Use the same Android export-name logic for compressed single-file encryption and `.zip.pcv` decryption.
- Add CLI and Android regression tests for the compressed single-file/stdin naming paths.

## Root Cause
With compression enabled, Picocrypt-NG wraps even a single input file in ZIP before encryption. Some default naming paths could hide that ZIP payload behind the original-looking extension, so a successful decrypt could produce ZIP bytes named like `page.html`.

## Notes
- This changes default naming/export suggestions only. It does not change the encrypted volume format or crypto processing.
- Explicit CLI `-o` paths remain under user control.
- No ZIP-signature sniffing was added on Android, to avoid mislabeling legitimate ZIP-container formats such as `.docx`, `.xlsx`, `.apk`, or `.jar`.

Fixes #181

## Validation
- `go test -count=1 ./...`
- `go test -count=1 ./internal/cli -run 'TestDefaultCompressOutputNameUsesZipSuffix|TestDefaultCompressStdinOutputNameUsesZipSuffix|TestDefaultEncryptOutput|TestEncryptDirectoryProducesZip'`\n- `./gradlew testDebugUnitTest --rerun-tasks`\n- `./gradlew testDebugUnitTest --tests 'io.github.picocrypt_ng.picocrypt_ng.FormDataTest' --rerun-tasks`\n- `mise run fmt`\n- `mise run vet`\n- `mise run lint`\n- `./gradlew lintDebug`\n- `mise run vuln`\n- `git diff --check`