### PR TITLE
ci(release): prevent release asset overwrites

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -10,6 +10,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      publish_release:
+        description: "Publish artifacts to the GitHub release. Existing assets are never overwritten."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -97,7 +103,7 @@ jobs:
 
   release:
     needs: build
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release) }}
     runs-on: ubuntu-24.04
     environment: release
     permissions:
@@ -211,3 +217,4 @@ jobs:
           out/*.sigstore.json
         tag_name: ${{ env.VERSION }}
         make_latest: true
+        overwrite_files: false

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -10,6 +10,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      publish_release:
+        description: "Publish artifacts to the GitHub release. Existing assets are never overwritten."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -166,7 +172,7 @@ jobs:
 
   release:
     needs: build
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release) }}
     runs-on: ubuntu-24.04
     environment: release
     permissions:
@@ -215,3 +221,4 @@ jobs:
           artifacts/${{ env.APPIMAGE_NAME }}.sigstore.json
           artifacts/${{ env.APPIMAGE_NAME }}.zsync.sigstore.json
         tag_name: ${{ env.VERSION }}
+        overwrite_files: false

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -10,6 +10,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      publish_release:
+        description: "Publish artifacts to the GitHub release. Existing assets are never overwritten."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -234,7 +240,7 @@ jobs:
 
   release:
     needs: build
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release) }}
     runs-on: ubuntu-24.04
     environment: release
     permissions:
@@ -283,3 +289,4 @@ jobs:
           artifacts/build-linux-arm64/*.sigstore.json
         tag_name: ${{ env.VERSION }}
         make_latest: true
+        overwrite_files: false

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -7,11 +7,15 @@ on:
   push:
     paths:
       - "VERSION"
-      - ".github/workflows/build-macos.yml"
-      - ".github/scripts/assert-macos-minos.sh"
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      publish_release:
+        description: "Publish artifacts to the GitHub release. Existing assets are never overwritten."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -126,7 +130,7 @@ jobs:
 
   release:
     needs: build
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release) }}
     runs-on: ubuntu-24.04
     environment: release
     permissions:
@@ -175,3 +179,4 @@ jobs:
           artifacts/build-macos/*.sigstore.json
         tag_name: ${{ env.VERSION }}
         make_latest: true
+        overwrite_files: false

--- a/.github/workflows/build-snapcraft.yml
+++ b/.github/workflows/build-snapcraft.yml
@@ -10,6 +10,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      publish_release:
+        description: "Publish artifacts to the GitHub release. Existing assets are never overwritten."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -69,7 +75,7 @@ jobs:
 
   release:
     needs: build-snapcraft
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release) }}
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -110,3 +116,4 @@ jobs:
           out/*.sigstore.json
         tag_name: ${{ env.VERSION }}
         make_latest: true
+        overwrite_files: false

--- a/.github/workflows/build-windows-legacy.yml
+++ b/.github/workflows/build-windows-legacy.yml
@@ -10,6 +10,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      publish_release:
+        description: "Publish artifacts to the GitHub release. Existing assets are never overwritten."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -100,7 +106,7 @@ jobs:
 
   release:
     needs: build
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release) }}
     runs-on: windows-2022
     environment: release
     permissions:
@@ -142,3 +148,4 @@ jobs:
           artifacts/build-windows-legacy/*.sigstore.json
         tag_name: ${{ env.VERSION }}
         make_latest: true
+        overwrite_files: false

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -10,6 +10,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      publish_release:
+        description: "Publish artifacts to the GitHub release. Existing assets are never overwritten."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -174,7 +180,7 @@ jobs:
 
   release:
     needs: build
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release) }}
     runs-on: windows-2025
     environment: release
     permissions:
@@ -220,3 +226,4 @@ jobs:
           artifacts/build-windows/*.sigstore.json
         tag_name: ${{ env.VERSION }}
         make_latest: true
+        overwrite_files: false

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -40,26 +40,25 @@ func TestStaticChecksWorkflowEnforcesFormatVetLintAndVuln(t *testing.T) {
 }
 
 func TestReleaseActionsPinnedToFullSHA(t *testing.T) {
-	testCases := []struct {
-		name string
-		path string
-		job  string
-	}{
-		{name: "build-android", path: ".github/workflows/build-android.yml", job: "release"},
-		{name: "build-linux", path: ".github/workflows/build-linux.yml", job: "release"},
-		{name: "build-macos", path: ".github/workflows/build-macos.yml", job: "release"},
-		{name: "build-windows", path: ".github/workflows/build-windows.yml", job: "release"},
-		{name: "build-windows-legacy", path: ".github/workflows/build-windows-legacy.yml", job: "release"},
-		{name: "build-snapcraft", path: ".github/workflows/build-snapcraft.yml", job: "release"},
-		{name: "build-appimage", path: ".github/workflows/build-appimage.yml", job: "release"},
-	}
-
-	for _, tc := range testCases {
+	for _, tc := range releaseWorkflowCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			workflow := mustReadWorkflowDoc(t, tc.path)
 			releaseJob := mustJob(t, workflow, tc.job)
 			releaseStep := mustHaveStepUsingPrefix(t, releaseJob, "softprops/action-gh-release@")
 			mustMatch(t, releaseStep.Uses, `softprops/action-gh-release@[0-9a-f]{40}`)
+		})
+	}
+}
+
+func TestReleaseUploadsNeverOverwriteExistingAssets(t *testing.T) {
+	for _, tc := range releaseWorkflowCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			workflow := mustReadWorkflowDoc(t, tc.path)
+			releaseJob := mustJob(t, workflow, tc.job)
+			releaseStep := mustHaveStepUsingPrefix(t, releaseJob, "softprops/action-gh-release@")
+			if got := releaseStep.With["overwrite_files"]; got != false && got != "false" {
+				t.Fatalf("release overwrite_files = %#v, want false to preserve published binaries", got)
+			}
 		})
 	}
 }
@@ -99,7 +98,46 @@ func TestExternalGitHubActionsPinnedToFullSHAWithVersionComment(t *testing.T) {
 }
 
 func TestReleaseJobsRequireMainBranchAndReleaseEnvironment(t *testing.T) {
-	testCases := []struct {
+	const releaseGuard = "${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release) }}"
+
+	for _, tc := range releaseWorkflowCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			workflow := mustReadWorkflowDoc(t, tc.path)
+			releaseJob := mustJob(t, workflow, tc.job)
+			if releaseJob.If != releaseGuard {
+				t.Fatalf("release job if = %q, want guarded push or explicit manual release", releaseJob.If)
+			}
+			if got := releaseEnvironmentName(releaseJob.Environment); got != "release" {
+				t.Fatalf("release job environment = %#v, want release", releaseJob.Environment)
+			}
+
+			content := mustReadWorkflow(t, tc.path)
+			mustContain(t, content, "publish_release:")
+			mustContain(t, content, "Existing assets are never overwritten.")
+		})
+	}
+}
+
+func TestMacOSReleaseWorkflowOnlyAutoRunsOnVersionChanges(t *testing.T) {
+	content := mustReadWorkflow(t, ".github/workflows/build-macos.yml")
+
+	mustContainInOrder(t, content,
+		"on:",
+		"push:",
+		"paths:",
+		"- \"VERSION\"",
+		"branches:",
+	)
+	mustNotContain(t, content, "- \".github/workflows/build-macos.yml\"")
+	mustNotContain(t, content, "- \".github/scripts/assert-macos-minos.sh\"")
+}
+
+func releaseWorkflowCases() []struct {
+	name string
+	path string
+	job  string
+} {
+	return []struct {
 		name string
 		path string
 		job  string
@@ -111,19 +149,6 @@ func TestReleaseJobsRequireMainBranchAndReleaseEnvironment(t *testing.T) {
 		{name: "build-snapcraft", path: ".github/workflows/build-snapcraft.yml", job: "release"},
 		{name: "build-windows", path: ".github/workflows/build-windows.yml", job: "release"},
 		{name: "build-windows-legacy", path: ".github/workflows/build-windows-legacy.yml", job: "release"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			workflow := mustReadWorkflowDoc(t, tc.path)
-			releaseJob := mustJob(t, workflow, tc.job)
-			if releaseJob.If != "${{ github.ref == 'refs/heads/main' }}" {
-				t.Fatalf("release job if = %q, want main branch guard", releaseJob.If)
-			}
-			if got := releaseEnvironmentName(releaseJob.Environment); got != "release" {
-				t.Fatalf("release job environment = %#v, want release", releaseJob.Environment)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop the macOS release workflow from auto-running when only the workflow or macOS min-version assertion script changes
- require manual workflow_dispatch release publishing to opt in with `publish_release`
- set `overwrite_files: false` on every `softprops/action-gh-release` release uploader and enforce it in workflow policy tests

## Why
The existing `2.18` release had macOS assets updated on 2026-07-07 by a `build-macos` push run from `794e92d`, even though `VERSION` was still `2.18`. `softprops/action-gh-release` defaults to overwriting assets with matching names, so a workflow-only dependency bump could replace published binaries.