### PR TITLE
fix: make verification wait for real results

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -79,12 +79,10 @@ jobs:
       run: |
         cd src
         if [ "${{ matrix.arch }}" = "amd64" ]; then
-          # Race detection on the unit tests only. The CLI integration tests spawn the
-          # real CLI binary (a separate, non-race build, so -race adds no coverage there)
-          # and each spawn runs the production 1 GiB Argon2id KDF; running them under -race
-          # with package parallelism exhausts the runner (SIGTERM/exit 143 + orphaned
-          # picocrypt-test child). Run them separately without -race, like the arm64 job.
-          CGO_ENABLED=1 go test -v -race -timeout 15m ./...
+          # Under -race, concurrent Argon2 volume and Fyne package tests exceed the
+          # runner's RAM, so cap package binaries at two. CLI integration spawns a
+          # separate non-race product binary, so run it separately without -race.
+          CGO_ENABLED=1 go test -v -race -p 2 -timeout 15m ./...
           PICOCRYPT_RUN_CLI_INTEGRATION=1 CGO_ENABLED=1 go test -v -timeout 15m ./internal/cli/...
         else
           PICOCRYPT_RUN_CLI_INTEGRATION=1 CGO_ENABLED=1 go test -v -timeout 15m ./...

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -76,18 +76,56 @@ jobs:
           throw "Checksum mismatch for reshacker_setup.zip: expected $expectedHash, got $actualHash"
         }
         Expand-Archive -DestinationPath reshacker_setup reshacker_setup.zip
-        reshacker_setup/reshacker_setup.exe /SILENT
-        Start-Sleep -Seconds 60
-        Invoke-Expression "& `"$Env:P`" -open src/1.exe -save src/2.exe -action addoverwrite -res images/key.ico -mask `"ICONGROUP,MAINICON,`""
-        Start-Sleep -Seconds 30
-        Invoke-Expression "& `"$Env:P`" -open src/2.exe -save src/3.exe -action addoverwrite -res images/key.ico -mask `"ICONGROUP,A,`""
-        Start-Sleep -Seconds 30
-        Invoke-Expression "& `"$Env:P`" -open src/3.exe -save src/4.exe -action addoverwrite -res dist/windows/manifest.xml -mask `"MANIFEST,1,`""
-        Start-Sleep -Seconds 30
-        Invoke-Expression "& `"$Env:P`" -open dist/windows/versioninfo.rc -save resources.res -action compile"
-        Start-Sleep -Seconds 30
-        Invoke-Expression "& `"$Env:P`" -open src/4.exe -save src/5.exe -action addoverwrite -res resources.res"
-        Start-Sleep -Seconds 30
+        $installer = Start-Process `
+          -FilePath "reshacker_setup/reshacker_setup.exe" `
+          -ArgumentList "/SILENT" `
+          -Wait -PassThru
+        if ($installer.ExitCode -ne 0) {
+          throw "Resource Hacker installer failed with exit code $($installer.ExitCode)"
+        }
+        if (-not (Test-Path -LiteralPath $env:P -PathType Leaf)) {
+          throw "Resource Hacker executable was not installed at $env:P"
+        }
+
+        function Invoke-ResourceHacker {
+          param(
+            [Parameter(Mandatory)][string[]]$Arguments,
+            [Parameter(Mandatory)][string]$ExpectedOutput
+          )
+
+          $process = Start-Process `
+            -FilePath $env:P `
+            -ArgumentList ($Arguments + @("-log", "CONSOLE")) `
+            -Wait -PassThru -NoNewWindow
+          if ($process.ExitCode -ne 0) {
+            throw "Resource Hacker failed with exit code $($process.ExitCode): $($Arguments -join ' ')"
+          }
+
+          $output = Get-Item -LiteralPath $ExpectedOutput -ErrorAction Stop
+          if ($output.Length -eq 0) {
+            throw "Resource Hacker produced an empty output: $ExpectedOutput"
+          }
+        }
+
+        Invoke-ResourceHacker `
+          -Arguments @("-open", "src/1.exe", "-save", "src/2.exe", "-action", "addoverwrite", "-res", "images/key.ico", "-mask", "ICONGROUP,MAINICON,") `
+          -ExpectedOutput "src/2.exe"
+
+        Invoke-ResourceHacker `
+          -Arguments @("-open", "src/2.exe", "-save", "src/3.exe", "-action", "addoverwrite", "-res", "images/key.ico", "-mask", "ICONGROUP,A,") `
+          -ExpectedOutput "src/3.exe"
+
+        Invoke-ResourceHacker `
+          -Arguments @("-open", "src/3.exe", "-save", "src/4.exe", "-action", "addoverwrite", "-res", "dist/windows/manifest.xml", "-mask", "MANIFEST,1,") `
+          -ExpectedOutput "src/4.exe"
+
+        Invoke-ResourceHacker `
+          -Arguments @("-open", "dist/windows/versioninfo.rc", "-save", "resources.res", "-action", "compile") `
+          -ExpectedOutput "resources.res"
+
+        Invoke-ResourceHacker `
+          -Arguments @("-open", "src/4.exe", "-save", "src/5.exe", "-action", "addoverwrite", "-res", "resources.res") `
+          -ExpectedOutput "src/5.exe"
       env:
         P: "C:\\Program Files (x86)\\Resource Hacker\\ResourceHacker.exe"
 

--- a/.github/workflows/pr-test-build-linux.yml
+++ b/.github/workflows/pr-test-build-linux.yml
@@ -71,12 +71,11 @@ jobs:
       run: |
         cd src
         if [ "${{ matrix.arch }}" = "amd64" ]; then
-          # -p 2 caps how many package test binaries run concurrently. Under -race
-          # (heavy memory instrumentation) the Argon2-memory-hard volume tests plus
-          # the Fyne ui tests otherwise peak past the runner's RAM, so the job is
-          # killed mid-run (SIGTERM, exit 143). Bounding concurrency holds peak
-          # memory under the ceiling; 15m is ample for the serialized run.
-          PICOCRYPT_RUN_CLI_INTEGRATION=1 CGO_ENABLED=1 go test -v -race -p 2 -timeout 15m ./...
+          # Under -race, concurrent Argon2 volume and Fyne package tests exceed the
+          # runner's RAM, so cap package binaries at two. CLI integration spawns a
+          # separate non-race product binary, so run it separately without -race.
+          CGO_ENABLED=1 go test -v -race -p 2 -timeout 15m ./...
+          PICOCRYPT_RUN_CLI_INTEGRATION=1 CGO_ENABLED=1 go test -v -timeout 15m ./internal/cli/...
         else
           PICOCRYPT_RUN_CLI_INTEGRATION=1 CGO_ENABLED=1 go test -v -timeout 15m ./...
         fi

--- a/.github/workflows/pr-test-build-windows.yml
+++ b/.github/workflows/pr-test-build-windows.yml
@@ -65,18 +65,56 @@ jobs:
           throw "Checksum mismatch for reshacker_setup.zip: expected $expectedHash, got $actualHash"
         }
         Expand-Archive -DestinationPath reshacker_setup reshacker_setup.zip
-        reshacker_setup/reshacker_setup.exe /SILENT
-        Start-Sleep -Seconds 60
-        Invoke-Expression "& `"$Env:P`" -open src/1.exe -save src/2.exe -action addoverwrite -res images/key.ico -mask `"ICONGROUP,MAINICON,`""
-        Start-Sleep -Seconds 30
-        Invoke-Expression "& `"$Env:P`" -open src/2.exe -save src/3.exe -action addoverwrite -res images/key.ico -mask `"ICONGROUP,A,`""
-        Start-Sleep -Seconds 30
-        Invoke-Expression "& `"$Env:P`" -open src/3.exe -save src/4.exe -action addoverwrite -res dist/windows/manifest.xml -mask `"MANIFEST,1,`""
-        Start-Sleep -Seconds 30
-        Invoke-Expression "& `"$Env:P`" -open dist/windows/versioninfo.rc -save resources.res -action compile"
-        Start-Sleep -Seconds 30
-        Invoke-Expression "& `"$Env:P`" -open src/4.exe -save src/5.exe -action addoverwrite -res resources.res"
-        Start-Sleep -Seconds 30
+        $installer = Start-Process `
+          -FilePath "reshacker_setup/reshacker_setup.exe" `
+          -ArgumentList "/SILENT" `
+          -Wait -PassThru
+        if ($installer.ExitCode -ne 0) {
+          throw "Resource Hacker installer failed with exit code $($installer.ExitCode)"
+        }
+        if (-not (Test-Path -LiteralPath $env:P -PathType Leaf)) {
+          throw "Resource Hacker executable was not installed at $env:P"
+        }
+
+        function Invoke-ResourceHacker {
+          param(
+            [Parameter(Mandatory)][string[]]$Arguments,
+            [Parameter(Mandatory)][string]$ExpectedOutput
+          )
+
+          $process = Start-Process `
+            -FilePath $env:P `
+            -ArgumentList ($Arguments + @("-log", "CONSOLE")) `
+            -Wait -PassThru -NoNewWindow
+          if ($process.ExitCode -ne 0) {
+            throw "Resource Hacker failed with exit code $($process.ExitCode): $($Arguments -join ' ')"
+          }
+
+          $output = Get-Item -LiteralPath $ExpectedOutput -ErrorAction Stop
+          if ($output.Length -eq 0) {
+            throw "Resource Hacker produced an empty output: $ExpectedOutput"
+          }
+        }
+
+        Invoke-ResourceHacker `
+          -Arguments @("-open", "src/1.exe", "-save", "src/2.exe", "-action", "addoverwrite", "-res", "images/key.ico", "-mask", "ICONGROUP,MAINICON,") `
+          -ExpectedOutput "src/2.exe"
+
+        Invoke-ResourceHacker `
+          -Arguments @("-open", "src/2.exe", "-save", "src/3.exe", "-action", "addoverwrite", "-res", "images/key.ico", "-mask", "ICONGROUP,A,") `
+          -ExpectedOutput "src/3.exe"
+
+        Invoke-ResourceHacker `
+          -Arguments @("-open", "src/3.exe", "-save", "src/4.exe", "-action", "addoverwrite", "-res", "dist/windows/manifest.xml", "-mask", "MANIFEST,1,") `
+          -ExpectedOutput "src/4.exe"
+
+        Invoke-ResourceHacker `
+          -Arguments @("-open", "dist/windows/versioninfo.rc", "-save", "resources.res", "-action", "compile") `
+          -ExpectedOutput "resources.res"
+
+        Invoke-ResourceHacker `
+          -Arguments @("-open", "src/4.exe", "-save", "src/5.exe", "-action", "addoverwrite", "-res", "resources.res") `
+          -ExpectedOutput "src/5.exe"
       env:
         P: "C:\\Program Files (x86)\\Resource Hacker\\ResourceHacker.exe"
 

--- a/src/internal/ui/drop.go
+++ b/src/internal/ui/drop.go
@@ -153,10 +153,10 @@ func (a *App) applyStartupPaths(paths []string) {
 }
 
 func (a *App) applyFolderWalkError() {
-	a.State.SetScanning(false)
 	a.resetUI()
 	a.State.SetStatusMessage(app.StatusDropFailedWalk, util.RED, app.StatusArgs{})
 	a.refreshUI()
+	a.State.SetScanning(false)
 }
 
 func (a *App) appendScannedFiles(files []scannedFile) {

--- a/src/internal/ui/drop_test.go
+++ b/src/internal/ui/drop_test.go
@@ -584,10 +584,13 @@ func TestFolderWalkErrorClearsScanningState(t *testing.T) {
 	})
 
 	waitForDropProcessing(t, a)
-	fyne.DoAndWait(func() {})
 
 	if a.State.IsScanning() {
 		t.Fatal("Scanning should be false after folder walk error")
+	}
+	wantStatus := tr("drop.failed_walk", "Failed to walk through dropped items")
+	if got := statusLabelText(t, a); got != wantStatus {
+		t.Fatalf("status = %q; want %q after folder walk completes", got, wantStatus)
 	}
 }
 

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -322,6 +322,70 @@ func TestLinuxPRAggregateGateIgnoresCancelledDuplicate(t *testing.T) {
 	)
 }
 
+func TestLinuxWorkflowsBoundRaceParallelismAndSeparateCLIIntegration(t *testing.T) {
+	for _, path := range []string{
+		".github/workflows/build-linux.yml",
+		".github/workflows/pr-test-build-linux.yml",
+	} {
+		t.Run(path, func(t *testing.T) {
+			workflow := mustReadWorkflowDoc(t, path)
+			testStep := mustStepNamed(t, mustJob(t, workflow, "build"), "Run tests")
+
+			mustContainInOrder(t, testStep.Run,
+				"CGO_ENABLED=1 go test -v -race -p 2 -timeout 15m ./...",
+				"PICOCRYPT_RUN_CLI_INTEGRATION=1 CGO_ENABLED=1 go test -v -timeout 15m ./internal/cli/...",
+			)
+			if got := strings.Count(testStep.Run, "go test -v -race"); got != 1 {
+				t.Fatalf("Linux Run tests race command count = %d, want exactly 1", got)
+			}
+			mustNotContain(t, testStep.Run, "PICOCRYPT_RUN_CLI_INTEGRATION=1 CGO_ENABLED=1 go test -v -race")
+		})
+	}
+}
+
+func TestWindowsResourceEditingWaitsAndFailsLoud(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		job  string
+	}{
+		{path: ".github/workflows/build-windows.yml", job: "build"},
+		{path: ".github/workflows/pr-test-build-windows.yml", job: "pr-test-build-windows"},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			workflow := mustReadWorkflowDoc(t, tc.path)
+			resourceStep := mustStepNamed(t, mustJob(t, workflow, tc.job), "Add icon, manifest, and version info")
+
+			mustNotContain(t, resourceStep.Run, "Start-Sleep")
+			mustNotContain(t, resourceStep.Run, "Invoke-Expression")
+			if got := strings.Count(resourceStep.Run, "Start-Process"); got != 2 {
+				t.Fatalf("Resource Hacker step Start-Process count = %d, want installer and CLI invocations", got)
+			}
+			mustContainInOrder(t, resourceStep.Run,
+				"$installer = Start-Process",
+				`-FilePath "reshacker_setup/reshacker_setup.exe"`,
+				`-ArgumentList "/SILENT"`,
+				"-Wait -PassThru",
+				"if ($installer.ExitCode -ne 0)",
+				"function Invoke-ResourceHacker",
+				"$process = Start-Process",
+				"-FilePath $env:P",
+				`-ArgumentList ($Arguments + @("-log", "CONSOLE"))`,
+				"-Wait -PassThru",
+				"if ($process.ExitCode -ne 0)",
+				"Get-Item -LiteralPath $ExpectedOutput -ErrorAction Stop",
+				"if ($output.Length -eq 0)",
+			)
+			mustContainInOrder(t, resourceStep.Run,
+				`-ExpectedOutput "src/2.exe"`,
+				`-ExpectedOutput "src/3.exe"`,
+				`-ExpectedOutput "src/4.exe"`,
+				`-ExpectedOutput "resources.res"`,
+				`-ExpectedOutput "src/5.exe"`,
+			)
+		})
+	}
+}
+
 func TestLinuxDebPackagingDoesNotUseExternalScaffold(t *testing.T) {
 	for _, path := range []string{
 		".github/workflows/build-linux.yml",


### PR DESCRIPTION
## What changed

- makes folder-scan completion mean that the final Fyne status refresh has actually finished
- separates Linux race detection from the opt-in subprocess CLI integration suite
- replaces 210 seconds of fixed Resource Hacker sleeps with process, exit-code, and output checks

## Why

Linux CI caught an unfinished folder-scan goroutine updating Fyne while the next test was building a new UI. The affected keyfile test was only the victim: `Scanning` became false before the previous callback finished. The Windows Resource Hacker step also spent 210 of its 212 seconds sleeping instead of checking results.

The CLI integration suite builds and runs a separate non-race binary. Running it inside the parent `go test -race` command adds load without instrumenting that product subprocess, so the PR workflow now uses the already-proven release-workflow split.

## Test intent

- the existing folder-walk regression now asserts the final rendered failure status, not merely an early internal flag
- workflow-policy tests bind exact named steps to the race/integration commands and to fail-loud Resource Hacker outputs
- no tests are skipped, weakened, or added only to search for unrelated tokens

## Verification

- RED then GREEN: `go test -race -run '^(TestFolderWalkErrorClearsScanningState|TestKeyfileDropHandling)$' -count=20 ./internal/ui`
- `go test -race -count=10 ./internal/ui`
- workflow-policy tests, including observed RED-to-GREEN failures for all changed workflow contracts
- `actionlint`
- native Linux and Windows PR jobs required before merge