### PR TITLE
deps(go): update goldmark to 1.8.4

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c // indirect
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
-	github.com/yuin/goldmark v1.8.2 // indirect
+	github.com/yuin/goldmark v1.8.4 // indirect
 	golang.org/x/image v0.44.0 // indirect
 	golang.org/x/mobile v0.0.0-20260709172247-6129f5bee9d5 // indirect
 	golang.org/x/mod v0.38.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -85,8 +85,8 @@ github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef h1:Ch6Q+AZUxDBCVqd
 github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef/go.mod h1:nXTWP6+gD5+LUJ8krVhhoeHjvHTutPxMYl5SvkcnJNE=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
-github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark v1.8.4 h1:oat/nd3U6NeQqFEL3xpEJq7d7c86NI+DbSNGAs4xnjA=
+github.com/yuin/goldmark v1.8.4/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=


### PR DESCRIPTION
## Summary

- update the Fyne desktop dependency graph from `github.com/yuin/goldmark` v1.8.2 to v1.8.4
- take the upstream hardening that rejects SVG `data:image` URLs, plus the fenced-code parsing fixes
- keep Fyne at v2.7.4; the separate Fyne 2.8 adaptation is intentionally out of scope

## Compatibility and scope

- changes only `src/go.mod` and `src/go.sum`
- keeps Picocrypt NG and volume metadata at 2.18/v2.18; no release is created
- does not touch crypto, header, keyfile, volume, Android, Windows 7 legacy, packaging, workflows, or application source
- adds no dependency-string or source-spelling tests

## Verification

- confirmed production path: `internal/ui -> fyne/widget -> goldmark`
- resolved versions: Goldmark v1.8.4 and Fyne v2.7.4
- `go mod tidy -diff` and `go mod verify`
- Fyne UI package tests and real desktop GUI build
- full Go suite with opt-in CLI integration
- `govulncheck`: 0 affected and 0 imported-package vulnerabilities
- independent task and whole-branch reviews: no Critical, Important, or Minor findings

The existing module-only `GO-2026-5932` notice concerns unimported `x/crypto/openpgp`, has no fixed version, and is not reachable from Picocrypt NG.