### PR TITLE
chore(packaging): refresh verified toolchain pins

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -56,7 +56,7 @@ jobs:
         # linuxdeploy/appimagetool "continuous" builds; if upstream republishes them this
         # check fails and the pin must be refreshed -- intentional, not silent drift.
         wget -O linuxdeploy https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-        echo "514d4ffe2a2f757369b41863a4f63fbbb222c429652803ebc081cb16ba21ac25  linuxdeploy" | sha256sum --check --strict --status
+        echo "e87ee0815d109282fdda73e34c2361d64d02b0ffaea3674b18f1fd1f6a687dcf  linuxdeploy" | sha256sum --check --strict --status
         wget -O appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
         echo "a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0  appimagetool" | sha256sum --check --strict --status
         chmod +x linuxdeploy appimagetool

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -29,16 +29,16 @@ jobs:
         include:
           - arch: amd64
             runner: ubuntu-24.04
-            upx_pkg: upx-5.1.0-amd64_linux
-            upx_sha256: 946b7269d0f7fcc1c5da0f771ea7fe9c0fed3534cf41d285980830019b4bc95e
+            upx_pkg: upx-5.2.0-amd64_linux
+            upx_sha256: 3db5d3294707439db97866feab8d75d800f028f48481a40547411824da4288a1
             gui_binary: Picocrypt-NG
             cli_binary: Picocrypt-NG-cli
             artifact_name: build-linux-amd64
             build_deb: "true"
           - arch: arm64
             runner: ubuntu-24.04-arm
-            upx_pkg: upx-5.1.0-arm64_linux
-            upx_sha256: 222dde34dfa3244a31b06c97820ee651515270e524736f532ac8456783afe76e
+            upx_pkg: upx-5.2.0-arm64_linux
+            upx_sha256: 55d48a61e8ffd17152db871c855376cba7f08e830b37799d0947a16dff8ec36c
             gui_binary: Picocrypt-NG-arm64
             cli_binary: Picocrypt-NG-cli-arm64
             artifact_name: build-linux-arm64
@@ -106,7 +106,7 @@ jobs:
 
     - name: Compress with upx
       run: |
-        wget -O upx.tar.xz https://github.com/upx/upx/releases/download/v5.1.0/${{ matrix.upx_pkg }}.tar.xz
+        wget -O upx.tar.xz https://github.com/upx/upx/releases/download/v5.2.0/${{ matrix.upx_pkg }}.tar.xz
         echo "${{ matrix.upx_sha256 }}  upx.tar.xz" | sha256sum --check --strict --status
         tar -xf upx.tar.xz
         ${{ matrix.upx_pkg }}/upx --lzma "src/${{ matrix.gui_binary }}"

--- a/.github/workflows/build-windows-legacy.yml
+++ b/.github/workflows/build-windows-legacy.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       GOTOOLCHAIN: local
       GO_LEGACY_SHA256: c9d0c79dc2b408a4ea580b62a3d093a4219f9ff95316ef891dc987827e6900e3
-      UPX_SHA256: 41c7492edeed0f7e67d347ca9e8d2131e2af7ca7a7695f92283a8e655c251c13
+      UPX_SHA256: b471ebf1b7f20f4a89150264ed9a008a2a5bfd247f3c6d1184a75bb59ca08f5d
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -101,14 +101,14 @@ jobs:
     - name: Compress with upx
       shell: pwsh
       run: |
-        Invoke-WebRequest -OutFile upx.zip https://github.com/upx/upx/releases/download/v5.1.0/upx-5.1.0-win64.zip
+        Invoke-WebRequest -OutFile upx.zip https://github.com/upx/upx/releases/download/v5.2.0/upx-5.2.0-win64.zip
         $expectedHash = $env:UPX_SHA256
         $actualHash = (Get-FileHash upx.zip -Algorithm SHA256).Hash.ToLower()
         if ($actualHash -ne $expectedHash) {
           throw "Checksum mismatch for upx.zip: expected $expectedHash, got $actualHash"
         }
         Expand-Archive -DestinationPath upx upx.zip
-        upx/upx-5.1.0-win64/upx.exe --lzma src/Picocrypt-NG-cli-Legacy.exe
+        upx/upx-5.2.0-win64/upx.exe --lzma src/Picocrypt-NG-cli-Legacy.exe
 
     - name: Upload artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     env:
       RESHACKER_SHA256: e5a5b6d6be38ae3eb20e72b09f257f284bab2deb5f37164e9f2faefd23f27cf4
-      UPX_SHA256: 41c7492edeed0f7e67d347ca9e8d2131e2af7ca7a7695f92283a8e655c251c13
+      UPX_SHA256: b471ebf1b7f20f4a89150264ed9a008a2a5bfd247f3c6d1184a75bb59ca08f5d
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -132,15 +132,15 @@ jobs:
     - name: Compress with upx
       shell: pwsh
       run: |
-        Invoke-WebRequest -OutFile upx.zip https://github.com/upx/upx/releases/download/v5.1.0/upx-5.1.0-win64.zip
+        Invoke-WebRequest -OutFile upx.zip https://github.com/upx/upx/releases/download/v5.2.0/upx-5.2.0-win64.zip
         $expectedHash = $env:UPX_SHA256
         $actualHash = (Get-FileHash upx.zip -Algorithm SHA256).Hash.ToLower()
         if ($actualHash -ne $expectedHash) {
           throw "Checksum mismatch for upx.zip: expected $expectedHash, got $actualHash"
         }
         Expand-Archive -DestinationPath upx upx.zip
-        upx/upx-5.1.0-win64/upx.exe --lzma -o src/Picocrypt-NG.exe src/5.exe
-        upx/upx-5.1.0-win64/upx.exe --lzma src/Picocrypt-NG-cli.exe
+        upx/upx-5.2.0-win64/upx.exe --lzma -o src/Picocrypt-NG.exe src/5.exe
+        upx/upx-5.2.0-win64/upx.exe --lzma src/Picocrypt-NG-cli.exe
 
     # === Phase 4 (FA-WIN-04): build NSIS installer ===
     # NSIS is NOT pre-installed on windows-2025 [actions/runner-images#11754,

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -156,7 +156,7 @@ jobs:
     - name: Install NSIS
       shell: pwsh
       run: |
-        choco install -y --no-progress nsis
+        choco install -y --no-progress nsis --version=3.12.0
         & "C:\Program Files (x86)\NSIS\makensis.exe" -VERSION
 
     - name: Build NSIS installer

--- a/.github/workflows/pr-test-build-linux.yml
+++ b/.github/workflows/pr-test-build-linux.yml
@@ -21,16 +21,16 @@ jobs:
         include:
           - arch: amd64
             runner: ubuntu-24.04
-            upx_pkg: upx-5.1.0-amd64_linux
-            upx_sha256: 946b7269d0f7fcc1c5da0f771ea7fe9c0fed3534cf41d285980830019b4bc95e
+            upx_pkg: upx-5.2.0-amd64_linux
+            upx_sha256: 3db5d3294707439db97866feab8d75d800f028f48481a40547411824da4288a1
             gui_binary: Picocrypt-NG
             cli_binary: Picocrypt-NG-cli
             artifact_name: pr-test-build-linux-amd64-ONLY-FOR-TESTING
             build_deb: "true"
           - arch: arm64
             runner: ubuntu-24.04-arm
-            upx_pkg: upx-5.1.0-arm64_linux
-            upx_sha256: 222dde34dfa3244a31b06c97820ee651515270e524736f532ac8456783afe76e
+            upx_pkg: upx-5.2.0-arm64_linux
+            upx_sha256: 55d48a61e8ffd17152db871c855376cba7f08e830b37799d0947a16dff8ec36c
             gui_binary: Picocrypt-NG-arm64
             cli_binary: Picocrypt-NG-cli-arm64
             artifact_name: pr-test-build-linux-arm64-ONLY-FOR-TESTING
@@ -98,7 +98,7 @@ jobs:
 
     - name: Compress with upx
       run: |
-        wget -O upx.tar.xz https://github.com/upx/upx/releases/download/v5.1.0/${{ matrix.upx_pkg }}.tar.xz
+        wget -O upx.tar.xz https://github.com/upx/upx/releases/download/v5.2.0/${{ matrix.upx_pkg }}.tar.xz
         echo "${{ matrix.upx_sha256 }}  upx.tar.xz" | sha256sum --check --strict --status
         tar -xf upx.tar.xz
         ${{ matrix.upx_pkg }}/upx --lzma "src/${{ matrix.gui_binary }}"

--- a/.github/workflows/pr-test-build-windows-legacy.yml
+++ b/.github/workflows/pr-test-build-windows-legacy.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       GOTOOLCHAIN: local
       GO_LEGACY_SHA256: c9d0c79dc2b408a4ea580b62a3d093a4219f9ff95316ef891dc987827e6900e3
-      UPX_SHA256: 41c7492edeed0f7e67d347ca9e8d2131e2af7ca7a7695f92283a8e655c251c13
+      UPX_SHA256: b471ebf1b7f20f4a89150264ed9a008a2a5bfd247f3c6d1184a75bb59ca08f5d
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -90,14 +90,14 @@ jobs:
     - name: Compress with upx
       shell: pwsh
       run: |
-        Invoke-WebRequest -OutFile upx.zip https://github.com/upx/upx/releases/download/v5.1.0/upx-5.1.0-win64.zip
+        Invoke-WebRequest -OutFile upx.zip https://github.com/upx/upx/releases/download/v5.2.0/upx-5.2.0-win64.zip
         $expectedHash = $env:UPX_SHA256
         $actualHash = (Get-FileHash upx.zip -Algorithm SHA256).Hash.ToLower()
         if ($actualHash -ne $expectedHash) {
           throw "Checksum mismatch for upx.zip: expected $expectedHash, got $actualHash"
         }
         Expand-Archive -DestinationPath upx upx.zip
-        upx/upx-5.1.0-win64/upx.exe --lzma src/Picocrypt-NG-cli-Legacy.exe
+        upx/upx-5.2.0-win64/upx.exe --lzma src/Picocrypt-NG-cli-Legacy.exe
 
     - name: Upload artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/pr-test-build-windows.yml
+++ b/.github/workflows/pr-test-build-windows.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-2025
     env:
       RESHACKER_SHA256: e5a5b6d6be38ae3eb20e72b09f257f284bab2deb5f37164e9f2faefd23f27cf4
-      UPX_SHA256: 41c7492edeed0f7e67d347ca9e8d2131e2af7ca7a7695f92283a8e655c251c13
+      UPX_SHA256: b471ebf1b7f20f4a89150264ed9a008a2a5bfd247f3c6d1184a75bb59ca08f5d
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -121,15 +121,15 @@ jobs:
     - name: Compress with upx
       shell: pwsh
       run: |
-        Invoke-WebRequest -OutFile upx.zip https://github.com/upx/upx/releases/download/v5.1.0/upx-5.1.0-win64.zip
+        Invoke-WebRequest -OutFile upx.zip https://github.com/upx/upx/releases/download/v5.2.0/upx-5.2.0-win64.zip
         $expectedHash = $env:UPX_SHA256
         $actualHash = (Get-FileHash upx.zip -Algorithm SHA256).Hash.ToLower()
         if ($actualHash -ne $expectedHash) {
           throw "Checksum mismatch for upx.zip: expected $expectedHash, got $actualHash"
         }
         Expand-Archive -DestinationPath upx upx.zip
-        upx/upx-5.1.0-win64/upx.exe --lzma -o src/Picocrypt-NG.exe src/5.exe
-        upx/upx-5.1.0-win64/upx.exe --lzma src/Picocrypt-NG-cli.exe
+        upx/upx-5.2.0-win64/upx.exe --lzma -o src/Picocrypt-NG.exe src/5.exe
+        upx/upx-5.2.0-win64/upx.exe --lzma src/Picocrypt-NG-cli.exe
 
     # === Phase 4 (FA-WIN-04): build NSIS installer ===
     # NSIS is NOT pre-installed on windows-2025 [actions/runner-images#11754,

--- a/.github/workflows/pr-test-build-windows.yml
+++ b/.github/workflows/pr-test-build-windows.yml
@@ -145,7 +145,7 @@ jobs:
     - name: Install NSIS
       shell: pwsh
       run: |
-        choco install -y --no-progress nsis
+        choco install -y --no-progress nsis --version=3.12.0
         & "C:\Program Files (x86)\NSIS\makensis.exe" -VERSION
 
     - name: Build NSIS installer

--- a/.github/workflows/pr-test-installer-upgrade.yml
+++ b/.github/workflows/pr-test-installer-upgrade.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install NSIS
       shell: pwsh
       run: |
-        choco install -y --no-progress nsis
+        choco install -y --no-progress nsis --version=3.12.0
         & "C:\Program Files (x86)\NSIS\makensis.exe" -VERSION
 
     - name: Runtime upgrade / orphan-sweep / running-instance test


### PR DESCRIPTION
## Summary

- refresh the reviewed SHA-256 for the mutable `linuxdeploy/continuous` AppImage
- update UPX from 5.1.0 to 5.2.0 across Linux, Windows, and Windows 7 legacy release/PR workflows, keeping strict per-platform checksums
- pin Chocolatey NSIS to 3.12.0 in the standard Windows build and installer-upgrade workflows

This PR does not change Picocrypt NG source code, encrypted-volume behavior,
Android support, Go/Android application dependencies, release metadata, or the
2.18 version. It does not publish 2.19.

## Verification

- downloaded and strictly verified all three UPX 5.2.0 archives and the current reviewed linuxdeploy bytes
- `actionlint` passed for all eight changed workflows
- `go test -count=1 ./internal/workflowpolicy` passed
- golden v1/v2 volume compatibility tests and a fresh full `go test -count=1 ./...` passed
- strict local `act` dry-runs passed for the Ubuntu workflow definitions; Windows jobs were schema-checked/listed locally and remain authoritative hosted-runner gates
- a faithful non-root local Linux amd64 PR job passed the full race-enabled suite plus CLI integration, GUI/CLI builds, UPX compression, Debian packaging, and artifact preparation
- a faithful Ubuntu 22.04 AppImage job passed tool checksum verification, build, embedded update/signature checks, zsync generation, and runtime smoke test
- no tests were added, removed, disabled, or weakened; existing intentional
  platform/race skips remained visible

The two real local jobs reached `actions/upload-artifact@v7`; stable `act` 0.2.89
then rejected its new `mime_type` field (tracked upstream in
[nektos/act#6053](https://github.com/nektos/act/pull/6053)). Therefore hosted
GitHub Actions remains the explicit artifact-upload, Linux arm64, and Windows
runtime gate before merge.