### PR TITLE
fix(ui): prevent non-ASCII password layout drift

### DIFF
--- a/src/internal/ui/app.go
+++ b/src/internal/ui/app.go
@@ -115,6 +115,7 @@ type App struct {
 	languageSelector   *languageSelector
 	aboutVersionLabel  *widget.Label
 	mainContent        *fyne.Container
+	passwordContainer  *fyne.Container
 	passwordLabel      *widget.Label
 	passwordEntry      *PasswordEntry
 	cPasswordEntry     *PasswordEntry

--- a/src/internal/ui/layout_regression_test.go
+++ b/src/internal/ui/layout_regression_test.go
@@ -582,6 +582,148 @@ func TestDesktopPasswordEntriesUseFullFormWidth(t *testing.T) {
 	}
 }
 
+func TestUpdateNonASCIIHintRelayoutsPasswordSection(t *testing.T) {
+	fyneApp := newTestFyneApp(t)
+	fyneApp.Settings().SetTheme(fixedVariantTheme{Theme: NewCompactTheme(), variant: theme.VariantLight})
+	a := newDesktopEncryptLayoutApp(t, fyneApp)
+
+	nonASCII := "caf" + string(rune(0x00E9))
+	var baselineY, shownY, hintBottom, restoredY float32
+	var hintWidth, hintHeight float32
+	var shown, hidden bool
+
+	fyne.DoAndWait(func() {
+		baselineY = a.confirmRow.Position().Y
+
+		a.State.Password = nonASCII
+		a.updateNonASCIIHint()
+		shown = a.nonASCIIHint.Visible()
+		hintSize := a.nonASCIIHint.Size()
+		hintWidth = hintSize.Width
+		hintHeight = hintSize.Height
+		hintBottom = a.nonASCIIHint.Position().Y + hintSize.Height
+		shownY = a.confirmRow.Position().Y
+
+		a.State.Password = "plain-ascii"
+		a.updateNonASCIIHint()
+		hidden = !a.nonASCIIHint.Visible()
+		restoredY = a.confirmRow.Position().Y
+	})
+
+	if !shown {
+		t.Fatal("non-ASCII hint was not shown")
+	}
+	if hintWidth <= 0 || hintHeight <= 0 {
+		t.Fatalf("hint size = (%.1f, %.1f); want non-zero laid-out geometry", hintWidth, hintHeight)
+	}
+	if shownY < baselineY+1 {
+		t.Fatalf("confirm row Y %.1f did not move below baseline %.1f", shownY, baselineY)
+	}
+	if shownY < hintBottom-1 {
+		t.Fatalf("confirm row Y %.1f overlaps hint bottom %.1f", shownY, hintBottom)
+	}
+	if !hidden {
+		t.Fatal("non-ASCII hint was not hidden after returning to ASCII")
+	}
+	restoredDelta := restoredY - baselineY
+	if restoredDelta < -1 || restoredDelta > 1 {
+		t.Fatalf("confirm row did not return to baseline: baseline %.1f restored %.1f", baselineY, restoredY)
+	}
+}
+
+func TestDesktopNonASCIIHintLayoutDoesNotDrift(t *testing.T) {
+	fyneApp := newTestFyneApp(t)
+	fyneApp.Settings().SetTheme(fixedVariantTheme{Theme: NewCompactTheme(), variant: theme.VariantLight})
+	a := newDesktopEncryptLayoutApp(t, fyneApp)
+
+	const asciiPassword = "plain-ascii"
+	nonASCII := "caf" + string(rune(0x00E9))
+
+	type layoutSnapshot struct {
+		hintVisible   bool
+		hintWidth     float32
+		hintHeight    float32
+		hintMinHeight float32
+		hintBottom    float32
+		confirmY      float32
+		windowHeight  float32
+	}
+
+	capture := func(password string) layoutSnapshot {
+		t.Helper()
+		var got layoutSnapshot
+		fyne.DoAndWait(func() {
+			a.passwordEntry.SetText(password)
+			hintSize := a.nonASCIIHint.Size()
+			got = layoutSnapshot{
+				hintVisible:   a.nonASCIIHint.Visible(),
+				hintWidth:     hintSize.Width,
+				hintHeight:    hintSize.Height,
+				hintMinHeight: a.nonASCIIHint.MinSize().Height,
+				hintBottom:    a.nonASCIIHint.Position().Y + hintSize.Height,
+				confirmY:      a.confirmRow.Position().Y,
+				windowHeight:  a.Window.Canvas().Size().Height,
+			}
+		})
+		assertWindowFitsContent(t, a)
+		return got
+	}
+
+	baseline := capture(asciiPassword)
+	if baseline.hintVisible {
+		t.Fatal("non-ASCII hint is visible for the ASCII baseline")
+	}
+
+	firstShown := capture(nonASCII)
+	firstHidden := capture(asciiPassword)
+	secondShown := capture(nonASCII)
+	secondHidden := capture(asciiPassword)
+
+	assertShown := func(cycle int, got layoutSnapshot) {
+		t.Helper()
+		if !got.hintVisible {
+			t.Fatalf("cycle %d: non-ASCII hint is hidden", cycle)
+		}
+		if got.hintWidth <= 0 || got.hintHeight <= 0 {
+			t.Fatalf("cycle %d: hint size = (%.1f, %.1f); want non-zero geometry", cycle, got.hintWidth, got.hintHeight)
+		}
+		if got.hintHeight < got.hintMinHeight-1 {
+			t.Fatalf("cycle %d: hint height %.1f clips MinSize height %.1f", cycle, got.hintHeight, got.hintMinHeight)
+		}
+		if got.confirmY < baseline.confirmY+1 {
+			t.Fatalf("cycle %d: confirm row Y %.1f did not move below baseline %.1f", cycle, got.confirmY, baseline.confirmY)
+		}
+		if got.confirmY < got.hintBottom-1 {
+			t.Fatalf("cycle %d: confirm row Y %.1f overlaps hint bottom %.1f", cycle, got.confirmY, got.hintBottom)
+		}
+	}
+
+	assertHidden := func(cycle int, got layoutSnapshot) {
+		t.Helper()
+		if got.hintVisible {
+			t.Fatalf("cycle %d: non-ASCII hint stayed visible for ASCII password", cycle)
+		}
+		confirmDelta := got.confirmY - baseline.confirmY
+		if confirmDelta < -1 || confirmDelta > 1 {
+			t.Fatalf("cycle %d: confirm row drifted from %.1f to %.1f", cycle, baseline.confirmY, got.confirmY)
+		}
+		windowDelta := got.windowHeight - baseline.windowHeight
+		if windowDelta < -1 || windowDelta > 1 {
+			t.Fatalf("cycle %d: window height drifted from %.1f to %.1f", cycle, baseline.windowHeight, got.windowHeight)
+		}
+	}
+
+	assertShown(1, firstShown)
+	assertHidden(1, firstHidden)
+	assertShown(2, secondShown)
+	assertHidden(2, secondHidden)
+
+	shownDelta := secondShown.windowHeight - firstShown.windowHeight
+	if shownDelta < -1 || shownDelta > 1 {
+		t.Fatalf("visible window height drifted from %.1f to %.1f", firstShown.windowHeight, secondShown.windowHeight)
+	}
+}
+
 func newDesktopEncryptLayoutApp(t *testing.T, fyneApp fyne.App) *App {
 	t.Helper()
 

--- a/src/internal/ui/password_section.go
+++ b/src/internal/ui/password_section.go
@@ -117,12 +117,13 @@ func (a *App) buildPasswordSection() fyne.CanvasObject {
 	a.nonASCIIHint.Wrapping = fyne.TextWrapWord
 	a.nonASCIIHint.Hide()
 
-	return container.NewVBox(
+	a.passwordContainer = container.NewVBox(
 		passwordHeader,
 		a.passwordEntry,
 		a.nonASCIIHint,
 		a.confirmRow,
 	)
+	return a.passwordContainer
 }
 
 // updatePasswordStrength updates the password strength indicator.
@@ -142,10 +143,17 @@ func (a *App) updateNonASCIIHint() {
 	if a.nonASCIIHint == nil {
 		return
 	}
-	if a.State.Mode != "decrypt" && pwnorm.ContainsNonASCII([]byte(a.State.Password)) {
+	shouldShow := a.State.Mode != "decrypt" && pwnorm.ContainsNonASCII([]byte(a.State.Password))
+	if a.nonASCIIHint.Visible() == shouldShow {
+		return
+	}
+	if shouldShow {
 		a.nonASCIIHint.Show()
 	} else {
 		a.nonASCIIHint.Hide()
+	}
+	if a.passwordContainer != nil {
+		a.passwordContainer.Refresh()
 	}
 }
 


### PR DESCRIPTION
## Summary

- retain the desktop password section's immediate `VBox` so its layout can be refreshed locally;
- refresh that container only when the non-ASCII advisory actually changes visibility;
- keep desktop window sizing centralized after the parent layout is current;
- add component and user-path regressions for clipping, overlap, restoration, and repeated-transition drift.

## Root cause

Showing or hiding the wrapped advisory refreshed the label, but not its parent
layout. The subsequent fixed-window resize could therefore measure stale
geometry before the canvas performed another layout pass. The regression
reproduced a 616.9-high canvas with a 674.1 content minimum on the first
non-ASCII transition.

The fix establishes the deterministic order:

1. change advisory visibility;
2. refresh the immediate password container;
3. let the existing centralized window resize measure the updated layout.

No second resize or generic visibility abstraction is introduced.

## Verification

- focused non-ASCII regressions: passed;
- complete `internal/ui` package: passed with no skipped or failed tests;
- complete `go test -count=1 -tags migrated_fynedo ./...`: passed;
- complete race suite with `-race -p 2 -timeout 15m`: passed;
- `go vet`, `golangci-lint`, and `govulncheck`: passed with zero reachable vulnerabilities;
- `go mod tidy -diff` and `go mod verify`: clean;
- real CGO desktop GUI build: passed;
- independent task and whole-branch reviews: no Critical, Important, or Minor findings.

## Security and privacy

The exact one-commit range was scanned with Gitleaks and TruffleHog. Both
reported zero secret findings. The diff contains only three intended Go files
and no local artifacts, credentials, personal paths, dependency changes, or
release metadata.

## Remaining platform gate

The native Windows 10/11 cursor, DPI, non-client geometry, and original
blank-band sequence still require smoke testing on a current portable artifact.
The local Linux GL smoke was not executable because `openbox` and `wmctrl` were
unavailable. These are release/issue-closure evidence gaps, not hidden local
test failures.

Refs #218