### PR TITLE
test(ui): join readiness worker before restoring seams

### DIFF
--- a/src/internal/ui/drop_test.go
+++ b/src/internal/ui/drop_test.go
@@ -1853,10 +1853,12 @@ func TestInvalidStartCancelsOpenedPathReadiness(t *testing.T) {
 func TestOpenedPathReadinessPendingStatusDoesNotOverwriteBusyStatus(t *testing.T) {
 	oldCheck := checkOpenedPathReadiness
 	oldPoll := openedPathPollInterval
-	defer func() {
+	// Register this before the App cleanup so its readiness worker is joined
+	// before these package-level test seams are restored (cleanups run LIFO).
+	t.Cleanup(func() {
 		checkOpenedPathReadiness = oldCheck
 		openedPathPollInterval = oldPoll
-	}()
+	})
 	openedPathPollInterval = 5 * time.Millisecond
 
 	fyneApp := newTestFyneApp(t)


### PR DESCRIPTION
## Summary

- restore the readiness test seams with t.Cleanup instead of a function-level defer
- preserve LIFO cleanup ordering so the existing App cleanup cancels and joins the readiness worker first
- keep production behavior unchanged

## Root cause

The Linux race job on PR #222 detected a write to the package-level checkOpenedPathReadiness test seam while the readiness worker was still reading it. The test's deferred restoration ran before testing.T cleanups, so it raced with the App cleanup that owns worker cancellation and joining.

This is a test teardown race, not a production callback mutation. The change registers restoration as an earlier t.Cleanup; the App cleanup is registered later and therefore runs first.

## Validation

- go test -count=100 -tags migrated_fynedo -race -run '^TestOpenedPathReadinessPendingStatusDoesNotOverwriteBusyStatus$' ./internal/ui
- go test -count=1 -tags migrated_fynedo -race -p 2 ./internal/ui
- go test -count=1 ./internal/workflowpolicy ./internal/distmeta
- git diff --check
- Gitleaks scan of the exact patch: no leaks found

Detected in [PR #222 CI](https://github.com/Picocrypt-NG/Picocrypt-NG/actions/runs/29358642071).
