### PR TITLE
fix(android): keep apksigner diagnostics exact on newer JDKs

### DIFF
--- a/android/verify-release-apks.sh
+++ b/android/verify-release-apks.sh
@@ -78,7 +78,10 @@ if [[ ! -x "$APKSIGNER" ]]; then
     echo "apksigner is not executable: $APKSIGNER" >&2
     exit 1
 fi
-if ! apksigner_version="$("$APKSIGNER" version 2>&1)" || [[ -z "$apksigner_version" ]]; then
+# Keep apksigner's diagnostics exact without filtering stderr when Java warns
+# about the Conscrypt native library used by Android Build Tools 36.
+apksigner_command=("$APKSIGNER" -J-enable-native-access=ALL-UNNAMED)
+if ! apksigner_version="$("${apksigner_command[@]}" version 2>&1)" || [[ -z "$apksigner_version" ]]; then
     echo "apksigner health check failed: $APKSIGNER" >&2
     printf '%s\n' "$apksigner_version" >&2
     exit 1
@@ -121,7 +124,7 @@ verify_apk() {
     local apk="$apk_dir/$filename"
     local badging package_line actual_application_id actual_version_code actual_version_name entries actual_abis signature_output signer_count signer_digest abi jni_file elf_header actual_machine expected_machine expected_machine_code
 
-    if signature_output="$("$APKSIGNER" verify --Werr --verbose --print-certs "$apk" 2>&1)"; then
+    if signature_output="$("${apksigner_command[@]}" verify --Werr --verbose --print-certs "$apk" 2>&1)"; then
         if [[ "$build_kind" == unsigned ]]; then
             echo "$filename has a valid APK signature, want unsigned" >&2
             exit 1

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -682,6 +682,11 @@ func TestAndroidReleaseWorkflowsRunExactArtifactVerifier(t *testing.T) {
 	if runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
 		t.Fatalf("Android release APK verifier mode = %v, want executable", info.Mode().Perm())
 	}
+	verifier := mustReadRepoFile(t, "android/verify-release-apks.sh")
+	// Keep Java native-access warnings out of the pinned apksigner diagnostic
+	// without filtering stderr, which would weaken the fail-closed check.
+	mustContain(t, verifier, `apksigner_command=("$APKSIGNER" -J-enable-native-access=ALL-UNNAMED)`)
+	mustContain(t, verifier, `"${apksigner_command[@]}" verify --Werr --verbose --print-certs "$apk"`)
 
 	for _, tc := range []struct {
 		name string


### PR DESCRIPTION
## Summary

- run Android Build Tools 36 `apksigner` with the JVM native-access option it expects on newer JDKs
- reuse the same quoted command for the health check and every APK verification
- preserve this release-integrity invariant in the workflow policy tests

## Why

`verify-release-apks.sh` intentionally compares the complete unsigned-APK diagnostic with a pinned value. On JDK 26, Conscrypt's native-library load adds JVM warnings to `stderr`, so a genuine unsigned release APK is rejected even though `apksigner` reports the expected result.

Filtering or partially matching `stderr` would weaken the fail-closed check. Passing `-J-enable-native-access=ALL-UNNAMED` through the standard `apksigner` launcher prevents that JVM warning at its source while leaving every `apksigner` diagnostic intact.

## Security and compatibility

- unexpected signature diagnostics are still rejected byte-for-byte
- native access is scoped to the short-lived trusted `apksigner.jar` process; APK code is not loaded or executed
- the Bash array preserves executable paths containing spaces and avoids duplicated invocation logic
- no crypto, volume format, signing key, release permission, or artifact-publishing behavior changes

## Validation

- full unsigned release APK contract: JDK 17, Temurin 21.0.11, and OpenJDK 26.0.1
- JDK 26 unsigned diagnostic with the option: exact pinned two-line result
- `bash -n android/verify-release-apks.sh`
- `go test -count=1 ./internal/workflowpolicy ./internal/distmeta` with an isolated clean Go build cache
- `golangci-lint run --output.text.path /dev/null --output.json.path stdout`: 0 issues
- `git diff --check`
- Gitleaks scan of the exact PR diff: no findings

Merge remains gated on all required checks for the current head SHA.
