### PR TITLE
ci: add SignPath Authenticode signing for Windows releases

### DIFF
--- a/.github/workflows/build-windows-legacy.yml
+++ b/.github/workflows/build-windows-legacy.yml
@@ -16,6 +16,16 @@ on:
         required: false
         type: boolean
         default: false
+      signpath_test:
+        description: "Submit the legacy CLI to SignPath with the self-signed test policy. Never publishes a GitHub release."
+        required: false
+        type: boolean
+        default: false
+      signpath_release_dry_run:
+        description: "Submit the legacy CLI to SignPath with the release policy for end-to-end validation. Never publishes a GitHub release."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -113,14 +123,100 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: build-windows-legacy
+        name: unsigned-windows-legacy
         path: src/Picocrypt-NG-cli-Legacy.exe
         if-no-files-found: error
         compression-level: 9
+        retention-days: 1
+
+  sign:
+    needs: build
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release || inputs.signpath_test || inputs.signpath_release_dry_run) }}
+    runs-on: windows-2022
+    timeout-minutes: 30
+    environment: release
+    permissions:
+      actions: read
+      contents: read
+    env:
+      SIGNPATH_SIGNING_POLICY_SLUG: ${{ inputs.signpath_test && 'test-signing' || 'release-signing' }}
+      SIGNPATH_TEST: ${{ inputs.signpath_test && 'true' || 'false' }}
+      SIGNPATH_PRODUCTION_CERTIFICATE_SHA256: ${{ vars.SIGNPATH_PRODUCTION_CERTIFICATE_SHA256 }}
+    steps:
+    - name: Reject conflicting SignPath modes
+      if: ${{ inputs.signpath_test && inputs.signpath_release_dry_run }}
+      shell: pwsh
+      run: throw "signpath_test and signpath_release_dry_run cannot both be enabled"
+
+    - name: Download unsigned build artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: unsigned-windows-legacy
+        path: unsigned-legacy
+
+    - name: Upload unsigned legacy CLI for SignPath
+      id: upload-signpath-legacy
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: signpath-windows-legacy
+        path: unsigned-legacy/Picocrypt-NG-cli-Legacy.exe
+        if-no-files-found: error
+        compression-level: 0
+        retention-days: 1
+
+    - name: Sign legacy CLI with SignPath
+      uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
+      with:
+        api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+        organization-id: d6e78672-6bae-47d3-b2b8-fa464705b34e
+        project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+        signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY_SLUG }}
+        artifact-configuration-slug: windows-legacy-cli
+        github-artifact-id: ${{ steps.upload-signpath-legacy.outputs.artifact-id }}
+        wait-for-completion: true
+        output-artifact-directory: signpath-signed-legacy
+
+    - name: Verify legacy Authenticode signature
+      shell: pwsh
+      run: |
+        $path = "signpath-signed-legacy/Picocrypt-NG-cli-Legacy.exe"
+        $signature = Get-AuthenticodeSignature -FilePath $path
+        if ($null -eq $signature.SignerCertificate) {
+          throw "No Authenticode signer certificate: $path"
+        }
+        if (@("NotSigned", "HashMismatch", "NotSupported") -contains [string]$signature.Status) {
+          throw "Invalid Authenticode signature: $($signature.Status) $($signature.StatusMessage)"
+        }
+        if ($env:SIGNPATH_TEST -ne "true" -and $signature.Status -ne "Valid") {
+          throw "Production Authenticode signature is not trusted: $($signature.Status) $($signature.StatusMessage)"
+        }
+        if ($env:SIGNPATH_TEST -ne "true" -and $null -eq $signature.TimeStamperCertificate) {
+          throw "Production Authenticode signature has no timestamp: $path"
+        }
+        if ($env:SIGNPATH_TEST -ne "true" -and $env:SIGNPATH_PRODUCTION_CERTIFICATE_SHA256 -notmatch '^[0-9A-Fa-f]{64}$') {
+          throw "SIGNPATH_PRODUCTION_CERTIFICATE_SHA256 must be the production certificate's 64-character SHA-256 fingerprint"
+        }
+        if ($env:SIGNPATH_TEST -ne "true") {
+          $actualCertificateSHA256 = $signature.SignerCertificate.GetCertHashString(
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256
+          )
+          if ($actualCertificateSHA256 -ne $env:SIGNPATH_PRODUCTION_CERTIFICATE_SHA256) {
+            throw "Unexpected production signing certificate: $actualCertificateSHA256"
+          }
+        }
+
+    - name: Upload signed Windows legacy artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.signpath_test && 'signed-windows-legacy-TEST-DO-NOT-PUBLISH' || inputs.signpath_release_dry_run && 'signed-windows-legacy-RELEASE-SIGNING-DRY-RUN-DO-NOT-PUBLISH' || 'signed-windows-legacy' }}
+        path: signpath-signed-legacy/Picocrypt-NG-cli-Legacy.exe
+        if-no-files-found: error
+        compression-level: 9
+        retention-days: 1
 
   release:
-    needs: build
-    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release) }}
+    needs: [build, sign]
+    if: ${{ github.ref == 'refs/heads/main' && !inputs.signpath_test && !inputs.signpath_release_dry_run && (github.event_name == 'push' || inputs.publish_release) }}
     runs-on: windows-2022
     environment: release
     permissions:
@@ -130,10 +226,10 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-    - name: Download artifact
+    - name: Download signed artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: build-windows-legacy
+        name: signed-windows-legacy
         path: artifacts/build-windows-legacy
 
     - name: Get version tag

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -16,6 +16,16 @@ on:
         required: false
         type: boolean
         default: false
+      signpath_test:
+        description: "Submit artifacts to SignPath with the self-signed test policy. Never publishes a GitHub release."
+        required: false
+        type: boolean
+        default: false
+      signpath_release_dry_run:
+        description: "Submit artifacts to SignPath with the release policy for end-to-end validation. Never publishes a GitHub release."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -211,14 +221,318 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: build-windows
+        name: unsigned-windows
         path: release-staging/
         if-no-files-found: error
         compression-level: 9
+        retention-days: 1
+
+  sign:
+    needs: build
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release || inputs.signpath_test || inputs.signpath_release_dry_run) }}
+    runs-on: windows-2025
+    timeout-minutes: 60
+    environment: release
+    permissions:
+      actions: read
+      contents: read
+    env:
+      SIGNPATH_SIGNING_POLICY_SLUG: ${{ inputs.signpath_test && 'test-signing' || 'release-signing' }}
+      SIGNPATH_TEST: ${{ inputs.signpath_test && 'true' || 'false' }}
+      SIGNPATH_PRODUCTION_CERTIFICATE_SHA256: ${{ vars.SIGNPATH_PRODUCTION_CERTIFICATE_SHA256 }}
+    steps:
+    - name: Reject conflicting SignPath modes
+      if: ${{ inputs.signpath_test && inputs.signpath_release_dry_run }}
+      shell: pwsh
+      run: throw "signpath_test and signpath_release_dry_run cannot both be enabled"
+
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    - name: Download unsigned build artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: unsigned-windows
+        path: unsigned-build
+
+    - name: Stage unsigned binaries for SignPath
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Force -Path signpath-input-binaries | Out-Null
+        Copy-Item unsigned-build/Picocrypt-NG-portable.exe signpath-input-binaries/
+        Copy-Item unsigned-build/Picocrypt-NG-cli.exe signpath-input-binaries/
+
+        $expected = @("Picocrypt-NG-cli.exe", "Picocrypt-NG-portable.exe")
+        $actual = @(Get-ChildItem signpath-input-binaries -File).Name | Sort-Object
+        if (Compare-Object $expected $actual) {
+          throw "Unexpected SignPath binary input: $($actual -join ', ')"
+        }
+
+    - name: Upload unsigned binaries for SignPath
+      id: upload-signpath-binaries
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: signpath-windows-binaries
+        path: signpath-input-binaries/
+        if-no-files-found: error
+        compression-level: 0
+        retention-days: 1
+
+    - name: Sign binaries with SignPath
+      uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
+      with:
+        api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+        organization-id: d6e78672-6bae-47d3-b2b8-fa464705b34e
+        project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+        signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY_SLUG }}
+        artifact-configuration-slug: windows-binaries
+        github-artifact-id: ${{ steps.upload-signpath-binaries.outputs.artifact-id }}
+        wait-for-completion: true
+        output-artifact-directory: signpath-signed-binaries
+
+    - name: Verify signed binaries before packaging
+      shell: pwsh
+      run: |
+        $expected = @("Picocrypt-NG-cli.exe", "Picocrypt-NG-portable.exe")
+        $actual = @(Get-ChildItem signpath-signed-binaries -File).Name | Sort-Object
+        if (Compare-Object $expected $actual) {
+          throw "Unexpected SignPath binary output: $($actual -join ', ')"
+        }
+
+        $requireTrusted = $env:SIGNPATH_TEST -ne "true"
+        foreach ($path in @(
+          "signpath-signed-binaries/Picocrypt-NG-portable.exe",
+          "signpath-signed-binaries/Picocrypt-NG-cli.exe"
+        )) {
+          $signature = Get-AuthenticodeSignature -FilePath $path
+          if ($null -eq $signature.SignerCertificate) {
+            throw "No Authenticode signer certificate: $path"
+          }
+          if (@("NotSigned", "HashMismatch", "NotSupported") -contains [string]$signature.Status) {
+            throw "Invalid Authenticode signature for ${path}: $($signature.Status) $($signature.StatusMessage)"
+          }
+          if ($requireTrusted -and $signature.Status -ne "Valid") {
+            throw "Production Authenticode signature is not trusted for ${path}: $($signature.Status) $($signature.StatusMessage)"
+          }
+          if ($requireTrusted -and $null -eq $signature.TimeStamperCertificate) {
+            throw "Production Authenticode signature has no timestamp: $path"
+          }
+        }
+
+    - name: Export unsigned NSIS uninstaller
+      shell: pwsh
+      run: |
+        Copy-Item signpath-signed-binaries/Picocrypt-NG-portable.exe src/Picocrypt-NG-portable.exe
+        Copy-Item signpath-signed-binaries/Picocrypt-NG-cli.exe src/Picocrypt-NG-cli.exe
+
+        choco install -y --no-progress nsis --version=3.12.0
+        & "C:\Program Files (x86)\NSIS\makensis.exe" -VERSION
+
+        $version = (Get-Content -Path "VERSION" -Raw).Trim()
+        $scriptPath = (Resolve-Path "dist\windows\installer.nsi").Path
+        Remove-Item dist/windows/Uninstall.exe -Force -ErrorAction SilentlyContinue
+        Remove-Item dist/windows/Picocrypt-NG-Setup.exe -Force -ErrorAction SilentlyContinue
+        & "C:\Program Files (x86)\NSIS\makensis.exe" `
+          -WX `
+          -V4 `
+          "-DVERSION=$version" `
+          "-DEXPORT_UNINST" `
+          "$scriptPath"
+        if ($LASTEXITCODE -ne 0) {
+          throw "makensis failed to export the uninstaller with exit code $LASTEXITCODE"
+        }
+
+        $uninstaller = Get-Item -LiteralPath "dist/windows/Uninstall.exe" -ErrorAction Stop
+        if ($uninstaller.Length -lt 10KB -or $uninstaller.Length -gt 10MB) {
+          throw "Uninstall.exe size outside expected range: $($uninstaller.Length) bytes"
+        }
+        Remove-Item dist/windows/Picocrypt-NG-Setup.exe -Force -ErrorAction Stop
+
+    - name: Upload unsigned uninstaller for SignPath
+      id: upload-signpath-uninstaller
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: signpath-windows-uninstaller
+        path: dist/windows/Uninstall.exe
+        if-no-files-found: error
+        compression-level: 0
+        retention-days: 1
+
+    - name: Sign uninstaller with SignPath
+      uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
+      with:
+        api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+        organization-id: d6e78672-6bae-47d3-b2b8-fa464705b34e
+        project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+        signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY_SLUG }}
+        artifact-configuration-slug: windows-uninstaller
+        github-artifact-id: ${{ steps.upload-signpath-uninstaller.outputs.artifact-id }}
+        wait-for-completion: true
+        output-artifact-directory: signpath-signed-uninstaller
+
+    - name: Verify signed uninstaller
+      shell: pwsh
+      run: |
+        $path = "signpath-signed-uninstaller/Uninstall.exe"
+        $signature = Get-AuthenticodeSignature -FilePath $path
+        if ($null -eq $signature.SignerCertificate) {
+          throw "No Authenticode signer certificate: $path"
+        }
+        if (@("NotSigned", "HashMismatch", "NotSupported") -contains [string]$signature.Status) {
+          throw "Invalid Authenticode signature: $($signature.Status) $($signature.StatusMessage)"
+        }
+        if ($env:SIGNPATH_TEST -ne "true" -and $signature.Status -ne "Valid") {
+          throw "Production Authenticode signature is not trusted: $($signature.Status) $($signature.StatusMessage)"
+        }
+        if ($env:SIGNPATH_TEST -ne "true" -and $null -eq $signature.TimeStamperCertificate) {
+          throw "Production Authenticode signature has no timestamp: $path"
+        }
+
+    - name: Build NSIS installer from signed components
+      shell: pwsh
+      run: |
+        Copy-Item signpath-signed-uninstaller/Uninstall.exe dist/windows/Uninstall.exe -Force
+
+        $version = (Get-Content -Path "VERSION" -Raw).Trim()
+        $scriptPath = (Resolve-Path "dist\windows\installer.nsi").Path
+        Remove-Item dist/windows/Picocrypt-NG-Setup.exe -Force -ErrorAction SilentlyContinue
+        & "C:\Program Files (x86)\NSIS\makensis.exe" `
+          -WX `
+          -V4 `
+          "-DVERSION=$version" `
+          "-DIMPORT_UNINST" `
+          "$scriptPath"
+        if ($LASTEXITCODE -ne 0) {
+          throw "makensis failed to import the signed uninstaller with exit code $LASTEXITCODE"
+        }
+
+        $setup = Get-Item -LiteralPath "dist/windows/Picocrypt-NG-Setup.exe" -ErrorAction Stop
+        if ($setup.Length -lt 1MB -or $setup.Length -gt 100MB) {
+          throw "Setup.exe size outside expected range: $($setup.Length) bytes"
+        }
+
+    - name: Upload unsigned installer for SignPath
+      id: upload-signpath-installer
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: signpath-windows-installer
+        path: dist/windows/Picocrypt-NG-Setup.exe
+        if-no-files-found: error
+        compression-level: 0
+        retention-days: 1
+
+    - name: Sign installer with SignPath
+      uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2.2
+      with:
+        api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+        organization-id: d6e78672-6bae-47d3-b2b8-fa464705b34e
+        project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+        signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY_SLUG }}
+        artifact-configuration-slug: windows-installer
+        github-artifact-id: ${{ steps.upload-signpath-installer.outputs.artifact-id }}
+        wait-for-completion: true
+        output-artifact-directory: signpath-signed-installer
+
+    - name: Verify final Authenticode artifacts
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Force -Path signed-release | Out-Null
+        Copy-Item signpath-signed-binaries/Picocrypt-NG-portable.exe signed-release/
+        Copy-Item signpath-signed-binaries/Picocrypt-NG-cli.exe signed-release/
+        Copy-Item signpath-signed-installer/Picocrypt-NG-Setup.exe signed-release/
+
+        $expected = @("Picocrypt-NG-Setup.exe", "Picocrypt-NG-cli.exe", "Picocrypt-NG-portable.exe") | Sort-Object
+        $actual = @(Get-ChildItem signed-release -File).Name | Sort-Object
+        if (Compare-Object $expected $actual) {
+          throw "Unexpected final Windows artifact set: $($actual -join ', ')"
+        }
+
+        if ($env:SIGNPATH_TEST -ne "true" -and $env:SIGNPATH_PRODUCTION_CERTIFICATE_SHA256 -notmatch '^[0-9A-Fa-f]{64}$') {
+          throw "SIGNPATH_PRODUCTION_CERTIFICATE_SHA256 must be the production certificate's 64-character SHA-256 fingerprint"
+        }
+
+        function Assert-AuthenticodeSignature {
+          param([Parameter(Mandatory)][string]$Path)
+
+          $signature = Get-AuthenticodeSignature -FilePath $Path
+          if ($null -eq $signature.SignerCertificate) {
+            throw "No Authenticode signer certificate: $Path"
+          }
+          if (@("NotSigned", "HashMismatch", "NotSupported") -contains [string]$signature.Status) {
+            throw "Invalid Authenticode signature for ${Path}: $($signature.Status) $($signature.StatusMessage)"
+          }
+          if ($env:SIGNPATH_TEST -ne "true" -and $signature.Status -ne "Valid") {
+            throw "Production Authenticode signature is not trusted for ${Path}: $($signature.Status) $($signature.StatusMessage)"
+          }
+          if ($env:SIGNPATH_TEST -ne "true" -and $null -eq $signature.TimeStamperCertificate) {
+            throw "Production Authenticode signature has no timestamp: $Path"
+          }
+          if ($env:SIGNPATH_TEST -ne "true") {
+            $actualCertificateSHA256 = $signature.SignerCertificate.GetCertHashString(
+              [System.Security.Cryptography.HashAlgorithmName]::SHA256
+            )
+            if ($actualCertificateSHA256 -ne $env:SIGNPATH_PRODUCTION_CERTIFICATE_SHA256) {
+              throw "Unexpected production signing certificate for ${Path}: $actualCertificateSHA256"
+            }
+          }
+        }
+
+        foreach ($path in @(
+          "signed-release/Picocrypt-NG-portable.exe",
+          "signed-release/Picocrypt-NG-cli.exe",
+          "signed-release/Picocrypt-NG-Setup.exe",
+          "signpath-signed-uninstaller/Uninstall.exe"
+        )) {
+          Assert-AuthenticodeSignature -Path $path
+        }
+
+        $sevenZip = "C:\Program Files\7-Zip\7z.exe"
+        if (-not (Test-Path -LiteralPath $sevenZip -PathType Leaf)) {
+          throw "7z.exe not found at $sevenZip"
+        }
+        New-Item -ItemType Directory -Force -Path extracted-installer | Out-Null
+        & $sevenZip x signed-release/Picocrypt-NG-Setup.exe "-oextracted-installer" -y
+        if ($LASTEXITCODE -ne 0) {
+          throw "7z.exe failed to extract the signed installer with exit code $LASTEXITCODE"
+        }
+
+        $embeddedGUI = "extracted-installer/Picocrypt-NG.exe"
+        $embeddedCLI = "extracted-installer/Picocrypt-NG-cli.exe"
+        $embeddedUninstaller = "extracted-installer/Uninstall.exe"
+        foreach ($path in @($embeddedGUI, $embeddedCLI, $embeddedUninstaller)) {
+          if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+            throw "Signed installer is missing embedded binary: $path"
+          }
+          Assert-AuthenticodeSignature -Path $path
+        }
+
+        $portableHash = (Get-FileHash signed-release/Picocrypt-NG-portable.exe -Algorithm SHA256).Hash
+        $embeddedGUIHash = (Get-FileHash $embeddedGUI -Algorithm SHA256).Hash
+        if ($portableHash -ne $embeddedGUIHash) {
+          throw "Installer GUI payload does not match the signed portable artifact"
+        }
+        $cliHash = (Get-FileHash signed-release/Picocrypt-NG-cli.exe -Algorithm SHA256).Hash
+        $embeddedCLIHash = (Get-FileHash $embeddedCLI -Algorithm SHA256).Hash
+        if ($cliHash -ne $embeddedCLIHash) {
+          throw "Installer CLI payload does not match the signed CLI artifact"
+        }
+        $uninstallerHash = (Get-FileHash signpath-signed-uninstaller/Uninstall.exe -Algorithm SHA256).Hash
+        $embeddedUninstallerHash = (Get-FileHash $embeddedUninstaller -Algorithm SHA256).Hash
+        if ($uninstallerHash -ne $embeddedUninstallerHash) {
+          throw "Installer uninstaller payload does not match the signed Uninstall.exe artifact"
+        }
+
+    - name: Upload signed Windows artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.signpath_test && 'signed-windows-TEST-DO-NOT-PUBLISH' || inputs.signpath_release_dry_run && 'signed-windows-RELEASE-SIGNING-DRY-RUN-DO-NOT-PUBLISH' || 'signed-windows' }}
+        path: signed-release/
+        if-no-files-found: error
+        compression-level: 9
+        retention-days: 1
 
   release:
-    needs: build
-    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release) }}
+    needs: [build, sign]
+    if: ${{ github.ref == 'refs/heads/main' && !inputs.signpath_test && !inputs.signpath_release_dry_run && (github.event_name == 'push' || inputs.publish_release) }}
     runs-on: windows-2025
     environment: release
     permissions:
@@ -228,10 +542,10 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-    - name: Download artifact
+    - name: Download signed artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: build-windows
+        name: signed-windows
         path: artifacts/build-windows
 
     - name: Get version tag

--- a/dist/signpath/windows-binaries.xml
+++ b/dist/signpath/windows-binaries.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <zip-file>
+    <pe-file path="Picocrypt-NG-portable.exe">
+      <authenticode-sign
+        hash-algorithm="sha256"
+        description="Picocrypt NG"
+        description-url="https://github.com/Picocrypt-NG/Picocrypt-NG" />
+    </pe-file>
+    <pe-file path="Picocrypt-NG-cli.exe">
+      <authenticode-sign
+        hash-algorithm="sha256"
+        description="Picocrypt NG"
+        description-url="https://github.com/Picocrypt-NG/Picocrypt-NG" />
+    </pe-file>
+  </zip-file>
+</artifact-configuration>

--- a/dist/signpath/windows-installer.xml
+++ b/dist/signpath/windows-installer.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <zip-file>
+    <pe-file path="Picocrypt-NG-Setup.exe">
+      <authenticode-sign
+        hash-algorithm="sha256"
+        description="Picocrypt NG"
+        description-url="https://github.com/Picocrypt-NG/Picocrypt-NG" />
+    </pe-file>
+  </zip-file>
+</artifact-configuration>

--- a/dist/signpath/windows-legacy-cli.xml
+++ b/dist/signpath/windows-legacy-cli.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <zip-file>
+    <pe-file path="Picocrypt-NG-cli-Legacy.exe">
+      <authenticode-sign
+        hash-algorithm="sha256"
+        description="Picocrypt NG"
+        description-url="https://github.com/Picocrypt-NG/Picocrypt-NG" />
+    </pe-file>
+  </zip-file>
+</artifact-configuration>

--- a/dist/signpath/windows-uninstaller.xml
+++ b/dist/signpath/windows-uninstaller.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <zip-file>
+    <pe-file path="Uninstall.exe">
+      <authenticode-sign
+        hash-algorithm="sha256"
+        description="Picocrypt NG"
+        description-url="https://github.com/Picocrypt-NG/Picocrypt-NG" />
+    </pe-file>
+  </zip-file>
+</artifact-configuration>

--- a/dist/windows/installer.nsi
+++ b/dist/windows/installer.nsi
@@ -1,6 +1,10 @@
 ; Picocrypt-NG NSIS installer script (Phase 4 D-01 canonical source-of-truth).
 ;
 ; Build:   makensis -WX -V4 -DVERSION=<version> dist/windows/installer.nsi
+; Signed uninstaller round trip:
+;   makensis -WX -V4 -DVERSION=<version> -DEXPORT_UNINST dist/windows/installer.nsi
+;   sign dist/windows/Uninstall.exe externally
+;   makensis -WX -V4 -DVERSION=<version> -DIMPORT_UNINST dist/windows/installer.nsi
 ; Output:  dist/windows/Picocrypt-NG-Setup.exe (per OutFile, written adjacent to this script)
 ;
 ; Decision references:
@@ -71,8 +75,10 @@ VIAddVersionKey   "LegalCopyright"  "(c) ${COMPANYNAME}"
 !define MUI_FINISHPAGE_RUN_TEXT "Run Picocrypt-NG"
 !insertmacro MUI_PAGE_FINISH
 
+!ifndef IMPORT_UNINST
 !insertmacro MUI_UNPAGE_CONFIRM
 !insertmacro MUI_UNPAGE_INSTFILES
+!endif
 
 !insertmacro MUI_LANGUAGE "English"
 
@@ -85,9 +91,11 @@ Function .onInit
   SetRegView 64
 FunctionEnd
 
+!ifndef IMPORT_UNINST
 Function un.onInit
   SetRegView 64
 FunctionEnd
+!endif
 
 ; --- Section: Picocrypt-NG (required, hidden via leading dash, RO) ---
 Section "-Picocrypt-NG (required)" SecCore
@@ -132,7 +140,11 @@ Section "-Picocrypt-NG (required)" SecCore
   File "${__FILEDIR__}\..\..\images\pcv-icon.ico"
 
   ; --- Uninstaller writer ---
+!ifdef IMPORT_UNINST
+  File "/oname=Uninstall.exe" "${__FILEDIR__}\Uninstall.exe"
+!else
   WriteUninstaller "$INSTDIR\Uninstall.exe"
+!endif
 
   ; --- InstallDir record for re-install detection (D-24) ---
   WriteRegStr HKLM "Software\${APPNAME}" "InstallDir" "$INSTDIR"
@@ -154,6 +166,11 @@ Section "-Picocrypt-NG (required)" SecCore
   IntFmt $0 "0x%08X" $0
   WriteRegDWORD HKLM "${ARP}" "EstimatedSize" "$0"
 SectionEnd
+
+!ifdef EXPORT_UNINST
+  ; Export the generated uninstaller for external signing and -DIMPORT_UNINST.
+  !uninstfinalize 'echo copy /Y "%1" "${__FILEDIR__}\Uninstall.exe"&copy /Y "%1" "${__FILEDIR__}\Uninstall.exe" >nul'
+!endif
 
 ; --- Section: Associate .pcv files (D-21 six-key, D-22 capabilities, D-25 SHChangeNotify) ---
 Section "Associate .pcv files" SecAssoc
@@ -208,6 +225,7 @@ LangString DESC_SecStartMenu ${LANG_ENGLISH} "Create a Start Menu folder with Pi
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 ; --- Section: Uninstall (D-27 hybrid cleanup, D-26 SHChangeNotify, D-28 RMDir-if-empty) ---
+!ifndef IMPORT_UNINST
 Section "Uninstall"
   ; --- Hybrid cleanup — only our keys; preserve other apps' OpenWithProgids (D-27) ---
   DeleteRegKey   HKLM "Software\Classes\${PROGID}"
@@ -245,3 +263,4 @@ Section "Uninstall"
   ; --- Notify shell (D-26) ---
   System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0x0000, p 0, p 0)'
 SectionEnd
+!endif

--- a/src/internal/distmeta/distmeta_test.go
+++ b/src/internal/distmeta/distmeta_test.go
@@ -902,6 +902,31 @@ func TestWindowsNSISScript(t *testing.T) {
 		}
 	})
 
+	t.Run("external_uninstaller_signing_round_trip", func(t *testing.T) {
+		importBlock := regexp.MustCompile(`(?ms)!ifdef IMPORT_UNINST\s+File\s+"/oname=Uninstall\.exe"\s+"\$\{__FILEDIR__\}\\Uninstall\.exe"\s+!else\s+WriteUninstaller\s+"\$INSTDIR\\Uninstall\.exe"\s+!endif`).FindString(text)
+		if importBlock == "" {
+			t.Error("installer.nsi must import a signed Uninstall.exe instead of generating a new unsigned uninstaller on the final build")
+		}
+
+		exportBlock := regexp.MustCompile(`(?ms)!ifdef EXPORT_UNINST.*?!uninstfinalize.*?\$\{__FILEDIR__\}\\Uninstall\.exe.*?!endif`).FindString(text)
+		if exportBlock == "" {
+			t.Error("installer.nsi must export the generated Uninstall.exe for external SignPath signing")
+		}
+
+		guardedUnpages := regexp.MustCompile(`(?ms)!ifndef IMPORT_UNINST\s+!insertmacro MUI_UNPAGE_CONFIRM\s+!insertmacro MUI_UNPAGE_INSTFILES\s+!endif`).FindString(text)
+		if guardedUnpages == "" {
+			t.Error("uninstaller pages must be excluded when rebuilding the installer with the signed imported Uninstall.exe")
+		}
+		guardedUninit := regexp.MustCompile(`(?ms)!ifndef IMPORT_UNINST\s+Function un\.onInit.*?FunctionEnd\s+!endif`).FindString(text)
+		if guardedUninit == "" {
+			t.Error("un.onInit must be excluded when rebuilding the installer with the signed imported Uninstall.exe")
+		}
+		guardedUninstallSection := regexp.MustCompile(`(?ms)!ifndef IMPORT_UNINST\s+Section\s+"Uninstall".*?SectionEnd\s+!endif`).FindString(text)
+		if guardedUninstallSection == "" {
+			t.Error("the Uninstall section must be excluded when rebuilding the installer with the signed imported Uninstall.exe")
+		}
+	})
+
 	// --- Uninstaller block scoped assertions (D-27 hybrid cleanup) ---
 	uninstallBlock := regexp.MustCompile(`(?ms)Section\s+"Uninstall".*?SectionEnd`).FindString(text)
 	if uninstallBlock == "" {

--- a/src/internal/workflowpolicy/helpers_test.go
+++ b/src/internal/workflowpolicy/helpers_test.go
@@ -11,12 +11,30 @@ import (
 )
 
 type workflowDoc struct {
+	On          workflowTriggers       `yaml:"on"`
 	Permissions map[string]string      `yaml:"permissions"`
 	Jobs        map[string]workflowJob `yaml:"jobs"`
 }
 
+type workflowTriggers struct {
+	WorkflowDispatch workflowDispatch `yaml:"workflow_dispatch"`
+}
+
+type workflowDispatch struct {
+	Inputs map[string]workflowDispatchInput `yaml:"inputs"`
+}
+
+type workflowDispatchInput struct {
+	Description string `yaml:"description"`
+	Required    bool   `yaml:"required"`
+	Type        string `yaml:"type"`
+	Default     any    `yaml:"default"`
+}
+
 type workflowJob struct {
 	If              string            `yaml:"if"`
+	Needs           any               `yaml:"needs"`
+	TimeoutMinutes  int               `yaml:"timeout-minutes"`
 	ContinueOnError any               `yaml:"continue-on-error"`
 	Environment     any               `yaml:"environment"`
 	Permissions     map[string]string `yaml:"permissions"`

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -3,7 +3,9 @@ package workflowpolicy
 import (
 	"crypto/sha256"
 	"encoding/xml"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -96,12 +98,17 @@ func TestExternalGitHubActionsPinnedToFullSHAWithVersionComment(t *testing.T) {
 
 func TestReleaseJobsRequireMainBranchAndReleaseEnvironment(t *testing.T) {
 	const releaseGuard = "${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release) }}"
+	const signPathReleaseGuard = "${{ github.ref == 'refs/heads/main' && !inputs.signpath_test && !inputs.signpath_release_dry_run && (github.event_name == 'push' || inputs.publish_release) }}"
 
 	for _, tc := range releaseWorkflowCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			workflow := mustReadWorkflowDoc(t, tc.path)
 			releaseJob := mustJob(t, workflow, tc.job)
-			if releaseJob.If != releaseGuard {
+			wantGuard := releaseGuard
+			if tc.name == "build-windows" || tc.name == "build-windows-legacy" {
+				wantGuard = signPathReleaseGuard
+			}
+			if releaseJob.If != wantGuard {
 				t.Fatalf("release job if = %q, want guarded push or explicit manual release", releaseJob.If)
 			}
 			if got := releaseEnvironmentName(releaseJob.Environment); got != "release" {
@@ -290,6 +297,449 @@ func TestWindowsReleaseWorkflowPassesRootVersionToNSIS(t *testing.T) {
 		`makensis.exe`,
 		`"-DVERSION=$version"`,
 	)
+}
+
+func TestWindowsReleaseAuthenticodeSigningPrecedesPackagingAndSigstore(t *testing.T) {
+	workflow := mustReadWorkflowDoc(t, ".github/workflows/build-windows.yml")
+	buildJob := mustJob(t, workflow, "build")
+	unsignedUpload := mustStepNamed(t, buildJob, "Upload artifact")
+	if got := unsignedUpload.With["name"]; got != "unsigned-windows" {
+		t.Fatalf("unsigned Windows artifact name = %#v, want unsigned-windows", got)
+	}
+	if got := unsignedUpload.With["retention-days"]; got != 1 {
+		t.Fatalf("unsigned Windows artifact retention = %#v, want 1 day", got)
+	}
+
+	signJob := mustJob(t, workflow, "sign")
+
+	if signJob.If != "${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release || inputs.signpath_test || inputs.signpath_release_dry_run) }}" {
+		t.Fatalf("Windows SignPath job if = %q, want main release, test signing, or release-signing dry-run guard", signJob.If)
+	}
+	if signJob.TimeoutMinutes != 60 {
+		t.Fatalf("Windows SignPath job timeout = %d minutes, want 60 for three sequential requests", signJob.TimeoutMinutes)
+	}
+	if got := releaseEnvironmentName(signJob.Environment); got != "release" {
+		t.Fatalf("Windows SignPath job environment = %#v, want release", signJob.Environment)
+	}
+	mustPermission(t, signJob.Permissions, "actions", "read")
+	mustPermission(t, signJob.Permissions, "contents", "read")
+	if got := signJob.Env["SIGNPATH_PRODUCTION_CERTIFICATE_SHA256"]; got != "${{ vars.SIGNPATH_PRODUCTION_CERTIFICATE_SHA256 }}" {
+		t.Fatalf("production certificate trust anchor = %q, want protected GitHub variable", got)
+	}
+	if got := signJob.Env["SIGNPATH_SIGNING_POLICY_SLUG"]; got != "${{ inputs.signpath_test && 'test-signing' || 'release-signing' }}" {
+		t.Fatalf("Windows SignPath policy routing = %q, want explicit test/release policies", got)
+	}
+	if got := signJob.Env["SIGNPATH_TEST"]; got != "${{ inputs.signpath_test && 'true' || 'false' }}" {
+		t.Fatalf("Windows test-signing verification mode = %q, want exact boolean routing", got)
+	}
+	if _, ok := signJob.Permissions["contents"]; !ok {
+		t.Fatal("Windows SignPath job must declare contents: read explicitly")
+	}
+	validateMode := mustStepNamed(t, signJob, "Reject conflicting SignPath modes")
+	if validateMode.If != "${{ inputs.signpath_test && inputs.signpath_release_dry_run }}" {
+		t.Fatalf("Windows SignPath mode validation if = %q, want mutually exclusive test and release dry-run modes", validateMode.If)
+	}
+	mustContain(t, validateMode.Run, "cannot both be enabled")
+
+	orderedSigningSteps := []string{
+		"Download unsigned build artifact",
+		"Stage unsigned binaries for SignPath",
+		"Upload unsigned binaries for SignPath",
+		"Sign binaries with SignPath",
+		"Verify signed binaries before packaging",
+		"Export unsigned NSIS uninstaller",
+		"Upload unsigned uninstaller for SignPath",
+		"Sign uninstaller with SignPath",
+		"Verify signed uninstaller",
+		"Build NSIS installer from signed components",
+		"Upload unsigned installer for SignPath",
+		"Sign installer with SignPath",
+		"Verify final Authenticode artifacts",
+		"Upload signed Windows artifacts",
+	}
+	lastIndex := -1
+	for _, name := range orderedSigningSteps {
+		index := -1
+		for candidateIndex, step := range signJob.Steps {
+			if step.Name == name {
+				index = candidateIndex
+				break
+			}
+		}
+		if index < 0 {
+			t.Fatalf("Windows SignPath job is missing step %q", name)
+		}
+		if index <= lastIndex {
+			t.Fatalf("Windows SignPath step %q is out of order; want %s", name, strings.Join(orderedSigningSteps, " < "))
+		}
+		lastIndex = index
+	}
+
+	for _, tc := range []struct {
+		name              string
+		configurationSlug string
+		uploadStepID      string
+		outputDirectory   string
+	}{
+		{name: "Sign binaries with SignPath", configurationSlug: "windows-binaries", uploadStepID: "upload-signpath-binaries", outputDirectory: "signpath-signed-binaries"},
+		{name: "Sign uninstaller with SignPath", configurationSlug: "windows-uninstaller", uploadStepID: "upload-signpath-uninstaller", outputDirectory: "signpath-signed-uninstaller"},
+		{name: "Sign installer with SignPath", configurationSlug: "windows-installer", uploadStepID: "upload-signpath-installer", outputDirectory: "signpath-signed-installer"},
+	} {
+		step := mustStepNamed(t, signJob, tc.name)
+		if step.Uses != "signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd" {
+			t.Fatalf("%s action = %q, want reviewed SignPath v2.2 commit", tc.name, step.Uses)
+		}
+		for key, want := range map[string]any{
+			"api-token":                   "${{ secrets.SIGNPATH_API_TOKEN }}",
+			"organization-id":             "d6e78672-6bae-47d3-b2b8-fa464705b34e",
+			"project-slug":                "${{ vars.SIGNPATH_PROJECT_SLUG }}",
+			"signing-policy-slug":         "${{ env.SIGNPATH_SIGNING_POLICY_SLUG }}",
+			"artifact-configuration-slug": tc.configurationSlug,
+			"github-artifact-id":          "${{ steps." + tc.uploadStepID + ".outputs.artifact-id }}",
+			"wait-for-completion":         true,
+			"output-artifact-directory":   tc.outputDirectory,
+		} {
+			if got := step.With[key]; got != want {
+				t.Fatalf("%s input %s = %#v, want %#v", tc.name, key, got, want)
+			}
+		}
+	}
+
+	verifyFinal := mustStepNamed(t, signJob, "Verify final Authenticode artifacts")
+	mustContain(t, verifyFinal.Run, "Get-AuthenticodeSignature")
+	mustContain(t, verifyFinal.Run, "GetCertHashString")
+	mustContain(t, verifyFinal.Run, "SIGNPATH_PRODUCTION_CERTIFICATE_SHA256")
+	mustContain(t, verifyFinal.Run, "TimeStamperCertificate")
+	mustContain(t, verifyFinal.Run, "Picocrypt-NG-Setup.exe")
+	mustContain(t, verifyFinal.Run, "7z.exe")
+	mustContain(t, verifyFinal.Run, "Picocrypt-NG.exe")
+	mustContain(t, verifyFinal.Run, "Picocrypt-NG-cli.exe")
+	mustContain(t, verifyFinal.Run, "Uninstall.exe")
+	mustContain(t, verifyFinal.Run, "Get-FileHash")
+	for _, name := range []string{
+		"Verify signed binaries before packaging",
+		"Verify signed uninstaller",
+		"Verify final Authenticode artifacts",
+	} {
+		if got := mustStepNamed(t, signJob, name).ContinueOnError; got != nil && got != false {
+			t.Fatalf("Windows verification step %q continue-on-error = %#v, want blocking", name, got)
+		}
+	}
+
+	uploadSigned := mustStepNamed(t, signJob, "Upload signed Windows artifacts")
+	if got := uploadSigned.With["name"]; got != "${{ inputs.signpath_test && 'signed-windows-TEST-DO-NOT-PUBLISH' || inputs.signpath_release_dry_run && 'signed-windows-RELEASE-SIGNING-DRY-RUN-DO-NOT-PUBLISH' || 'signed-windows' }}" {
+		t.Fatalf("signed Windows artifact name = %#v, want visibly distinct test and release dry-run artifacts", got)
+	}
+	if got := uploadSigned.With["retention-days"]; got != 1 {
+		t.Fatalf("signed Windows artifact retention = %#v, want 1 day", got)
+	}
+
+	releaseJob := mustJob(t, workflow, "release")
+	needs, ok := releaseJob.Needs.([]any)
+	if !ok || len(needs) != 2 || needs[0] != "build" || needs[1] != "sign" {
+		t.Fatalf("Windows release needs = %#v, want [build sign] so unsigned artifacts cannot bypass SignPath", releaseJob.Needs)
+	}
+	mustContain(t, releaseJob.If, "!inputs.signpath_test")
+	mustContain(t, releaseJob.If, "!inputs.signpath_release_dry_run")
+	downloadSigned := mustStepNamed(t, releaseJob, "Download signed artifact")
+	if got := downloadSigned.With["name"]; got != "signed-windows" {
+		t.Fatalf("Windows release artifact name = %#v, want signed-windows", got)
+	}
+	orderedReleaseSteps := []string{"Download signed artifact", "Sign and attest artifacts", "Release"}
+	lastIndex = -1
+	for _, name := range orderedReleaseSteps {
+		index := -1
+		for candidateIndex, step := range releaseJob.Steps {
+			if step.Name == name {
+				index = candidateIndex
+				break
+			}
+		}
+		if index < 0 || index <= lastIndex {
+			t.Fatalf("Windows release steps must be ordered as %s", strings.Join(orderedReleaseSteps, " < "))
+		}
+		lastIndex = index
+	}
+}
+
+func TestWindowsLegacyReleaseUsesSignPathBeforeSigstore(t *testing.T) {
+	workflow := mustReadWorkflowDoc(t, ".github/workflows/build-windows-legacy.yml")
+	buildJob := mustJob(t, workflow, "build")
+	unsignedUpload := mustStepNamed(t, buildJob, "Upload artifact")
+	if got := unsignedUpload.With["name"]; got != "unsigned-windows-legacy" {
+		t.Fatalf("unsigned legacy artifact name = %#v, want unsigned-windows-legacy", got)
+	}
+	if got := unsignedUpload.With["retention-days"]; got != 1 {
+		t.Fatalf("unsigned legacy artifact retention = %#v, want 1 day", got)
+	}
+
+	signJob := mustJob(t, workflow, "sign")
+	if signJob.If != "${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.publish_release || inputs.signpath_test || inputs.signpath_release_dry_run) }}" {
+		t.Fatalf("legacy SignPath job if = %q, want main release, test signing, or release-signing dry-run guard", signJob.If)
+	}
+	if got := releaseEnvironmentName(signJob.Environment); got != "release" {
+		t.Fatalf("legacy SignPath job environment = %#v, want release", signJob.Environment)
+	}
+	mustPermission(t, signJob.Permissions, "actions", "read")
+	mustPermission(t, signJob.Permissions, "contents", "read")
+	if got := signJob.Env["SIGNPATH_PRODUCTION_CERTIFICATE_SHA256"]; got != "${{ vars.SIGNPATH_PRODUCTION_CERTIFICATE_SHA256 }}" {
+		t.Fatalf("legacy production certificate trust anchor = %q, want protected GitHub variable", got)
+	}
+	if got := signJob.Env["SIGNPATH_SIGNING_POLICY_SLUG"]; got != "${{ inputs.signpath_test && 'test-signing' || 'release-signing' }}" {
+		t.Fatalf("legacy SignPath policy routing = %q, want explicit test/release policies", got)
+	}
+	if got := signJob.Env["SIGNPATH_TEST"]; got != "${{ inputs.signpath_test && 'true' || 'false' }}" {
+		t.Fatalf("legacy test-signing verification mode = %q, want exact boolean routing", got)
+	}
+	validateMode := mustStepNamed(t, signJob, "Reject conflicting SignPath modes")
+	if validateMode.If != "${{ inputs.signpath_test && inputs.signpath_release_dry_run }}" {
+		t.Fatalf("legacy SignPath mode validation if = %q, want mutually exclusive test and release dry-run modes", validateMode.If)
+	}
+	mustContain(t, validateMode.Run, "cannot both be enabled")
+
+	signStep := mustStepNamed(t, signJob, "Sign legacy CLI with SignPath")
+	if signStep.Uses != "signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd" {
+		t.Fatalf("legacy SignPath action = %q, want reviewed SignPath v2.2 commit", signStep.Uses)
+	}
+	for key, want := range map[string]any{
+		"api-token":                   "${{ secrets.SIGNPATH_API_TOKEN }}",
+		"organization-id":             "d6e78672-6bae-47d3-b2b8-fa464705b34e",
+		"project-slug":                "${{ vars.SIGNPATH_PROJECT_SLUG }}",
+		"signing-policy-slug":         "${{ env.SIGNPATH_SIGNING_POLICY_SLUG }}",
+		"artifact-configuration-slug": "windows-legacy-cli",
+		"github-artifact-id":          "${{ steps.upload-signpath-legacy.outputs.artifact-id }}",
+		"wait-for-completion":         true,
+		"output-artifact-directory":   "signpath-signed-legacy",
+	} {
+		if got := signStep.With[key]; got != want {
+			t.Fatalf("legacy SignPath input %s = %#v, want %#v", key, got, want)
+		}
+	}
+
+	verifyStep := mustStepNamed(t, signJob, "Verify legacy Authenticode signature")
+	mustContain(t, verifyStep.Run, "Get-AuthenticodeSignature")
+	mustContain(t, verifyStep.Run, "GetCertHashString")
+	mustContain(t, verifyStep.Run, "SIGNPATH_PRODUCTION_CERTIFICATE_SHA256")
+	mustContain(t, verifyStep.Run, "TimeStamperCertificate")
+	if got := verifyStep.ContinueOnError; got != nil && got != false {
+		t.Fatalf("legacy verification continue-on-error = %#v, want blocking", got)
+	}
+	uploadSigned := mustStepNamed(t, signJob, "Upload signed Windows legacy artifact")
+	if got := uploadSigned.With["name"]; got != "${{ inputs.signpath_test && 'signed-windows-legacy-TEST-DO-NOT-PUBLISH' || inputs.signpath_release_dry_run && 'signed-windows-legacy-RELEASE-SIGNING-DRY-RUN-DO-NOT-PUBLISH' || 'signed-windows-legacy' }}" {
+		t.Fatalf("signed legacy artifact name = %#v, want visibly distinct test and release dry-run artifacts", got)
+	}
+	if got := uploadSigned.With["retention-days"]; got != 1 {
+		t.Fatalf("signed legacy artifact retention = %#v, want 1 day", got)
+	}
+
+	releaseJob := mustJob(t, workflow, "release")
+	needs, ok := releaseJob.Needs.([]any)
+	if !ok || len(needs) != 2 || needs[0] != "build" || needs[1] != "sign" {
+		t.Fatalf("legacy release needs = %#v, want [build sign]", releaseJob.Needs)
+	}
+	mustContain(t, releaseJob.If, "!inputs.signpath_test")
+	mustContain(t, releaseJob.If, "!inputs.signpath_release_dry_run")
+	downloadStep := mustStepNamed(t, releaseJob, "Download signed artifact")
+	if got := downloadStep.With["name"]; got != "signed-windows-legacy" {
+		t.Fatalf("legacy signed artifact name = %#v, want signed-windows-legacy", got)
+	}
+}
+
+func TestWindowsSignPathReleaseDryRunUsesProductionVerificationWithoutPublishing(t *testing.T) {
+	for _, path := range []string{
+		".github/workflows/build-windows.yml",
+		".github/workflows/build-windows-legacy.yml",
+	} {
+		t.Run(path, func(t *testing.T) {
+			workflow := mustReadWorkflowDoc(t, path)
+			input, ok := workflow.On.WorkflowDispatch.Inputs["signpath_release_dry_run"]
+			if !ok {
+				t.Fatal("workflow_dispatch must expose signpath_release_dry_run so the production certificate path can be tested without publishing")
+			}
+			if input.Required || input.Default != false || input.Type != "boolean" {
+				t.Fatalf("signpath_release_dry_run = %#v, want optional boolean defaulting to false", input)
+			}
+			mustContain(t, input.Description, "Never publishes a GitHub release")
+
+			signJob := mustJob(t, workflow, "sign")
+			mustContain(t, signJob.If, "inputs.signpath_release_dry_run")
+			if got := signJob.Env["SIGNPATH_SIGNING_POLICY_SLUG"]; got != "${{ inputs.signpath_test && 'test-signing' || 'release-signing' }}" {
+				t.Fatalf("release dry-run policy route = %q, want release-signing whenever signpath_test is false", got)
+			}
+			if got := signJob.Env["SIGNPATH_TEST"]; got != "${{ inputs.signpath_test && 'true' || 'false' }}" {
+				t.Fatalf("release dry-run verification mode = %q, want production verification whenever signpath_test is false", got)
+			}
+
+			releaseJob := mustJob(t, workflow, "release")
+			mustContain(t, releaseJob.If, "!inputs.signpath_release_dry_run")
+		})
+	}
+}
+
+type signPathArtifactConfiguration struct {
+	XMLName xml.Name           `xml:"artifact-configuration"`
+	ZIP     signPathZIPElement `xml:"zip-file"`
+}
+
+type signPathZIPElement struct {
+	PEFiles []signPathPEFile `xml:"pe-file"`
+}
+
+type signPathPEFile struct {
+	Path string                   `xml:"path,attr"`
+	Sign signPathAuthenticodeSign `xml:"authenticode-sign"`
+}
+
+type signPathAuthenticodeSign struct {
+	HashAlgorithm  string `xml:"hash-algorithm,attr"`
+	Description    string `xml:"description,attr"`
+	DescriptionURL string `xml:"description-url,attr"`
+}
+
+func mustAllowOnlySignPathElements(t *testing.T, content, namespace string, wantFiles []string) {
+	t.Helper()
+
+	decoder := xml.NewDecoder(strings.NewReader(content))
+	stack := make([]xml.Name, 0, 4)
+	counts := make(map[string]int)
+	peIndex := 0
+
+	checkAttributes := func(element xml.StartElement, want map[string]string, allowDefaultNamespace bool) {
+		t.Helper()
+
+		got := make(map[string]string)
+		for _, attribute := range element.Attr {
+			if allowDefaultNamespace && attribute.Name.Space == "" && attribute.Name.Local == "xmlns" {
+				if attribute.Value != namespace {
+					t.Fatalf("%s default namespace = %q, want %q", element.Name.Local, attribute.Value, namespace)
+				}
+				continue
+			}
+			if attribute.Name.Space != "" {
+				t.Fatalf("%s has unexpected namespaced attribute %s:%s", element.Name.Local, attribute.Name.Space, attribute.Name.Local)
+			}
+			got[attribute.Name.Local] = attribute.Value
+		}
+		if len(got) != len(want) {
+			t.Fatalf("%s attributes = %#v, want exactly %#v", element.Name.Local, got, want)
+		}
+		for name, value := range want {
+			if got[name] != value {
+				t.Fatalf("%s attribute %s = %q, want %q", element.Name.Local, name, got[name], value)
+			}
+		}
+	}
+
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("decode SignPath XML token: %v", err)
+		}
+
+		switch token := token.(type) {
+		case xml.StartElement:
+			if token.Name.Space != namespace {
+				t.Fatalf("element %s namespace = %q, want %q", token.Name.Local, token.Name.Space, namespace)
+			}
+			parent := ""
+			if len(stack) > 0 {
+				parent = stack[len(stack)-1].Local
+			}
+			counts[token.Name.Local]++
+			switch token.Name.Local {
+			case "artifact-configuration":
+				if parent != "" || counts[token.Name.Local] != 1 {
+					t.Fatal("artifact-configuration must be the single root element")
+				}
+				checkAttributes(token, map[string]string{}, true)
+			case "zip-file":
+				if parent != "artifact-configuration" || counts[token.Name.Local] != 1 {
+					t.Fatal("zip-file must be the single artifact-configuration child")
+				}
+				checkAttributes(token, map[string]string{}, false)
+			case "pe-file":
+				if parent != "zip-file" || peIndex >= len(wantFiles) {
+					t.Fatalf("unexpected pe-file at index %d", peIndex)
+				}
+				checkAttributes(token, map[string]string{"path": wantFiles[peIndex]}, false)
+				peIndex++
+			case "authenticode-sign":
+				if parent != "pe-file" || counts[token.Name.Local] > len(wantFiles) {
+					t.Fatal("each pe-file must contain one authenticode-sign directive")
+				}
+				checkAttributes(token, map[string]string{
+					"hash-algorithm":  "sha256",
+					"description":     "Picocrypt NG",
+					"description-url": "https://github.com/Picocrypt-NG/Picocrypt-NG",
+				}, false)
+			default:
+				t.Fatalf("unexpected SignPath artifact configuration element %q", token.Name.Local)
+			}
+			stack = append(stack, token.Name)
+		case xml.EndElement:
+			if len(stack) == 0 || stack[len(stack)-1] != token.Name {
+				t.Fatalf("unexpected closing element %q", token.Name.Local)
+			}
+			stack = stack[:len(stack)-1]
+		case xml.CharData:
+			if strings.TrimSpace(string(token)) != "" {
+				t.Fatalf("unexpected text in SignPath artifact configuration: %q", string(token))
+			}
+		case xml.ProcInst:
+			if token.Target != "xml" {
+				t.Fatalf("unexpected XML processing instruction %q", token.Target)
+			}
+		case xml.Directive:
+			t.Fatalf("unexpected XML directive %q", string(token))
+		}
+	}
+
+	if len(stack) != 0 || counts["artifact-configuration"] != 1 || counts["zip-file"] != 1 || peIndex != len(wantFiles) || counts["authenticode-sign"] != len(wantFiles) {
+		t.Fatalf("SignPath XML tree counts = %#v, PE files = %d/%d", counts, peIndex, len(wantFiles))
+	}
+}
+
+func TestSignPathArtifactConfigurationsAllowlistOnlyReleaseExecutables(t *testing.T) {
+	const namespace = "http://signpath.io/artifact-configuration/v1"
+	const projectURL = "https://github.com/Picocrypt-NG/Picocrypt-NG"
+
+	for _, tc := range []struct {
+		path      string
+		wantFiles []string
+	}{
+		{path: "dist/signpath/windows-binaries.xml", wantFiles: []string{"Picocrypt-NG-portable.exe", "Picocrypt-NG-cli.exe"}},
+		{path: "dist/signpath/windows-uninstaller.xml", wantFiles: []string{"Uninstall.exe"}},
+		{path: "dist/signpath/windows-installer.xml", wantFiles: []string{"Picocrypt-NG-Setup.exe"}},
+		{path: "dist/signpath/windows-legacy-cli.xml", wantFiles: []string{"Picocrypt-NG-cli-Legacy.exe"}},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			content := mustReadRepoFile(t, tc.path)
+			mustAllowOnlySignPathElements(t, content, namespace, tc.wantFiles)
+
+			var configuration signPathArtifactConfiguration
+			if err := xml.Unmarshal([]byte(content), &configuration); err != nil {
+				t.Fatalf("parse SignPath artifact configuration: %v", err)
+			}
+			if configuration.XMLName.Space != namespace {
+				t.Fatalf("artifact configuration namespace = %q, want %q", configuration.XMLName.Space, namespace)
+			}
+			if len(configuration.ZIP.PEFiles) != len(tc.wantFiles) {
+				t.Fatalf("PE file count = %d, want %d exact release files", len(configuration.ZIP.PEFiles), len(tc.wantFiles))
+			}
+			for i, wantFile := range tc.wantFiles {
+				pe := configuration.ZIP.PEFiles[i]
+				if pe.Path != wantFile {
+					t.Fatalf("PE file %d path = %q, want %q", i, pe.Path, wantFile)
+				}
+				if pe.Sign.HashAlgorithm != "sha256" || pe.Sign.Description != "Picocrypt NG" || pe.Sign.DescriptionURL != projectURL {
+					t.Fatalf("PE file %q Authenticode settings = %#v, want sha256 and Picocrypt NG project identity", pe.Path, pe.Sign)
+				}
+			}
+		})
+	}
 }
 
 func TestLinuxUPXDownloadsRemainChecksumGated(t *testing.T) {


### PR DESCRIPTION
## Summary

- submit the Windows GUI, current CLI, legacy CLI, NSIS uninstaller, and final installer to SignPath using the reviewed action pinned to the v2.2 commit
- define four exact-path SignPath artifact configurations so no unexpected files are selected for signing
- export the generated NSIS uninstaller, sign it externally, import it back into the installer, and then sign the final installer
- preserve the existing Sigstore bundle and GitHub provenance flow after Authenticode signing
- add separate main-only dry-run modes for the self-signed `test-signing` policy and the real `release-signing` policy; neither mode can publish a GitHub release
- fail closed on missing or invalid signatures, unexpected artifact sets, missing production timestamps, certificate fingerprint mismatches, and embedded-file hash mismatches
- enforce the release contract in workflow-policy and distribution-metadata tests

## Why

The Windows 2.18 PE release assets are not Authenticode-signed. Picocrypt NG has been accepted into the SignPath Foundation program, so the 2.19 release path should publish Windows artifacts only after SignPath signing and local verification.

NSIS creates a separate `Uninstall.exe` inside the installer. Signing only the portable executable, CLI, and outer installer would leave that embedded executable unsigned. This PR therefore implements the complete export, sign, import, package, and final-sign round trip.

## Release safety

- this PR does not change `VERSION` and cannot publish 2.19
- SignPath jobs run only for `main` release events or explicit manual signing requests
- the GitHub `release` environment now has a custom deployment policy allowing only the `main` branch; it must remain restricted before the SignPath token is installed or rotated
- `signpath_test` selects the self-signed test policy and uploads visibly named `TEST-DO-NOT-PUBLISH` artifacts
- `signpath_release_dry_run` selects the production release policy, requires all production trust, timestamp, and certificate checks, uploads visibly named `RELEASE-SIGNING-DRY-RUN-DO-NOT-PUBLISH` artifacts, and is explicitly excluded from release jobs
- conflicting test and release dry-run inputs fail before any signing request
- unsigned, test, dry-run, and intermediate GitHub artifacts are retained for one day
- release jobs download only the production signed artifact names
- the existing Sigstore signing and GitHub provenance steps still run on the final Authenticode-signed bytes

## Validation

- `go test -count=1 -tags migrated_fynedo ./...`
- `go test -count=1 ./internal/workflowpolicy ./internal/distmeta`
- `golangci-lint run --output.text.path /dev/null --output.json.path stdout` — 0 issues
- `actionlint`
- `git diff --check`
- all four artifact configurations validated against the current public SignPath XSD with .NET `XmlSchemaSet`
- `gitleaks` scan — no leaks
- real local Authenticode and NSIS integration run using the released Picocrypt NG 2.18 PE files, NSIS, `osslsigncode`, a temporary code-signing certificate, and 7-Zip:
  - signed the real GUI and CLI binaries
  - exported and signed the real NSIS uninstaller
  - imported the signed uninstaller, then built and signed the final installer
  - extracted the final installer and verified that all three embedded executables were byte-for-byte identical to their signed inputs
  - verified every Authenticode signature

The local integration validates the executable and NSIS mechanics. It is not presented as a SignPath service test.

The workflow syntax and expression behavior were checked against current GitHub Actions documentation, including boolean `workflow_dispatch` inputs, `jobs.if`, `needs`, expression truthiness, job environments, permissions, and named artifact transfer between jobs.

## SignPath rollout gate

Before any 2.19 version bump:

1. create the four artifact configurations in the SignPath project with slugs `windows-binaries`, `windows-uninstaller`, `windows-installer`, and `windows-legacy-cli`
2. add the predefined GitHub.com trusted build system to the SignPath organization and project, install the SignPath GitHub App for this repository, and configure the project repository URL
3. require trusted-build and origin verification in the Open Source Code Signing policies; restrict `release-signing` origin to branch `main` and use release approval if the Foundation setup supports it
4. verify that the GitHub `release` environment still allows only branch `main`; this policy is already configured and currently contains no secrets or variables
5. configure the `release` environment secret `SIGNPATH_API_TOKEN` for a least-privilege CI submitter and variable `SIGNPATH_PROJECT_SLUG`
6. merge this workflow change without changing `VERSION`
7. manually dispatch both Windows workflows on `main` with `signpath_test=true`, `signpath_release_dry_run=false`, and `publish_release=false`; inspect the real test-policy requests and signed Actions artifacts
8. let SignPath review the setup and issue/import the production certificate
9. configure `SIGNPATH_PRODUCTION_CERTIFICATE_SHA256` from the issued certificate
10. manually dispatch both workflows with `signpath_test=false`, `signpath_release_dry_run=true`, and `publish_release=false`; verify the real release policy, Windows trust, timestamps, certificate fingerprint, full NSIS chain, and non-publishing artifact names
11. only after both dry-run modes pass, change `VERSION` for 2.19

The self-signed test certificate is expected to be untrusted by Windows. The test path checks for a real, structurally valid Authenticode signature; only the production dry-run and release paths require Windows trust, a timestamp, and the pinned certificate fingerprint.

The manual test dispatch validates the SignPath service integration. A later production dry run and VERSION release are separate trusted builds, not resubmissions of the exact test artifact. SignPath supports direct `release-signing` requests; exact release-candidate promotion through the optional resubmit API would be a separate design.

## References

- [GitHub Actions workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
- [GitHub Actions expressions](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions)
- [GitHub deployment environments](https://docs.github.com/en/rest/deployments/environments)
- [SignPath GitHub trusted build system](https://docs.signpath.io/trusted-build-systems/github)
- [SignPath artifact configuration syntax](https://docs.signpath.io/artifact-configuration/syntax)
- [SignPath signing and resubmission flow](https://docs.signpath.io/signing-code)
- [SignPath test and release certificates](https://docs.signpath.io/managing-certificates)
- [SignPath project and signing policies](https://docs.signpath.io/projects)
- [NSIS external uninstaller signing](https://nsis.sourceforge.io/Signing_an_Uninstaller_externally)