### PR TITLE
ci: harden SignPath dry-runs and Foundation configs

### DIFF
--- a/.github/workflows/build-windows-legacy.yml
+++ b/.github/workflows/build-windows-legacy.yml
@@ -22,7 +22,7 @@ on:
         type: boolean
         default: false
       signpath_release_dry_run:
-        description: "Submit the legacy CLI to SignPath with the release policy for end-to-end validation. Never publishes a GitHub release."
+        description: "Validate the SignPath release policy without uploading signed output or publishing a GitHub release."
         required: false
         type: boolean
         default: false
@@ -206,9 +206,10 @@ jobs:
         }
 
     - name: Upload signed Windows legacy artifact
+      if: ${{ !inputs.signpath_release_dry_run }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: ${{ inputs.signpath_test && 'signed-windows-legacy-TEST-DO-NOT-PUBLISH' || inputs.signpath_release_dry_run && 'signed-windows-legacy-RELEASE-SIGNING-DRY-RUN-DO-NOT-PUBLISH' || 'signed-windows-legacy' }}
+        name: ${{ inputs.signpath_test && 'signed-windows-legacy-TEST-DO-NOT-PUBLISH' || 'signed-windows-legacy' }}
         path: signpath-signed-legacy/Picocrypt-NG-cli-Legacy.exe
         if-no-files-found: error
         compression-level: 9

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -22,7 +22,7 @@ on:
         type: boolean
         default: false
       signpath_release_dry_run:
-        description: "Submit artifacts to SignPath with the release policy for end-to-end validation. Never publishes a GitHub release."
+        description: "Validate the SignPath release policy without uploading signed output or publishing a GitHub release."
         required: false
         type: boolean
         default: false
@@ -522,9 +522,10 @@ jobs:
         }
 
     - name: Upload signed Windows artifacts
+      if: ${{ !inputs.signpath_release_dry_run }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: ${{ inputs.signpath_test && 'signed-windows-TEST-DO-NOT-PUBLISH' || inputs.signpath_release_dry_run && 'signed-windows-RELEASE-SIGNING-DRY-RUN-DO-NOT-PUBLISH' || 'signed-windows' }}
+        name: ${{ inputs.signpath_test && 'signed-windows-TEST-DO-NOT-PUBLISH' || 'signed-windows' }}
         path: signed-release/
         if-no-files-found: error
         compression-level: 9

--- a/dist/signpath/windows-binaries.xml
+++ b/dist/signpath/windows-binaries.xml
@@ -3,15 +3,11 @@
   <zip-file>
     <pe-file path="Picocrypt-NG-portable.exe">
       <authenticode-sign
-        hash-algorithm="sha256"
-        description="Picocrypt NG"
-        description-url="https://github.com/Picocrypt-NG/Picocrypt-NG" />
+        hash-algorithm="sha256" />
     </pe-file>
     <pe-file path="Picocrypt-NG-cli.exe">
       <authenticode-sign
-        hash-algorithm="sha256"
-        description="Picocrypt NG"
-        description-url="https://github.com/Picocrypt-NG/Picocrypt-NG" />
+        hash-algorithm="sha256" />
     </pe-file>
   </zip-file>
 </artifact-configuration>

--- a/dist/signpath/windows-installer.xml
+++ b/dist/signpath/windows-installer.xml
@@ -3,9 +3,7 @@
   <zip-file>
     <pe-file path="Picocrypt-NG-Setup.exe">
       <authenticode-sign
-        hash-algorithm="sha256"
-        description="Picocrypt NG"
-        description-url="https://github.com/Picocrypt-NG/Picocrypt-NG" />
+        hash-algorithm="sha256" />
     </pe-file>
   </zip-file>
 </artifact-configuration>

--- a/dist/signpath/windows-legacy-cli.xml
+++ b/dist/signpath/windows-legacy-cli.xml
@@ -3,9 +3,7 @@
   <zip-file>
     <pe-file path="Picocrypt-NG-cli-Legacy.exe">
       <authenticode-sign
-        hash-algorithm="sha256"
-        description="Picocrypt NG"
-        description-url="https://github.com/Picocrypt-NG/Picocrypt-NG" />
+        hash-algorithm="sha256" />
     </pe-file>
   </zip-file>
 </artifact-configuration>

--- a/dist/signpath/windows-uninstaller.xml
+++ b/dist/signpath/windows-uninstaller.xml
@@ -3,9 +3,7 @@
   <zip-file>
     <pe-file path="Uninstall.exe">
       <authenticode-sign
-        hash-algorithm="sha256"
-        description="Picocrypt NG"
-        description-url="https://github.com/Picocrypt-NG/Picocrypt-NG" />
+        hash-algorithm="sha256" />
     </pe-file>
   </zip-file>
 </artifact-configuration>

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -427,8 +427,8 @@ func TestWindowsReleaseAuthenticodeSigningPrecedesPackagingAndSigstore(t *testin
 	}
 
 	uploadSigned := mustStepNamed(t, signJob, "Upload signed Windows artifacts")
-	if got := uploadSigned.With["name"]; got != "${{ inputs.signpath_test && 'signed-windows-TEST-DO-NOT-PUBLISH' || inputs.signpath_release_dry_run && 'signed-windows-RELEASE-SIGNING-DRY-RUN-DO-NOT-PUBLISH' || 'signed-windows' }}" {
-		t.Fatalf("signed Windows artifact name = %#v, want visibly distinct test and release dry-run artifacts", got)
+	if got := uploadSigned.With["name"]; got != "${{ inputs.signpath_test && 'signed-windows-TEST-DO-NOT-PUBLISH' || 'signed-windows' }}" {
+		t.Fatalf("signed Windows artifact name = %#v, want visibly distinct self-signed test output", got)
 	}
 	if got := uploadSigned.With["retention-days"]; got != 1 {
 		t.Fatalf("signed Windows artifact retention = %#v, want 1 day", got)
@@ -525,8 +525,8 @@ func TestWindowsLegacyReleaseUsesSignPathBeforeSigstore(t *testing.T) {
 		t.Fatalf("legacy verification continue-on-error = %#v, want blocking", got)
 	}
 	uploadSigned := mustStepNamed(t, signJob, "Upload signed Windows legacy artifact")
-	if got := uploadSigned.With["name"]; got != "${{ inputs.signpath_test && 'signed-windows-legacy-TEST-DO-NOT-PUBLISH' || inputs.signpath_release_dry_run && 'signed-windows-legacy-RELEASE-SIGNING-DRY-RUN-DO-NOT-PUBLISH' || 'signed-windows-legacy' }}" {
-		t.Fatalf("signed legacy artifact name = %#v, want visibly distinct test and release dry-run artifacts", got)
+	if got := uploadSigned.With["name"]; got != "${{ inputs.signpath_test && 'signed-windows-legacy-TEST-DO-NOT-PUBLISH' || 'signed-windows-legacy' }}" {
+		t.Fatalf("signed legacy artifact name = %#v, want visibly distinct self-signed test output", got)
 	}
 	if got := uploadSigned.With["retention-days"]; got != 1 {
 		t.Fatalf("signed legacy artifact retention = %#v, want 1 day", got)
@@ -546,12 +546,15 @@ func TestWindowsLegacyReleaseUsesSignPathBeforeSigstore(t *testing.T) {
 }
 
 func TestWindowsSignPathReleaseDryRunUsesProductionVerificationWithoutPublishing(t *testing.T) {
-	for _, path := range []string{
-		".github/workflows/build-windows.yml",
-		".github/workflows/build-windows-legacy.yml",
+	for _, tc := range []struct {
+		path             string
+		signedUploadStep string
+	}{
+		{path: ".github/workflows/build-windows.yml", signedUploadStep: "Upload signed Windows artifacts"},
+		{path: ".github/workflows/build-windows-legacy.yml", signedUploadStep: "Upload signed Windows legacy artifact"},
 	} {
-		t.Run(path, func(t *testing.T) {
-			workflow := mustReadWorkflowDoc(t, path)
+		t.Run(tc.path, func(t *testing.T) {
+			workflow := mustReadWorkflowDoc(t, tc.path)
 			input, ok := workflow.On.WorkflowDispatch.Inputs["signpath_release_dry_run"]
 			if !ok {
 				t.Fatal("workflow_dispatch must expose signpath_release_dry_run so the production certificate path can be tested without publishing")
@@ -559,7 +562,7 @@ func TestWindowsSignPathReleaseDryRunUsesProductionVerificationWithoutPublishing
 			if input.Required || input.Default != false || input.Type != "boolean" {
 				t.Fatalf("signpath_release_dry_run = %#v, want optional boolean defaulting to false", input)
 			}
-			mustContain(t, input.Description, "Never publishes a GitHub release")
+			mustContain(t, input.Description, "without uploading signed output or publishing a GitHub release")
 
 			signJob := mustJob(t, workflow, "sign")
 			mustContain(t, signJob.If, "inputs.signpath_release_dry_run")
@@ -568,6 +571,10 @@ func TestWindowsSignPathReleaseDryRunUsesProductionVerificationWithoutPublishing
 			}
 			if got := signJob.Env["SIGNPATH_TEST"]; got != "${{ inputs.signpath_test && 'true' || 'false' }}" {
 				t.Fatalf("release dry-run verification mode = %q, want production verification whenever signpath_test is false", got)
+			}
+			uploadSigned := mustStepNamed(t, signJob, tc.signedUploadStep)
+			if uploadSigned.If != "${{ !inputs.signpath_release_dry_run }}" {
+				t.Fatalf("release dry-run signed artifact upload if = %q, want production-signed dry-run output to remain inside the job", uploadSigned.If)
 			}
 
 			releaseJob := mustJob(t, workflow, "release")

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -678,9 +678,7 @@ func mustAllowOnlySignPathElements(t *testing.T, content, namespace string, want
 					t.Fatal("each pe-file must contain one authenticode-sign directive")
 				}
 				checkAttributes(token, map[string]string{
-					"hash-algorithm":  "sha256",
-					"description":     "Picocrypt NG",
-					"description-url": "https://github.com/Picocrypt-NG/Picocrypt-NG",
+					"hash-algorithm": "sha256",
 				}, false)
 			default:
 				t.Fatalf("unexpected SignPath artifact configuration element %q", token.Name.Local)
@@ -711,7 +709,6 @@ func mustAllowOnlySignPathElements(t *testing.T, content, namespace string, want
 
 func TestSignPathArtifactConfigurationsAllowlistOnlyReleaseExecutables(t *testing.T) {
 	const namespace = "http://signpath.io/artifact-configuration/v1"
-	const projectURL = "https://github.com/Picocrypt-NG/Picocrypt-NG"
 
 	for _, tc := range []struct {
 		path      string
@@ -741,8 +738,8 @@ func TestSignPathArtifactConfigurationsAllowlistOnlyReleaseExecutables(t *testin
 				if pe.Path != wantFile {
 					t.Fatalf("PE file %d path = %q, want %q", i, pe.Path, wantFile)
 				}
-				if pe.Sign.HashAlgorithm != "sha256" || pe.Sign.Description != "Picocrypt NG" || pe.Sign.DescriptionURL != projectURL {
-					t.Fatalf("PE file %q Authenticode settings = %#v, want sha256 and Picocrypt NG project identity", pe.Path, pe.Sign)
+				if pe.Sign.HashAlgorithm != "sha256" || pe.Sign.Description != "" || pe.Sign.DescriptionURL != "" {
+					t.Fatalf("PE file %q Authenticode settings = %#v, want sha256 with subscription-managed identity", pe.Path, pe.Sign)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

- keep production-signed dry-run output inside the signing job instead of uploading it as a downloadable GitHub Actions artifact
- keep self-signed test artifacts and normal release artifacts unchanged
- remove Authenticode description overrides from all four SignPath configurations so the Foundation subscription can apply its managed watermark
- enforce both contracts in workflow-policy tests

## Why

A production dry-run correctly avoided creating a GitHub Release, but still uploaded fully production-signed executables as a one-day Actions artifact. In a public repository, signed-in users with read access can download workflow artifacts, so the output was not private despite its name.

During live SignPath setup, the Foundation tenant rejected the description attribute because it would override the automatically generated subscription watermark. The generic SignPath schema permits that optional attribute, but this Open Source Code Signing subscription applies a stricter policy. The repository configurations now use only explicit SHA-256 signing directives and match the four configurations accepted as VALID by the live tenant.

## Validation

- TDD red/green: workflow-policy tests failed on the exposed dry-run upload before its guards were added
- TDD red/green: the SignPath configuration test failed on all four watermark overrides before the XML fix
- live SignPath validation: windows-binaries, windows-uninstaller, windows-installer, and windows-legacy-cli were created and report VALID
- actionlint .github/workflows/build-windows.yml .github/workflows/build-windows-legacy.yml
- GOMAXPROCS=2 go test -p 1 -count=1 ./internal/workflowpolicy
- git diff --check

The full Go suite was intentionally not repeated after the workstation OOM event. Local verification was limited to the small workflow-policy package and was run sequentially.