### PR TITLE
feat(ui): prepare desktop localization foundation

### DIFF
--- a/.github/workflows/android-instrumented.yml
+++ b/.github/workflows/android-instrumented.yml
@@ -114,6 +114,9 @@ jobs:
         # the 64-bit x86_64 gomobile/JNI library in the extended crypto scope.
         api-level: 36
         arch: x86_64
+        # Keep the manual target-SDK suite within the same hosted-runner AVD
+        # disk budget as the mandatory pull-request gate.
+        disk-size: 2048M
         disable-animations: true
         # -memory 6144: the Argon2id KDF allocates 1 GiB per operation
         # (src/internal/crypto/kdf.go); the runner's default ~2.5 GiB emulator OOMs

--- a/.github/workflows/pr-test-build-android.yml
+++ b/.github/workflows/pr-test-build-android.yml
@@ -123,6 +123,10 @@ jobs:
         api-level: 24
         target: google_apis
         arch: x86_64
+        # Bound the writable AVD partition. The emulator default exceeds the
+        # free disk left on current hosted runners after the Android builds.
+        # These on-device fixtures are deliberately small, so 2048M is ample.
+        disk-size: 2048M
         disable-animations: true
         # -memory 3583 keeps all guest RAM below QEMU's 3.5 GiB split threshold;
         # API 24 stalled when 4/6 GiB configurations mapped the excess above 4 GiB.
@@ -141,6 +145,9 @@ jobs:
         api-level: 36
         target: default
         arch: x86_64
+        # Keep the target-SDK gate bootable under the same hosted-runner disk
+        # budget as the Android 7 compatibility gate above.
+        disk-size: 2048M
         disable-animations: true
         # -memory 6144: the Argon2id KDF allocates 1 GiB per operation
         # (src/internal/crypto/kdf.go); the runner's default ~2.5 GiB emulator OOMs

--- a/docs/localization/TRANSLATION_GUIDE.md
+++ b/docs/localization/TRANSLATION_GUIDE.md
@@ -55,6 +55,7 @@ Use these sources before adding or changing localization mechanics:
 
 - go-i18n runtime localization: <https://github.com/nicksnyder/go-i18n>
 - Fyne app preferences and widgets: <https://docs.fyne.io/>
+- Fyne custom theme API: <https://docs.fyne.io/extend/custom-theme/>
 - Android localization: <https://developer.android.com/guide/topics/resources/localization>
 - Android string resources and plurals: <https://developer.android.com/guide/topics/resources/string-resource>
 - Android language and layout support: <https://developer.android.com/training/basics/supporting-devices/languages>
@@ -67,6 +68,9 @@ Use these sources before adding or changing localization mechanics:
 - Weblate hosted pricing and Libre plan: <https://weblate.org/en/hosting/>
 - Unicode CLDR plural rules: <https://cldr.unicode.org/index/cldr-spec/plural-rules>
 - Unicode LDML / locale identifiers: <https://www.unicode.org/reports/tr35/>
+- Unicode grapheme clusters: <https://unicode.org/reports/tr29/>
+- HarfBuzz shaping scope: <https://harfbuzz.github.io/what-harfbuzz-doesnt-do.html>
+- Noto font-selection guidance: <https://notofonts.github.io/noto-docs/website/use/>
 - Microsoft Localization Style Guides: <https://learn.microsoft.com/en-us/globalization/reference/microsoft-style-guides>
 - Microsoft Terminology: <https://learn.microsoft.com/en-us/globalization/reference/microsoft-terminology>
 - Microsoft Writing Style Guide: <https://learn.microsoft.com/en-us/style-guide/welcome/>
@@ -93,12 +97,25 @@ Picocrypt-NG keeps Fyne/Weblate-shaped flat JSON catalogs under
   menu shows native language names. Do not use flags.
 - The selected desktop UI language is stored in Fyne preferences under
   `ui.language`.
-- Only complete bundled Fyne catalogs appear in the selector. Target language
-  codes are `en`, `ru`, `de`, `fr`, `it`, and `es`. Russian is the first
-  curated non-English catalog and is gated by
-  `docs/localization/RUSSIAN_TRANSLATION_REVIEW.md`; additional non-English
-  production catalogs remain blocked until their language-specific review gate
-  or the Fyne/Weblate JSON round-trip proof exists.
+- Only complete embedded Fyne catalogs appear in the selector. Registered
+  desktop codes are `en`, `ru`, `de`, `fr`, `it`, `es`, `zh-Hans`, and `hi`.
+  `zh-Hans` is the catalog filename stem and stored preference; only the closed
+  selector abbreviates it to `zh`. The open menu uses native names and no flags.
+  Registration without a catalog does not claim that a locale has shipped.
+- Every embedded non-English catalog must exactly match `en.json` message IDs,
+  singular/plural shapes, and template placeholders, while using the exact
+  plural forms required by the pinned go-i18n version. The current contract is:
+
+  | Locale | Required plural forms |
+  |---|---|
+  | `en`, `de`, `hi` | `one`, `other` |
+  | `fr`, `es`, `it` | `one`, `many`, `other` |
+  | `ru` | `one`, `few`, `many`, `other` |
+  | `zh-Hans` | `other` |
+
+  In go-i18n 2.6.1, French and Hindi use `one` for integer zero; French and
+  Spanish use `many` for values such as one million. Runtime tests, not this
+  table alone, are the executable source of truth.
 - UI state must store semantic display state for labels and UI-owned statuses.
   Do not store translated strings as durable state when the text must relocalize
   after a runtime language switch.
@@ -122,6 +139,31 @@ JSON shape Picocrypt-NG uses. Generic Weblate JSON is useful for simple key/valu
 files, but its plain JSON format does not carry all plural/context metadata.
 The curated Russian catalog is a native-review exception, not evidence that the
 Fyne Weblate component is ready.
+
+### Fyne fonts and packaged rendering
+
+Picocrypt-NG uses Fyne's default theme and system-font fallback. It does not
+bundle or download fonts, install operating-system packages, hard-code font
+paths, or set `FYNE_FONT`. Nerd Fonts are not a CJK or Devanagari solution.
+
+Fyne's embedded Latin font covers the catalog text required by German, French,
+and Spanish. Simplified Chinese and Hindi depend on suitable fonts already
+available to the operating system. Fyne shapes text with HarfBuzz, but its
+preferred system face follows the operating-system locale rather than the
+language selected inside Picocrypt-NG. Therefore `zh-Hans` and `hi` require
+real packaged-build review both with matching and non-matching OS locales.
+
+Before either locale becomes selectable, reject screenshots containing tofu,
+replacement glyphs, wrong Simplified-Chinese regional forms, detached Hindi
+matras, dotted circles, exposed halants, broken conjuncts, clipped vertical
+metrics, hidden controls, or window growth beyond the normal 340 px desktop
+width. Missing system coverage blocks that locale on the affected target; it
+does not authorize adding an unreviewed font asset.
+
+Emoji and arbitrary mixed-script filenames/comments are platform best-effort.
+Font fallback must not change the underlying application string or selected
+path and must not cause a crash, but Picocrypt-NG does not promise universal
+rendering of every Unicode character or emoji sequence.
 
 ### Android
 
@@ -207,6 +249,8 @@ Language-specific voice:
 | German | Use formal-neutral `Sie` in instructions. Avoid English Title Case. Split long compounds with hyphens when readability suffers. |
 | Spanish | Use neutral international Spanish. Avoid regional-only terms and avoid relying on either `tú` or `usted` where an impersonal UI phrase works. |
 | Italian | Use concise UI actions and impersonal wording. Prefer short labels; use longer technical forms in explanatory text when needed. |
+| Simplified Chinese | Use concise Simplified Chinese and review regional glyph forms. Security terms such as deniability need an explanatory tooltip, not only a short label. |
+| Hindi | Use concise contemporary technical Hindi. Review conjuncts and matras visually; do not accept code-point presence as shaping proof. |
 
 ## Product Glossary
 
@@ -392,20 +436,44 @@ Every localization PR or Weblate merge must answer these checks:
 11. Has Android been checked with pseudolocales after large resource changes?
 12. Are non-translatable identifiers marked or excluded from translation?
 13. Does the change leave CLI output untouched?
+14. For a Fyne desktop locale, does the complete catalog pass exact key,
+    placeholder, message-shape, and locale-plural validation?
+15. Has the real packaged desktop UI been checked at 340 px in light and dark
+    mode? For `zh-Hans` and `hi`, was shaping checked with both matching and
+    non-matching operating-system locales?
+16. Are Android build and pseudolocale checks requested only when Android
+    resources are actually part of the localization change?
 
 ## Implementation Readiness Gates
 
-Before enabling a locale in a release:
+Before enabling any locale:
 
-- The locale has a glossary review against this guide.
-- Android resources compile.
-- Fyne catalogs load without runtime errors.
-- No enabled localized surface still depends on hard-coded user-facing source
-  text that bypasses the platform catalog.
-- Weblate or local validation reports no unresolved placeholder/plural/XML
-  issues.
-- The translated UI has been manually smoke-tested for core workflows:
-  selecting files, encrypting, decrypting, keyfiles, comments, force decrypt,
-  verify-first, deletion options, and error dialogs.
-- Release notes mention localization as user-facing UI work, not as a
-  cryptographic change.
+- The locale has a native or near-native linguistic review and a maintainer
+  security-meaning review against this guide.
+- No enabled surface depends on untranslated user-facing source text that
+  bypasses its platform catalog.
+- All placeholder, plural, syntax, and glossary checks are clean.
+- Release notes describe localization as UI work, not a cryptographic change.
+
+Before enabling a Fyne desktop locale:
+
+- The catalog is complete against `src/internal/ui/translation/en.json` and
+  passes the generic embedded-catalog contract.
+- Runtime language switching and preference restoration preserve the full
+  locale code.
+- Core workflows have been checked in a real packaged application: initial,
+  encrypt, decrypt, keyfiles, comments, force decrypt, verify-first, deletion
+  options, progress, and dialogs.
+- Windows 10/11 installer and portable builds, the supported macOS `.app`, and
+  Linux raw, `.deb`, and AppImage builds have no clipped controls or unexpected
+  width growth. Flatpak and Snap are checked when that catalog ships through
+  those channels.
+- Simplified Chinese and Hindi additionally pass the system-font and shaping
+  checks in this guide. Hindi also requires grapheme-safe application-owned
+  truncation before `hi.json` is admitted.
+
+Before enabling a native Android locale:
+
+- Android resources compile and the relevant UI passes pseudolocale checks.
+- Hard-coded Kotlin user messages for the localized surface have been
+  externalized or explicitly mapped.

--- a/docs/localization/TRANSLATION_GUIDE.md
+++ b/docs/localization/TRANSLATION_GUIDE.md
@@ -99,8 +99,10 @@ Picocrypt-NG keeps Fyne/Weblate-shaped flat JSON catalogs under
   `ui.language`.
 - Only complete embedded Fyne catalogs appear in the selector. Registered
   desktop codes are `en`, `ru`, `de`, `fr`, `it`, `es`, `zh-Hans`, and `hi`.
-  `zh-Hans` is the catalog filename stem and stored preference; only the closed
-  selector abbreviates it to `zh`. The open menu uses native names and no flags.
+  `zh-Hans` is the catalog filename stem and stored preference, with the open
+  menu label `简体中文`; `hi` uses the open-menu label `हिन्दी`. Only the closed
+  selector abbreviates `zh-Hans` to `zh`. The open menu uses native names and no
+  flags.
   Registration without a catalog does not claim that a locale has shipped.
 - Every embedded non-English catalog must exactly match `en.json` message IDs,
   singular/plural shapes, and template placeholders, while using the exact

--- a/src/internal/ui/advanced_section.go
+++ b/src/internal/ui/advanced_section.go
@@ -140,6 +140,14 @@ func (a *App) buildEncryptOptions() {
 	a.buildEncryptOptionsInto(a.advancedContainer)
 }
 
+func adaptiveAdvancedOptionPair(left, right fyne.CanvasObject) fyne.CanvasObject {
+	pair := container.NewGridWithColumns(2, left, right)
+	if pair.MinSize().Width > desktopContentWidth() {
+		return container.NewVBox(left, right)
+	}
+	return pair
+}
+
 func (a *App) buildEncryptOptionsInto(target *fyne.Container) {
 	if target == nil {
 		return
@@ -159,7 +167,7 @@ func (a *App) buildEncryptOptionsInto(target *fyne.Container) {
 	a.compressCheck.SetToolTip(tr("advanced.compress.tooltip", "Compress before encrypting"))
 	a.compressCheck.SetChecked(a.State.Compress)
 
-	row1 := container.NewGridWithColumns(2, a.paranoidCheck, a.compressCheck)
+	row1 := adaptiveAdvancedOptionPair(a.paranoidCheck, a.compressCheck)
 
 	a.reedSolomonCheck = ttwidget.NewCheck(tr("advanced.reed_solomon.label", "Reed-Solomon"), func(checked bool) {
 		a.State.ReedSolomon = checked
@@ -173,7 +181,7 @@ func (a *App) buildEncryptOptionsInto(target *fyne.Container) {
 	a.deleteCheck.SetToolTip(tr("advanced.delete_files.tooltip", "Delete source files after encryption"))
 	a.deleteCheck.SetChecked(a.State.Delete)
 
-	row2 := container.NewGridWithColumns(2, a.reedSolomonCheck, a.deleteCheck)
+	row2 := adaptiveAdvancedOptionPair(a.reedSolomonCheck, a.deleteCheck)
 
 	a.deniabilityCheck = ttwidget.NewCheck(tr("advanced.deniability.label", "Deniability"), func(checked bool) {
 		a.State.Deniability = checked
@@ -195,7 +203,7 @@ func (a *App) buildEncryptOptionsInto(target *fyne.Container) {
 	a.recursivelyCheck.SetToolTip(tr("advanced.recursively.tooltip", "Process each file separately"))
 	a.recursivelyCheck.SetChecked(a.State.Recursively)
 
-	row3 := container.NewGridWithColumns(2, a.deniabilityCheck, a.recursivelyCheck)
+	row3 := adaptiveAdvancedOptionPair(a.deniabilityCheck, a.recursivelyCheck)
 
 	a.splitCheck = ttwidget.NewCheck(tr("advanced.split.label", "Split:"), func(checked bool) {
 		a.State.Split = checked

--- a/src/internal/ui/app.go
+++ b/src/internal/ui/app.go
@@ -63,9 +63,11 @@ const (
 	windowHeightDecrypt = 430 // Reduced height for decrypt mode (fewer options)
 	windowHeightInitial = 350 // Compact height for initial state (no advanced options)
 	buttonWidth         = 54
-	padding             = 4 // Reduced from 8 to match compact theme
-	contentWidth        = windowWidth - padding*2
 )
+
+func desktopContentWidth() float32 {
+	return float32(windowWidth) - theme.Padding()*2
+}
 
 // App represents the main UI application.
 type App struct {
@@ -250,6 +252,12 @@ func (a *App) SwitchLanguage(code LanguageCode) error {
 		a.fyneApp.Preferences().SetString(languagePreferenceKey, string(code))
 	}
 	a.refreshLocalizedText()
+	if a.passwordContainer != nil {
+		a.rebuildPasswordHeader()
+	}
+	if a.advancedContainer != nil {
+		a.refreshAdvanced()
+	}
 	return nil
 }
 

--- a/src/internal/ui/language.go
+++ b/src/internal/ui/language.go
@@ -3,8 +3,9 @@ package ui
 type LanguageCode string
 
 type LanguageOption struct {
-	Code LanguageCode
-	Name string
+	Code        LanguageCode
+	Name        string
+	ButtonLabel string
 }
 
 const languagePreferenceKey = "ui.language"
@@ -16,6 +17,21 @@ var knownLanguageOptions = []LanguageOption{
 	{Code: "fr", Name: "Français"},
 	{Code: "it", Name: "Italiano"},
 	{Code: "es", Name: "Español"},
+	{Code: "zh-Hans", Name: "简体中文", ButtonLabel: "zh"},
+	{Code: "hi", Name: "हिन्दी"},
+}
+
+func languageButtonLabel(code LanguageCode) string {
+	for _, option := range knownLanguageOptions {
+		if option.Code != code {
+			continue
+		}
+		if option.ButtonLabel != "" {
+			return option.ButtonLabel
+		}
+		break
+	}
+	return string(code)
 }
 
 func bundledLanguageOptions() []LanguageOption {

--- a/src/internal/ui/language_selector.go
+++ b/src/internal/ui/language_selector.go
@@ -13,7 +13,7 @@ type languageSelector struct {
 
 func newLanguageSelector(owner *App) *languageSelector {
 	selector := &languageSelector{owner: owner}
-	selector.button = widget.NewButton(string(activeLanguage()), func() {
+	selector.button = widget.NewButton(languageButtonLabel(activeLanguage()), func() {
 		if owner == nil || owner.Window == nil {
 			return
 		}
@@ -35,7 +35,7 @@ func (s *languageSelector) refresh() {
 	if s == nil || s.button == nil {
 		return
 	}
-	s.button.SetText(string(activeLanguage()))
+	s.button.SetText(languageButtonLabel(activeLanguage()))
 	s.button.Refresh()
 }
 

--- a/src/internal/ui/language_selector_test.go
+++ b/src/internal/ui/language_selector_test.go
@@ -42,14 +42,35 @@ func TestChineseLanguagePreferenceKeepsFullCodeWhileSelectorShowsZh(t *testing.T
 	}
 
 	a := &App{fyneApp: fyneApp}
-	if err := a.SwitchLanguage("zh-Hans"); err != nil {
-		t.Fatalf("SwitchLanguage(zh-Hans) returned error: %v", err)
+	selector := newLanguageSelector(a)
+	a.languageSelector = selector
+	if got := selector.button.Text; got != "en" {
+		t.Fatalf("initial selector closed text = %q; want en", got)
 	}
+
+	var chineseItem *fyne.MenuItem
+	for _, item := range selector.menu().Items {
+		if item.Label == "简体中文" {
+			chineseItem = item
+			break
+		}
+	}
+	if chineseItem == nil {
+		t.Fatal("language selector menu is missing 简体中文")
+	}
+	if chineseItem.Action == nil {
+		t.Fatal("简体中文 language selector item has no action")
+	}
+	chineseItem.Action()
+
 	if got := activeLanguage(); got != "zh-Hans" {
-		t.Fatalf("activeLanguage = %q; want zh-Hans", got)
+		t.Errorf("activeLanguage after menu action = %q; want zh-Hans", got)
 	}
 	if got := fyneApp.Preferences().StringWithFallback(languagePreferenceKey, ""); got != "zh-Hans" {
-		t.Fatalf("stored language preference = %q; want zh-Hans", got)
+		t.Errorf("stored language preference after menu action = %q; want zh-Hans", got)
+	}
+	if got := selector.button.Text; got != "zh" {
+		t.Errorf("selector closed text after menu action = %q; want zh", got)
 	}
 	if err := setActiveLanguage("en"); err != nil {
 		t.Fatalf("setActiveLanguage(en) returned error: %v", err)
@@ -59,11 +80,6 @@ func TestChineseLanguagePreferenceKeepsFullCodeWhileSelectorShowsZh(t *testing.T
 	}
 	if got := activeLanguage(); got != "zh-Hans" {
 		t.Fatalf("activeLanguage after preference restore = %q; want zh-Hans", got)
-	}
-
-	selector := newLanguageSelector(a)
-	if got := selector.button.Text; got != "zh" {
-		t.Fatalf("selector closed text = %q; want zh", got)
 	}
 }
 

--- a/src/internal/ui/language_selector_test.go
+++ b/src/internal/ui/language_selector_test.go
@@ -9,6 +9,64 @@ import (
 	"fyne.io/fyne/v2/widget"
 )
 
+func TestLanguageButtonLabelUsesCompactChineseCode(t *testing.T) {
+	tests := []struct {
+		code LanguageCode
+		want string
+	}{
+		{code: "en", want: "en"},
+		{code: "de", want: "de"},
+		{code: "zh-Hans", want: "zh"},
+		{code: "hi", want: "hi"},
+		{code: "zz", want: "zz"},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.code), func(t *testing.T) {
+			if got := languageButtonLabel(tc.code); got != tc.want {
+				t.Fatalf("languageButtonLabel(%q) = %q; want %q", tc.code, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChineseLanguagePreferenceKeepsFullCodeWhileSelectorShowsZh(t *testing.T) {
+	fyneApp := newTestFyneApp(t)
+	resetLocalizationForTest(t)
+	testFS := fstest.MapFS{
+		"translation/en.json":      {Data: []byte(`{"status.ready":"Ready"}`)},
+		"translation/zh-Hans.json": {Data: []byte(`{"status.ready":"就绪"}`)},
+	}
+	if err := loadTranslationsFromFS(testFS); err != nil {
+		t.Fatalf("loadTranslationsFromFS returned error: %v", err)
+	}
+
+	a := &App{fyneApp: fyneApp}
+	if err := a.SwitchLanguage("zh-Hans"); err != nil {
+		t.Fatalf("SwitchLanguage(zh-Hans) returned error: %v", err)
+	}
+	if got := activeLanguage(); got != "zh-Hans" {
+		t.Fatalf("activeLanguage = %q; want zh-Hans", got)
+	}
+	if got := fyneApp.Preferences().StringWithFallback(languagePreferenceKey, ""); got != "zh-Hans" {
+		t.Fatalf("stored language preference = %q; want zh-Hans", got)
+	}
+	if err := setActiveLanguage("en"); err != nil {
+		t.Fatalf("setActiveLanguage(en) returned error: %v", err)
+	}
+	if err := a.loadPreferredLanguage(fyneApp.Preferences()); err != nil {
+		t.Fatalf("loadPreferredLanguage returned error: %v", err)
+	}
+	if got := activeLanguage(); got != "zh-Hans" {
+		t.Fatalf("activeLanguage after preference restore = %q; want zh-Hans", got)
+	}
+
+	selector := newLanguageSelector(a)
+	if got := selector.button.Text; got != "zh" {
+		t.Fatalf("selector closed text = %q; want zh", got)
+	}
+}
+
 func TestLanguageSelectorClosedTextUsesLanguageCode(t *testing.T) {
 	resetLocalizationForTest(t)
 	testFS := fstest.MapFS{
@@ -32,9 +90,11 @@ func TestLanguageSelectorClosedTextUsesLanguageCode(t *testing.T) {
 func TestLanguageSelectorMenuUsesNativeNamesAndNoIcons(t *testing.T) {
 	resetLocalizationForTest(t)
 	testFS := fstest.MapFS{
-		"translation/en.json": {Data: []byte(`{"status.ready":"Ready"}`)},
-		"translation/fr.json": {Data: []byte(`{"status.ready":"Pret"}`)},
-		"translation/it.json": {Data: []byte(`{"status.ready":"Pronto"}`)},
+		"translation/en.json":      {Data: []byte(`{"status.ready":"Ready"}`)},
+		"translation/fr.json":      {Data: []byte(`{"status.ready":"Pret"}`)},
+		"translation/it.json":      {Data: []byte(`{"status.ready":"Pronto"}`)},
+		"translation/zh-Hans.json": {Data: []byte(`{"status.ready":"就绪"}`)},
+		"translation/hi.json":      {Data: []byte(`{"status.ready":"तैयार"}`)},
 	}
 	if err := loadTranslationsFromFS(testFS); err != nil {
 		t.Fatalf("loadTranslationsFromFS returned error: %v", err)
@@ -50,7 +110,7 @@ func TestLanguageSelectorMenuUsesNativeNamesAndNoIcons(t *testing.T) {
 			t.Fatalf("language menu item %q has an icon; flags/icons are not allowed", item.Label)
 		}
 	}
-	want := []string{"English", "Français", "Italiano"}
+	want := []string{"English", "Français", "Italiano", "简体中文", "हिन्दी"}
 	if len(got) != len(want) {
 		t.Fatalf("menu labels = %#v; want %#v", got, want)
 	}

--- a/src/internal/ui/layout_regression_test.go
+++ b/src/internal/ui/layout_regression_test.go
@@ -505,29 +505,40 @@ func TestDesktopEncryptLayoutCollapsedAdvancedHeightBudgetRussian(t *testing.T) 
 	}
 }
 
-func TestDesktopEncryptLayoutExpandedAdvancedStillFitsWidth(t *testing.T) {
-	fyneApp := newTestFyneApp(t)
-	fyneApp.Settings().SetTheme(fixedVariantTheme{Theme: NewCompactTheme(), variant: theme.VariantLight})
-
-	a := newDesktopEncryptLayoutApp(t, fyneApp)
-
-	fyne.DoAndWait(func() {
-		a.State.Split = true
-		a.refreshAdvanced()
-		a.updateUIState()
-	})
-
-	var min, size fyne.Size
-	fyne.DoAndWait(func() {
-		min = a.Window.Content().MinSize()
-		size = a.Window.Canvas().Size()
-	})
-
-	if min.Width > windowWidth {
-		t.Fatalf("expanded encrypt layout MinSize width %.1f exceeds compact window width %.1f", min.Width, float32(windowWidth))
+func TestDesktopEncryptLayoutExpandedAdvancedKeepsCompactWidthForAllBundledLanguages(t *testing.T) {
+	resetLocalizationForTest(t)
+	if err := loadTranslations(); err != nil {
+		t.Fatalf("loadTranslations returned error: %v", err)
 	}
-	if size.Width > windowWidth {
-		t.Fatalf("expanded encrypt layout window width %.1f exceeds compact window width %.1f", size.Width, float32(windowWidth))
+
+	for _, option := range bundledLanguageOptions() {
+		t.Run(string(option.Code), func(t *testing.T) {
+			fyneApp := newTestFyneApp(t)
+			fyneApp.Settings().SetTheme(fixedVariantTheme{Theme: NewCompactTheme(), variant: theme.VariantLight})
+
+			a := newDesktopEncryptLayoutApp(t, fyneApp)
+
+			var min, size fyne.Size
+			fyne.DoAndWait(func() {
+				if err := a.SwitchLanguage(option.Code); err != nil {
+					t.Fatalf("SwitchLanguage(%s) returned error: %v", option.Code, err)
+				}
+				if a.advancedToggleBtn == nil {
+					t.Fatal("advanced disclosure button was not built")
+				}
+				a.advancedToggleBtn.OnTapped()
+				min = a.Window.Content().MinSize()
+				size = a.Window.Canvas().Size()
+			})
+
+			if min.Width > windowWidth {
+				t.Fatalf("%s expanded encrypt layout MinSize width %.1f exceeds compact window width %.1f", option.Code, min.Width, float32(windowWidth))
+			}
+			if size.Width > windowWidth {
+				t.Fatalf("%s expanded encrypt layout window width %.1f exceeds compact window width %.1f", option.Code, size.Width, float32(windowWidth))
+			}
+			assertWindowFitsContent(t, a)
+		})
 	}
 }
 

--- a/src/internal/ui/localization_language_test.go
+++ b/src/internal/ui/localization_language_test.go
@@ -83,6 +83,28 @@ func TestBundledLanguageOptionsOnlyIncludesLoadedCatalogs(t *testing.T) {
 	}
 }
 
+func TestRequestedDesktopLocalesHaveStableMetadata(t *testing.T) {
+	want := map[LanguageCode]LanguageOption{
+		"de":      {Code: "de", Name: "Deutsch"},
+		"fr":      {Code: "fr", Name: "Français"},
+		"es":      {Code: "es", Name: "Español"},
+		"zh-Hans": {Code: "zh-Hans", Name: "简体中文", ButtonLabel: "zh"},
+		"hi":      {Code: "hi", Name: "हिन्दी"},
+	}
+
+	for _, option := range knownLanguageOptions {
+		if expected, ok := want[option.Code]; ok {
+			if option != expected {
+				t.Errorf("language metadata for %q = %#v; want %#v", option.Code, option, expected)
+			}
+			delete(want, option.Code)
+		}
+	}
+	if len(want) != 0 {
+		t.Fatalf("requested desktop locales are not registered: %#v", want)
+	}
+}
+
 func TestRuntimeLanguageSwitchRerendersInputSummary(t *testing.T) {
 	resetLocalizationForTest(t)
 	testFS := fstest.MapFS{

--- a/src/internal/ui/localization_plural_test.go
+++ b/src/internal/ui/localization_plural_test.go
@@ -1,0 +1,106 @@
+package ui
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"testing/fstest"
+)
+
+func TestTargetLocalePluralRulesAtRuntime(t *testing.T) {
+	tests := []struct {
+		code   LanguageCode
+		forms  []string
+		probes map[int]string
+	}{
+		{
+			code:  "de",
+			forms: []string{"one", "other"},
+			probes: map[int]string{
+				0: "other",
+				1: "one",
+				2: "other",
+			},
+		},
+		{
+			code:  "fr",
+			forms: []string{"one", "many", "other"},
+			probes: map[int]string{
+				0:       "one",
+				1:       "one",
+				2:       "other",
+				1000000: "many",
+			},
+		},
+		{
+			code:  "es",
+			forms: []string{"one", "many", "other"},
+			probes: map[int]string{
+				0:       "other",
+				1:       "one",
+				2:       "other",
+				1000000: "many",
+			},
+		},
+		{
+			code:  "zh-Hans",
+			forms: []string{"other"},
+			probes: map[int]string{
+				0: "other",
+				1: "other",
+				2: "other",
+			},
+		},
+		{
+			code:  "hi",
+			forms: []string{"one", "other"},
+			probes: map[int]string{
+				0: "one",
+				1: "one",
+				2: "other",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.code), func(t *testing.T) {
+			resetLocalizationForTest(t)
+			pluralMessage := make(map[string]string, len(tc.forms))
+			for _, form := range tc.forms {
+				pluralMessage[form] = form + " {{.Count}}"
+			}
+			catalogData, err := json.Marshal(map[string]any{
+				"selection.files": pluralMessage,
+			})
+			if err != nil {
+				t.Fatalf("marshal %s catalog fixture: %v", tc.code, err)
+			}
+
+			testFS := fstest.MapFS{
+				"translation/en.json": {
+					Data: []byte(`{"selection.files":{"one":"one {{.Count}}","other":"other {{.Count}}"}}`),
+				},
+				"translation/" + string(tc.code) + ".json": {
+					Data: catalogData,
+				},
+			}
+			if err := loadTranslationsFromFS(testFS); err != nil {
+				t.Fatalf("loadTranslationsFromFS(%s) returned error: %v", tc.code, err)
+			}
+			if err := setActiveLanguage(tc.code); err != nil {
+				t.Fatalf("setActiveLanguage(%s) returned error: %v", tc.code, err)
+			}
+			if got := activeLanguage(); got != tc.code {
+				t.Fatalf("activeLanguage = %q; want %q", got, tc.code)
+			}
+
+			for count, wantForm := range tc.probes {
+				got := trn("selection.files", "fallback {{.Count}}", count, map[string]any{"Count": count})
+				want := fmt.Sprintf("%s %d", wantForm, count)
+				if got != want {
+					t.Errorf("%s plural for %d = %q; want %q", tc.code, count, got, want)
+				}
+			}
+		})
+	}
+}

--- a/src/internal/ui/localization_test.go
+++ b/src/internal/ui/localization_test.go
@@ -296,6 +296,50 @@ func TestCatalogValueValidationRequiresExactLocalePluralForms(t *testing.T) {
 			},
 		},
 		{
+			name: "Russian few many one and other",
+			code: "ru",
+			value: map[string]any{
+				"few":   "{{.Count}} файла",
+				"many":  "{{.Count}} файлов",
+				"one":   "{{.Count}} файл",
+				"other": "{{.Count}} файла",
+			},
+		},
+		{
+			name: "German one and other",
+			code: "de",
+			value: map[string]any{
+				"one":   "{{.Count}} Datei",
+				"other": "{{.Count}} Dateien",
+			},
+		},
+		{
+			name: "Italian many one and other",
+			code: "it",
+			value: map[string]any{
+				"many":  "{{.Count}} file",
+				"one":   "{{.Count}} file",
+				"other": "{{.Count}} file",
+			},
+		},
+		{
+			name: "Spanish many one and other",
+			code: "es",
+			value: map[string]any{
+				"many":  "{{.Count}} archivos",
+				"one":   "{{.Count}} archivo",
+				"other": "{{.Count}} archivos",
+			},
+		},
+		{
+			name: "Hindi one and other",
+			code: "hi",
+			value: map[string]any{
+				"one":   "{{.Count}} फ़ाइल",
+				"other": "{{.Count}} फ़ाइलें",
+			},
+		},
+		{
 			name: "Chinese other only",
 			code: "zh-Hans",
 			value: map[string]any{

--- a/src/internal/ui/localization_test.go
+++ b/src/internal/ui/localization_test.go
@@ -16,6 +16,25 @@ import (
 	"unicode/utf8"
 )
 
+var requiredCatalogPluralForms = map[LanguageCode][]string{
+	"en":      {"one", "other"},
+	"ru":      {"few", "many", "one", "other"},
+	"de":      {"one", "other"},
+	"fr":      {"many", "one", "other"},
+	"it":      {"many", "one", "other"},
+	"es":      {"many", "one", "other"},
+	"zh-Hans": {"other"},
+	"hi":      {"one", "other"},
+}
+
+func requiredPluralFormsForLanguage(code LanguageCode) ([]string, error) {
+	forms, ok := requiredCatalogPluralForms[code]
+	if !ok {
+		return nil, fmt.Errorf("no plural-form contract registered for language %q", code)
+	}
+	return forms, nil
+}
+
 func TestLoadTranslations(t *testing.T) {
 	resetLocalizationForTest(t)
 
@@ -45,7 +64,7 @@ func TestLocalizationCatalogJSON(t *testing.T) {
 		if strings.TrimSpace(key) == "" {
 			t.Fatal("translation/en.json contains an empty key")
 		}
-		validateCatalogValue(t, key, value)
+		validateCatalogValue(t, "en", key, value)
 	}
 }
 
@@ -78,34 +97,37 @@ func TestLocalizationCatalogEmbeddedByLoader(t *testing.T) {
 	}
 }
 
-func TestRussianFyneCatalogMatchesEnglishKeysAndPlaceholders(t *testing.T) {
+func TestEmbeddedFyneCatalogsMatchEnglish(t *testing.T) {
 	english := loadEmbeddedCatalog(t, "translation/en.json")
-	russian := loadEmbeddedCatalog(t, "translation/ru.json")
-
-	assertCatalogMatchesEnglish(t, "translation/ru.json", english, russian)
-}
-
-func TestRussianFyneCatalogUsesRussianPluralForms(t *testing.T) {
-	english := loadEmbeddedCatalog(t, "translation/en.json")
-	russian := loadEmbeddedCatalog(t, "translation/ru.json")
-
-	var failures []string
-	for key, englishValue := range english {
-		if !isPluralCatalogValue(englishValue) {
-			continue
-		}
-		translated, ok := russian[key].(map[string]any)
-		if !ok {
-			failures = append(failures, key+": missing Russian plural object")
-			continue
-		}
-		if got, want := sortedMapKeys(translated), []string{"few", "many", "one", "other"}; !sameStringSet(got, want) {
-			failures = append(failures, fmt.Sprintf("%s: plural forms = %v; want %v", key, got, want))
-		}
+	entries, err := translationFS.ReadDir("translation")
+	if err != nil {
+		t.Fatalf("read embedded translation directory: %v", err)
 	}
-	sort.Strings(failures)
-	if len(failures) > 0 {
-		t.Fatalf("Russian plural catalog must use one/few/many/other forms:\n%s", strings.Join(failures, "\n"))
+
+	known := make(map[LanguageCode]bool, len(knownLanguageOptions))
+	for _, option := range knownLanguageOptions {
+		known[option.Code] = true
+	}
+
+	nonEnglishCatalogs := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") || entry.Name() == "en.json" {
+			continue
+		}
+		nonEnglishCatalogs++
+		code := LanguageCode(strings.TrimSuffix(entry.Name(), ".json"))
+		if !known[code] {
+			t.Errorf("embedded catalog %q has no registered language option", entry.Name())
+			continue
+		}
+		path := "translation/" + entry.Name()
+		t.Run(string(code), func(t *testing.T) {
+			translated := loadEmbeddedCatalog(t, path)
+			assertCatalogMatchesEnglish(t, code, path, english, translated)
+		})
+	}
+	if nonEnglishCatalogs == 0 {
+		t.Fatal("found no embedded non-English catalogs to validate")
 	}
 }
 
@@ -258,46 +280,88 @@ func TestSelectionMixedCatalogComposesPluralizedPhrases(t *testing.T) {
 	}
 }
 
-func TestCatalogValueValidationRequiresEnglishPluralForms(t *testing.T) {
+func TestCatalogValueValidationRequiresExactLocalePluralForms(t *testing.T) {
 	tests := []struct {
-		name  string
-		value map[string]any
+		name    string
+		code    LanguageCode
+		value   map[string]any
+		wantErr bool
 	}{
 		{
-			name: "missing one",
+			name: "English one and other",
+			code: "en",
 			value: map[string]any{
+				"one":   "{{.Count}} file",
 				"other": "{{.Count}} files",
 			},
 		},
 		{
-			name: "missing other",
+			name: "Chinese other only",
+			code: "zh-Hans",
 			value: map[string]any{
-				"one": "{{.Count}} file",
+				"other": "{{.Count}} 个文件",
 			},
 		},
 		{
-			name: "missing count",
+			name: "Chinese rejects extra one",
+			code: "zh-Hans",
 			value: map[string]any{
-				"one":   "One file",
-				"other": "{{.Count}} files",
+				"one":   "{{.Count}} 个文件",
+				"other": "{{.Count}} 个文件",
 			},
+			wantErr: true,
+		},
+		{
+			name: "Hindi requires one",
+			code: "hi",
+			value: map[string]any{
+				"other": "{{.Count}} फ़ाइलें",
+			},
+			wantErr: true,
+		},
+		{
+			name: "French requires many",
+			code: "fr",
+			value: map[string]any{
+				"one":   "{{.Count}} fichier",
+				"other": "{{.Count}} fichiers",
+			},
+			wantErr: true,
+		},
+		{
+			name: "French accepts one many and other",
+			code: "fr",
+			value: map[string]any{
+				"one":   "{{.Count}} fichier",
+				"many":  "{{.Count}} fichiers",
+				"other": "{{.Count}} fichiers",
+			},
+		},
+		{
+			name: "plural form cannot omit count",
+			code: "de",
+			value: map[string]any{
+				"one":   "Eine Datei",
+				"other": "{{.Count}} Dateien",
+			},
+			wantErr: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := catalogValueValidationError("selection.files", tc.value); err == nil {
+			forms, err := requiredPluralFormsForLanguage(tc.code)
+			if err != nil {
+				t.Fatalf("requiredPluralFormsForLanguage(%q): %v", tc.code, err)
+			}
+			err = catalogValueValidationError("selection.files", tc.value, forms)
+			if tc.wantErr && err == nil {
 				t.Fatal("catalogValueValidationError returned nil; want validation error")
 			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("catalogValueValidationError returned error: %v", err)
+			}
 		})
-	}
-
-	valid := map[string]any{
-		"one":   "{{.Count}} file",
-		"other": "{{.Count}} files",
-	}
-	if err := catalogValueValidationError("selection.files", valid); err != nil {
-		t.Fatalf("catalogValueValidationError(valid) = %v; want nil", err)
 	}
 }
 
@@ -417,6 +481,10 @@ func TestFyneUITranslationCallKeysExistInCatalog(t *testing.T) {
 	if err := json.Unmarshal(data, &catalog); err != nil {
 		t.Fatalf("parse translation/en.json: %v", err)
 	}
+	englishPluralForms, err := requiredPluralFormsForLanguage("en")
+	if err != nil {
+		t.Fatalf("resolve English plural forms: %v", err)
+	}
 
 	files := uiProductionGoFiles(t)
 
@@ -454,7 +522,7 @@ func TestFyneUITranslationCallKeysExistInCatalog(t *testing.T) {
 					missing = append(missing, fset.Position(keyLit.Pos()).String()+": "+key+" is not plural")
 					return true
 				}
-				if err := catalogValueValidationError(key, plural); err != nil {
+				if err := catalogValueValidationError(key, plural, englishPluralForms); err != nil {
 					missing = append(missing, fset.Position(keyLit.Pos()).String()+": "+err.Error())
 				}
 			}
@@ -511,10 +579,14 @@ func TestNewAppLoadsEmbeddedTranslationsBeforeReturning(t *testing.T) {
 	}
 }
 
-func validateCatalogValue(t *testing.T, key string, value any) {
+func validateCatalogValue(t *testing.T, code LanguageCode, key string, value any) {
 	t.Helper()
 
-	if err := catalogValueValidationError(key, value); err != nil {
+	forms, err := requiredPluralFormsForLanguage(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := catalogValueValidationError(key, value, forms); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -537,8 +609,13 @@ func loadEmbeddedCatalog(t *testing.T, path string) map[string]any {
 	return catalog
 }
 
-func assertCatalogMatchesEnglish(t *testing.T, path string, english, translated map[string]any) {
+func assertCatalogMatchesEnglish(t *testing.T, code LanguageCode, path string, english, translated map[string]any) {
 	t.Helper()
+
+	requiredForms, err := requiredPluralFormsForLanguage(code)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var failures []string
 	for key, englishValue := range english {
@@ -551,7 +628,7 @@ func assertCatalogMatchesEnglish(t *testing.T, path string, english, translated 
 			failures = append(failures, key+": plural/string shape differs")
 			continue
 		}
-		if err := catalogValueValidationError(key, translatedValue); err != nil {
+		if err := catalogValueValidationError(key, translatedValue, requiredForms); err != nil {
 			failures = append(failures, key+": "+err.Error())
 		}
 		if got, want := templatePlaceholders(translatedValue), templatePlaceholders(englishValue); !sameStringSet(got, want) {
@@ -565,7 +642,7 @@ func assertCatalogMatchesEnglish(t *testing.T, path string, english, translated 
 	}
 	sort.Strings(failures)
 	if len(failures) > 0 {
-		t.Fatalf("%s must match translation/en.json keys, shapes, and placeholders:\n%s", path, strings.Join(failures, "\n"))
+		t.Fatalf("%s must match translation/en.json keys, shapes, placeholders, and locale plural forms:\n%s", path, strings.Join(failures, "\n"))
 	}
 }
 
@@ -649,22 +726,18 @@ func sameStringSet(a, b []string) bool {
 	return true
 }
 
-func catalogValueValidationError(key string, value any) error {
+func catalogValueValidationError(key string, value any, requiredForms []string) error {
 	switch v := value.(type) {
 	case string:
 		if strings.TrimSpace(v) == "" {
 			return fmt.Errorf("translation %q has an empty value", key)
 		}
 	case map[string]any:
-		for _, form := range []string{"one", "other"} {
-			if _, ok := v[form]; !ok {
-				return fmt.Errorf("plural translation %q is missing %s", key, form)
-			}
+		gotForms := sortedMapKeys(v)
+		if !sameStringSet(gotForms, requiredForms) {
+			return fmt.Errorf("plural translation %q has forms %v; want %v", key, gotForms, requiredForms)
 		}
 		for form, raw := range v {
-			if strings.TrimSpace(form) == "" {
-				return fmt.Errorf("plural translation %q contains an empty plural form", key)
-			}
 			text, ok := raw.(string)
 			if !ok {
 				return fmt.Errorf("plural translation %q form %q has non-string value %T", key, form, raw)

--- a/src/internal/ui/password_section.go
+++ b/src/internal/ui/password_section.go
@@ -70,10 +70,6 @@ func (a *App) buildPasswordSection() fyne.CanvasObject {
 		a.showPassgenModal()
 	})
 
-	buttonRow := container.NewGridWithColumns(5,
-		a.showHideBtn, a.clearPwdBtn, a.copyBtn, a.pasteBtn, a.createBtn,
-	)
-
 	// Password input with strength indicator
 	a.passwordEntry = NewPasswordEntry()
 	a.passwordEntry.SetPlaceHolder(tr("password.placeholder", "Password"))
@@ -100,9 +96,6 @@ func (a *App) buildPasswordSection() fyne.CanvasObject {
 	// Create bold labels for better visual hierarchy
 	a.passwordLabel = widget.NewLabel(tr("password.label", "Password:"))
 	a.passwordLabel.TextStyle = fyne.TextStyle{Bold: true}
-	passwordTitle := container.NewHBox(a.passwordLabel, a.strengthIndicator)
-	passwordHeader := container.NewBorder(nil, nil, passwordTitle, buttonRow, nil)
-
 	a.confirmLabel = widget.NewLabel(tr("password.confirm_label", "Confirm password:"))
 	a.confirmLabel.TextStyle = fyne.TextStyle{Bold: true}
 	confirmTitle := container.NewHBox(a.confirmLabel, a.validIndicator)
@@ -117,13 +110,32 @@ func (a *App) buildPasswordSection() fyne.CanvasObject {
 	a.nonASCIIHint.Wrapping = fyne.TextWrapWord
 	a.nonASCIIHint.Hide()
 
-	a.passwordContainer = container.NewVBox(
-		passwordHeader,
-		a.passwordEntry,
-		a.nonASCIIHint,
-		a.confirmRow,
-	)
+	a.passwordContainer = container.NewVBox()
+	a.rebuildPasswordHeader()
 	return a.passwordContainer
+}
+
+func (a *App) adaptivePasswordHeader() fyne.CanvasObject {
+	passwordTitle := container.NewHBox(a.passwordLabel, a.strengthIndicator)
+	buttonRow := container.NewGridWithColumns(5,
+		a.showHideBtn, a.clearPwdBtn, a.copyBtn, a.pasteBtn, a.createBtn,
+	)
+	passwordHeader := container.NewBorder(nil, nil, passwordTitle, buttonRow, nil)
+	if passwordHeader.MinSize().Width > desktopContentWidth() {
+		return container.NewVBox(passwordTitle, buttonRow)
+	}
+	return passwordHeader
+}
+
+func (a *App) rebuildPasswordHeader() {
+	if a.passwordContainer == nil {
+		return
+	}
+	a.passwordContainer.RemoveAll()
+	a.passwordContainer.Add(a.adaptivePasswordHeader())
+	a.passwordContainer.Add(a.passwordEntry)
+	a.passwordContainer.Add(a.nonASCIIHint)
+	a.passwordContainer.Add(a.confirmRow)
 }
 
 // updatePasswordStrength updates the password strength indicator.

--- a/src/internal/workflowpolicy/policy_test.go
+++ b/src/internal/workflowpolicy/policy_test.go
@@ -917,24 +917,27 @@ func TestAndroidPRWorkflowRunsBoundedDeviceSuites(t *testing.T) {
 	workflow := mustReadWorkflowDoc(t, ".github/workflows/pr-test-build-android.yml")
 	job := mustJob(t, workflow, "pr-test-build-android")
 	wantByAPI := map[int]struct {
-		arch   string
-		memory string
-		target string
-		script string
+		arch     string
+		diskSize string
+		memory   string
+		target   string
+		script   string
 	}{
 		// Storage and staging must work on Picocrypt NG's Android 7 compatibility floor.
 		24: {
-			arch:   "x86_64",
-			memory: "3583",
-			target: "google_apis",
-			script: command + roundtrip + ",io.github.picocrypt_ng.picocrypt_ng.FileCopyServiceTest,io.github.picocrypt_ng.picocrypt_ng.StagingServiceInstrumentedTest",
+			arch:     "x86_64",
+			diskSize: "2048M",
+			memory:   "3583",
+			target:   "google_apis",
+			script:   command + roundtrip + ",io.github.picocrypt_ng.picocrypt_ng.FileCopyServiceTest,io.github.picocrypt_ng.picocrypt_ng.StagingServiceInstrumentedTest",
 		},
 		// Activity security and Compose state must work on the target-SDK runtime.
 		36: {
-			arch:   "x86_64",
-			memory: "6144",
-			target: "default",
-			script: command + roundtrip + ",io.github.picocrypt_ng.picocrypt_ng.MainActivityUITest,io.github.picocrypt_ng.picocrypt_ng.ui.components.WorkButtonTest",
+			arch:     "x86_64",
+			diskSize: "2048M",
+			memory:   "6144",
+			target:   "default",
+			script:   command + roundtrip + ",io.github.picocrypt_ng.picocrypt_ng.MainActivityUITest,io.github.picocrypt_ng.picocrypt_ng.ui.components.WorkButtonTest",
 		},
 	}
 	seen := make(map[int]struct{}, len(wantByAPI))
@@ -965,6 +968,9 @@ func TestAndroidPRWorkflowRunsBoundedDeviceSuites(t *testing.T) {
 		}
 		if got := step.With["arch"]; got != want.arch {
 			t.Errorf("API %d arch = %#v, want %s", apiLevel, got, want.arch)
+		}
+		if got := step.With["disk-size"]; got != want.diskSize {
+			t.Errorf("API %d disk-size = %#v, want %s", apiLevel, got, want.diskSize)
 		}
 		emulatorOptions, ok := step.With["emulator-options"].(string)
 		if !ok {
@@ -1441,6 +1447,9 @@ func TestAndroidInstrumentedWorkflowIsManualAndPinned(t *testing.T) {
 	instrEmulator := mustHaveStepUsingPrefix(t, instrJob, "ReactiveCircus/android-emulator-runner@")
 	if got := instrEmulator.With["api-level"]; got != 36 {
 		t.Fatalf("instrumented emulator api-level = %v, want 36", got)
+	}
+	if got := instrEmulator.With["disk-size"]; got != "2048M" {
+		t.Fatalf("instrumented emulator disk-size = %v, want 2048M", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- register de, fr, es, zh-Hans, and hi while keeping absent catalogs hidden
- show zh only as the compact selector label while persisting zh-Hans
- enforce exact catalog parity and go-i18n 2.6.1 plural contracts
- document system-font and packaged-desktop admission gates
- bound Android emulator data partitions to 2048M for GitHub-hosted runner availability, without changing app or test scope

## Validation
- GOMAXPROCS=2 go test -p=1 -tags migrated_fynedo ./internal/ui -run "Test(Language|Bundled|Localization|EmbeddedFyneCatalogs|CatalogValue|TargetLocalePlural|RussianFyne|FyneUITranslation|CLIDoesNot)" -count=1
- GOMAXPROCS=2 go test -p=1 -tags migrated_fynedo ./...
- GOMAXPROCS=2 golangci-lint run --concurrency 1 --output.text.path /dev/null --output.json.path stdout
- bounded CGO desktop build with go build -p=1
- [real GitHub Android run](https://github.com/Picocrypt-NG/Picocrypt-NG/actions/runs/29403054527): AAR, unit tests, debug/release APK, API 24 crypto/filesystem, and API 36 crypto/UI suites

## Deliberately out of scope
- production de/fr/es/zh-Hans/hi catalogs
- bundled fonts or runtime font installation
- native Android app code, CLI, WASM, crypto, and release metadata

## Follow-up gates
Each catalog receives its own PR with native linguistic and security review. Hindi first requires grapheme-safe truncation; Chinese and Hindi require real packaged system-font and shaping evidence.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #235
- <kbd>&nbsp;5&nbsp;</kbd> #234
- <kbd>&nbsp;4&nbsp;</kbd> #233
- <kbd>&nbsp;3&nbsp;</kbd> #232
- <kbd>&nbsp;2&nbsp;</kbd> #231
- <kbd>&nbsp;1&nbsp;</kbd> #230 👈 
<!-- GitButler Footer Boundary Bottom -->