### PR TITLE
Integrate secure Hosted Weblate workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ Picocrypt NG provides a browser app <a href="https://picocrypt-ng.github.io/">he
 ## Translations
 Community translations for Picocrypt NG are hosted in the
 [Picocrypt-NG Weblate project](https://hosted.weblate.org/projects/picocrypt-ng/).
-The desktop and native Android components accept target-language corrections
-and proposals for new languages. Component configuration disables editing the
-base English catalogs and managing source string IDs. Every Weblate repository
-change is proposed from a fork through a GitHub pull request; human approval and
-the required CI checks remain mandatory before merge. The complete operational
-contract is recorded in
+When the project is operationally unlocked, the desktop and native Android
+components accept target-language corrections and proposals for new languages.
+Component configuration disables editing the base English catalogs and
+managing source string IDs. Every Weblate repository change is proposed from a
+fork through a GitHub pull request; human approval and the required CI checks
+remain mandatory before merge. The complete operational contract is recorded in
 [WEBLATE_SETUP.md](docs/localization/WEBLATE_SETUP.md).
 
 Security-sensitive wording must preserve the meaning documented in the

--- a/README.md
+++ b/README.md
@@ -77,24 +77,30 @@ Picocrypt NG includes a command-line interface in this repository; see <a href="
 Picocrypt NG provides a browser app <a href="https://picocrypt-ng.github.io/">here</a> for in-memory single-file encryption and decryption on modern browsers, including mobile devices. In this repository, the WASM bridge caps inputs at 1 GiB and supports comments, Paranoid mode, Reed-Solomon payload protection, force decrypt, deniability, and decryption of supported legacy keyfile volumes. Picocrypt-NG 2.19 encryption is password-only: the bridge rejects every request containing keyfiles instead of creating another v2 keyfile volume. The browser workflow is still intentionally non-streaming and single-file oriented; folder workflows, split volumes, and large streaming jobs remain desktop/CLI/native-app features. Go-owned byte buffers are wiped best-effort after use, but JavaScript engine copies and garbage-collected runtime copies cannot be guaranteed wiped. The hosted page is deployed separately and must use a consumer matching the 2.19 bridge error contract.
 
 ## Translations
-Picocrypt NG is prepared to use Hosted Weblate for community UI translations
-after the setup gates in
-[WEBLATE_SETUP.md](docs/localization/WEBLATE_SETUP.md) are complete.
-Translation work is reviewed before merge, and security-sensitive wording must
-preserve the meaning documented in the
-[translation guide](docs/localization/TRANSLATION_GUIDE.md).
+Community translations for Picocrypt NG are hosted in the
+[Picocrypt-NG Weblate project](https://hosted.weblate.org/projects/picocrypt-ng/).
+The desktop and native Android components accept target-language corrections
+and proposals for new languages. Component configuration disables editing the
+base English catalogs and managing source string IDs. Every Weblate repository
+change is proposed from a fork through a GitHub pull request; human approval and
+the required CI checks remain mandatory before merge. The complete operational
+contract is recorded in
+[WEBLATE_SETUP.md](docs/localization/WEBLATE_SETUP.md).
+
+Security-sensitive wording must preserve the meaning documented in the
+[translation guide](docs/localization/TRANSLATION_GUIDE.md). Community
+linguistic review is continuous, so the bundled catalogs are not presented as
+certified native-language reviews.
+
 Current desktop and native Android builds bundle application UI catalogs for
 English, Russian, German, French, Spanish, Simplified Chinese, Hindi, and Korean
 (`ko`, with contemporary neutral South Korean wording). The desktop app has an
 in-app language selector for Picocrypt-NG-owned UI; Fyne-owned dialogs and raw
 backend status text may remain English. Android 13 and newer expose the system
 per-app language selector; older Android versions follow the system locale. The
-CLI remains English-only.
-
-The six new Android catalogs (`de`, `fr`, `es`, `zh-Hans`, `hi`, and `ko`) are
-structurally complete and packaged, but this does not establish native-language
-or device review. They still require native or near-native linguistic review
-and real-device rendering checks before release admission.
+CLI remains English-only. Catalog structure, placeholders, plurals, and locale
+registration are enforced in repository tests; translation and rendering
+corrections continue through the same reviewed pull-request workflow.
 
 ## File Associations
 Double-click `.pcv` files to open Picocrypt NG in decrypt mode on Windows, macOS, and Linux. Installer/`.deb`/`.app` packages register the association automatically.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import com.android.build.api.variant.FilterConfiguration.FilterType.ABI
+import org.gradle.api.tasks.testing.Test
 
 plugins {
     alias(libs.plugins.android.application)
@@ -124,8 +125,12 @@ android {
     }
 }
 
-tasks.matching { it.name == "testDebugUnitTest" }.configureEach {
+tasks.withType<Test>().matching { it.name == "testDebugUnitTest" }.configureEach {
     dependsOn("processReleaseResources")
+    systemProperty(
+        "picocrypt.releaseLocaleFilters",
+        android.androidResources.localeFilters.joinToString(","),
+    )
 }
 
 kotlin {

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/LocaleConfigurationPolicyTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/LocaleConfigurationPolicyTest.kt
@@ -13,6 +13,9 @@ class LocaleConfigurationPolicyTest {
     private val resourcesProperties = File("src/main/res/resources.properties")
     private val sourceManifest = File("src/main/AndroidManifest.xml")
     private val buildRoot = File("build")
+    private val expectedGeneratedLocales by lazy {
+        releaseLocaleFilters().mapTo(mutableSetOf(), ::generatedLocaleTag)
+    }
 
     @Test
     fun `source declares generated and filtered locale policy`() {
@@ -21,13 +24,6 @@ class LocaleConfigurationPolicyTest {
         val androidResourcesBlock = androidBlock?.let { blockNamed(it, "androidResources") }
         val buildTypesBlock = androidBlock?.let { blockNamed(it, "buildTypes") }
         val debugBlock = buildTypesBlock?.let { blockNamed(it, "debug") }
-        val debugUnitTestBlock = blockAfter(
-            buildText,
-            Regex(
-                """tasks\.matching\s*\{\s*it\.name\s*==\s*"testDebugUnitTest"\s*}""" +
-                    """\.configureEach\s*\{""",
-            ),
-        )
         val issues = mutableListOf<String>()
 
         if (androidResourcesBlock?.contains(Regex("""\bgenerateLocaleConfig\s*=\s*true\b""")) != true) {
@@ -45,17 +41,6 @@ class LocaleConfigurationPolicyTest {
             }
         }
 
-        val configurationMatches = androidResourcesBlock
-            ?.let { localeFilters.findAll(it).toList() }
-            .orEmpty()
-        val configuredLocales = configurationMatches.singleOrNull()
-            ?.groupValues
-            ?.get(1)
-            ?.let { body -> quotedValue.findAll(body).map { it.groupValues[1] }.toList() }
-        if (configuredLocales != expectedResourceConfigurations) {
-            issues += "androidResources.localeFilters=" + configuredLocales +
-                "; want " + expectedResourceConfigurations
-        }
         val legacyFilters = androidBlock
             ?.let { legacyResourceConfigurations.findAll(it).map { match -> match.value }.toList() }
             .orEmpty()
@@ -65,10 +50,6 @@ class LocaleConfigurationPolicyTest {
         if (debugBlock?.contains(Regex("""\bisPseudoLocalesEnabled\s*=\s*true\b""")) != true) {
             issues += "debug pseudolocales must remain enabled"
         }
-        if (debugUnitTestBlock?.contains(Regex("""dependsOn\("processReleaseResources"\)""")) != true) {
-            issues += "testDebugUnitTest must depend on processReleaseResources"
-        }
-
         assertTrue("Locale configuration policy violations: " + issues, issues.isEmpty())
     }
 
@@ -165,6 +146,24 @@ class LocaleConfigurationPolicyTest {
         assertTrue("Generated release LocaleConfig policy violations: " + issues, issues.isEmpty())
     }
 
+    private fun releaseLocaleFilters(): List<String> {
+        val configured = System.getProperty(releaseLocaleFiltersProperty)
+            ?.split(",")
+            ?.filter(String::isNotBlank)
+            .orEmpty()
+        check(configured.isNotEmpty()) {
+            "Missing $releaseLocaleFiltersProperty; run this test through Gradle"
+        }
+        return configured
+    }
+
+    private fun generatedLocaleTag(resourceConfiguration: String): String {
+        if (resourceConfiguration.startsWith("b+")) {
+            return resourceConfiguration.removePrefix("b+").replace("+", "-")
+        }
+        return resourceConfiguration.replace(androidRegionQualifier, "-")
+    }
+
     private fun blockNamed(source: String, name: String): String? {
         return blockAfter(source, Regex("""\b""" + Regex.escape(name) + """\s*\{"""))
     }
@@ -244,25 +243,11 @@ class LocaleConfigurationPolicyTest {
 
     private companion object {
         private const val androidNamespace = "http://schemas.android.com/apk/res/android"
-        private val expectedResourceConfigurations = listOf(
-            "en",
-            "ru",
-            "de",
-            "fr",
-            "es",
-            "b+zh+Hans",
-            "hi",
-            "ko",
-        )
-        private val expectedGeneratedLocales = setOf("en", "ru", "de", "fr", "es", "zh-Hans", "hi", "ko")
-        private val localeFilters = Regex(
-            """\blocaleFilters\s*\+=\s*listOf\((.*?)\)""",
-            RegexOption.DOT_MATCHES_ALL,
-        )
+        private const val releaseLocaleFiltersProperty = "picocrypt.releaseLocaleFilters"
+        private val androidRegionQualifier = Regex("""-r(?=[A-Z]{2}(?:$|-)|\d{3}(?:$|-))""")
         private val legacyResourceConfigurations = Regex(
             """\b(?:resourceConfigurations|resConfigs?)\b""",
         )
-        private val quotedValue = Regex(""""([^"]+)"""")
         private val versionedXmlDirectory = Regex("""xml-v\d+""")
         private val localeConfigReference = Regex("""android:localeConfig\s*=\s*"([^"]+)"""")
     }

--- a/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/LocalizationResourcesTest.kt
+++ b/android/app/src/test/java/io/github/picocrypt_ng/picocrypt_ng/LocalizationResourcesTest.kt
@@ -27,12 +27,48 @@ class LocalizationResourcesTest {
     }
 
     @Test
-    fun `all release locale catalogs exist`() {
-        val missingCatalogs = localeSpecs
-            .filterNot { it.file.isFile }
-            .map { it.file.path }
+    fun `release locale filters catalogs and semantic checks stay in lockstep`() {
+        val configuredLocales = System.getProperty(releaseLocaleFiltersProperty)
+            ?.split(",")
+            ?.filter(String::isNotBlank)
+            .orEmpty()
+        check(configuredLocales.isNotEmpty()) {
+            "Missing $releaseLocaleFiltersProperty; run this test through Gradle"
+        }
+        val configuredCatalogDirectories = configuredLocales
+            .map { locale ->
+                if (locale == baseLocaleSpec.tag) {
+                    baseLocaleSpec.resourceDirectory
+                } else {
+                    "values-$locale"
+                }
+            }
+            .toSortedSet()
+        val repositoryCatalogDirectories = stringsFile.parentFile
+            ?.parentFile
+            ?.listFiles()
+            .orEmpty()
+            .filter { directory ->
+                directory.isDirectory &&
+                    (directory.name == "values" || directory.name.startsWith("values-")) &&
+                    File(directory, "strings.xml").isFile
+            }
+            .map(File::getName)
+            .toSortedSet()
+        val semanticallyCheckedDirectories = (listOf(baseLocaleSpec) + localeSpecs)
+            .map(LocaleSpec::resourceDirectory)
+            .toSortedSet()
 
-        assertTrue("Missing translation catalogs: $missingCatalogs", missingCatalogs.isEmpty())
+        assertEquals(
+            "Repo-owned strings.xml catalogs must exactly match androidResources.localeFilters",
+            configuredCatalogDirectories,
+            repositoryCatalogDirectories,
+        )
+        assertEquals(
+            "Every release catalog must participate in localization semantic checks",
+            configuredCatalogDirectories,
+            semanticallyCheckedDirectories,
+        )
     }
 
     @Test
@@ -646,6 +682,7 @@ class LocalizationResourcesTest {
     private data class TextResource(val name: String, val text: String)
 
     private companion object {
+        private const val releaseLocaleFiltersProperty = "picocrypt.releaseLocaleFilters"
         private val baseLocaleSpec = LocaleSpec(
             tag = "en",
             displayName = "English",

--- a/docs/localization/TRANSLATION_GUIDE.md
+++ b/docs/localization/TRANSLATION_GUIDE.md
@@ -6,7 +6,7 @@
 This guide defines the translation foundation for Picocrypt-NG. It is not a
 string catalog and does not enable localization by itself. It defines the voice,
 terminology, review rules, and tooling constraints that every future translation
-or Weblate import must follow.
+or Weblate pull request must follow.
 
 Picocrypt-NG is a security-sensitive encryption app. Translation quality is a
 security UX concern: translated strings must not promise stronger protection
@@ -17,8 +17,8 @@ integrity, password, keyfile, corruption, and deletion concepts.
 
 | Surface | Current state | Translation path |
 |---|---|---|
-| Desktop Fyne UI | Complete bundled application catalogs exist for English, Russian, German, French, Spanish, Simplified Chinese, Hindi, and Korean under `src/internal/ui/translation`. Fyne-owned dialogs and raw backend status text may remain English. | Keep using the project `tr`/`trn` wrappers. Russian has its curated review gate; the Korean review record documents model-assisted review and still-open native/device gates; Weblate-imported Fyne locales still require a Fyne/Weblate JSON round-trip. |
-| Android app | Release resources package the same eight languages: base English plus Russian, German, French, Spanish, Simplified Chinese, Hindi, and Korean. Raw Go/runtime details are not translator source copy. | Continue with Android string resources and explicit semantic display-boundary mappings. The six new catalogs still require human/device release admission. |
+| Desktop Fyne UI | Complete bundled application catalogs exist for English, Russian, German, French, Spanish, Simplified Chinese, Hindi, and Korean under `src/internal/ui/translation`. Fyne-owned dialogs and raw backend status text may remain English. | Use the live Weblate Desktop app component and keep the project `tr`/`trn` wrappers. Weblate uses the native go-i18n v2 JSON format; repository tests remain authoritative for keys, placeholders, plural shapes, and runtime registration. |
+| Android app | Release resources package the same eight languages: base English plus Russian, German, French, Spanish, Simplified Chinese, Hindi, and Korean. Raw Go/runtime details are not translator source copy. | Use the live Weblate Android app component, Android string resources, and explicit semantic display-boundary mappings. Repository tests keep resource files, release filters, generated LocaleConfig, and semantic checks in lockstep. |
 | CLI | Cobra help, prompts, warnings, and errors are hard-coded Go strings. | Do not localize CLI output, command names, flags, or examples. Keep CLI English-only. |
 | Web/WASM | The Go WASM bridge exports functions and numeric error codes; it does not own the hosted web UI copy. | Localize the web frontend separately if/when that source is brought into scope. |
 
@@ -30,7 +30,8 @@ Non-goals for the first localization phase:
 - Do not localize the CLI. CLI help, prompts, errors, stdout/stderr, command
   names, flags, and examples are an English scripting contract.
 - Do not translate comments stored inside user volumes. Those are user data.
-- Do not add Weblate before stable string IDs, a glossary, and review rules exist.
+- Do not let Weblate edit base English catalogs, manage source string IDs, or
+  push directly to `main`.
 
 ## String Source Of Truth
 
@@ -42,7 +43,7 @@ The source of truth is platform-native:
 | Surface | Source of truth | Rule |
 |---|---|---|
 | Android app | `android/app/src/main/res/values/strings.xml` | The base English file owns Android UI strings that are resource-backed. Hard-coded Kotlin user messages must be externalized or explicitly mapped before a locale can be released for Android. |
-| Desktop Fyne UI | `src/internal/ui/translation/en.json` | Keep the embedded catalog wired through `loadTranslations` and the project `tr`/`trn` wrappers. Do not add locale files without guard tests and either a language-specific review gate or a round-trip check. |
+| Desktop Fyne UI | `src/internal/ui/translation/en.json` | Keep the embedded catalog wired through `loadTranslations` and the project `tr`/`trn` wrappers. Do not add locale files without complete-catalog, plural, placeholder, and runtime-registration tests. |
 | CLI | none | CLI is not localized. |
 | Web/WASM | external web frontend source, if brought into scope | Do not add web UI strings to the Go WASM bridge. |
 
@@ -61,9 +62,7 @@ Use these sources before adding or changing localization mechanics:
 - Android language and layout support: <https://developer.android.com/training/basics/supporting-devices/languages>
 - Android pseudolocales: <https://developer.android.com/guide/topics/resources/pseudolocales>
 - Weblate Android resources: <https://docs.weblate.org/en/latest/formats/android.html>
-- Weblate JSON formats: <https://docs.weblate.org/en/latest/formats/json.html>
-- Weblate i18next formats: <https://docs.weblate.org/en/latest/formats/i18next.html>
-- Weblate gettext formats: <https://docs.weblate.org/en/latest/formats/gettext.html>
+- Weblate go-i18n JSON: <https://docs.weblate.org/en/latest/formats/go-i18n.html>
 - Weblate quality checks: <https://docs.weblate.org/en/latest/user/checks.html>
 - Weblate hosted pricing and Libre plan: <https://weblate.org/en/hosting/>
 - Unicode CLDR plural rules: <https://cldr.unicode.org/index/cldr-spec/plural-rules>
@@ -139,13 +138,14 @@ Picocrypt-NG keeps Fyne/Weblate-shaped flat JSON catalogs under
   `status.kept_output_unverified`, `comments.placeholder`,
   `advanced.delete_volume.label`, and `drop.header_may_be_deniable`.
 - Do not put translator comments in Fyne JSON. Keep context in this guide,
-  Weblate component metadata, or a review-only companion file.
+  Weblate component metadata, or another maintained project document.
 
-Before connecting Fyne JSON to Weblate, run a round-trip test on the exact Fyne
-JSON shape Picocrypt-NG uses. Generic Weblate JSON is useful for simple key/value
-files, but its plain JSON format does not carry all plural/context metadata.
-The curated Russian catalog is a native-review exception, not evidence that the
-Fyne Weblate component is ready.
+The live Weblate Desktop app component uses **go-i18n v2 JSON**, not generic
+JSON or i18next. This format preserves Picocrypt-NG's plural objects and
+`{{.Name}}` template markers. On 2026-07-25 Weblate imported all eight desktop
+catalogs as 141 strings each, and downloads of every imported catalog were
+byte-identical to the repository files. Keep the base English file read-only
+and keep source-string management disabled.
 
 ### Fyne fonts and packaged rendering
 
@@ -158,15 +158,14 @@ and Spanish. Simplified Chinese, Korean, and Hindi depend on suitable fonts
 already available to the operating system. Fyne shapes text with HarfBuzz, but
 its preferred system face follows the operating-system locale rather than the
 language selected inside Picocrypt-NG. Therefore `zh-Hans`, `ko`, and `hi`
-require real packaged-build review both with matching and non-matching OS
-locales.
+benefit from packaged-build review with matching and non-matching OS locales.
 
-Before release admission for any of these locales, reject screenshots
-containing tofu, replacement glyphs, wrong Simplified-Chinese regional forms,
+Treat screenshots containing any of the following as rendering defects: tofu,
+replacement glyphs, wrong Simplified-Chinese regional forms,
 detached Hindi matras, dotted circles, exposed halants, broken conjuncts,
 clipped vertical metrics, hidden controls, or window growth beyond the normal
-340 px desktop width. Missing system coverage blocks that locale on the
-affected target; it does not authorize adding an unreviewed font asset.
+340 px desktop width. Missing system coverage does not authorize adding an
+unreviewed font asset.
 
 Emoji and arbitrary mixed-script filenames/comments are platform best-effort.
 Font fallback must not change the underlying application string or selected
@@ -203,16 +202,17 @@ Android must use native string resources.
 - Mark non-translatable technical strings with `translatable="false"` when they
   are resource-backed.
 - Run Android pseudolocale checks before accepting broad UI localization.
-- The eight catalogs being structurally complete and packaged does not replace
-  native or near-native linguistic review or device rendering. German, French,
-  Spanish, Simplified Chinese, Hindi, and Korean still require those release
-  gates.
+- Structural completeness and packaging do not certify linguistic quality or
+  rendering. Community corrections remain welcome through reviewed Weblate
+  pull requests.
 
-Weblate setup for Android should use:
+The live Weblate Android app component uses:
 
 - File mask: `android/app/src/main/res/values-*/strings.xml`
 - Base language file: `android/app/src/main/res/values/strings.xml`
 - Format: Android String Resource
+- Base editing and source-string management: disabled
+- Repository delivery: fork-based GitHub pull requests
 
 ### CLI
 
@@ -227,11 +227,13 @@ the bridge API stable and localize the hosted web frontend where the UI lives.
 
 ### Hosted Weblate
 
-As of 2026-07-08, Weblate's official pricing page says libre public projects can
-use a hosted Libre plan gratis, with the same limits as the 160k hosted plan.
-Verify the current terms before setup. Self-hosting remains the fallback if the
-hosted eligibility rules change or if Picocrypt-NG needs stricter operational
-control.
+The live public project is
+<https://hosted.weblate.org/projects/picocrypt-ng/>. The Android and desktop
+components share one GitHub App repository integration and can only propose
+repository changes through pull requests. See
+[WEBLATE_SETUP.md](WEBLATE_SETUP.md) for the exact security and operational
+contract. Self-hosting remains the fallback if Hosted Libre terms or required
+controls change.
 
 Failing Weblate checks for placeholders, XML validity, tags, whitespace,
 newlines, plurals, or glossary rules are release blockers unless a maintainer
@@ -279,7 +281,11 @@ Language-specific voice:
 
 ## Product Glossary
 
-Use these translations unless a maintainer deliberately changes the glossary.
+This table records terminology already present in current or planned catalogs;
+it is a review aid, not automatic approval of a translation. Human-reviewed
+target entries in the live Weblate glossary and the exact pull-request diff are
+authoritative for new changes. If this table disagrees with an approved
+Weblate entry, update the table instead of blending the two wordings.
 
 | English concept | Russian | French | German | Spanish | Italian |
 |---|---|---|---|---|---|
@@ -445,7 +451,8 @@ Initial high-risk entries:
 
 ## Reviewer Checklist
 
-Every localization PR or Weblate merge must answer these checks:
+Every localization pull request, including one generated by Weblate, must
+answer these checks:
 
 1. Does the translation preserve Picocrypt-NG's security meaning?
 2. Are password, keyfile, authentication, integrity, and corruption terms
@@ -471,42 +478,40 @@ Every localization PR or Weblate merge must answer these checks:
 16. Are Android build and pseudolocale checks requested only when Android
     resources are actually part of the localization change?
 
-## Implementation Readiness Gates
+## Pull Request And Release Gates
 
-Before admitting any locale to a release:
+Before merging a localization pull request:
 
-- The locale has a native or near-native linguistic review and a maintainer
-  security-meaning review against this guide.
+- Weblate has written only approved units, and a human repository reviewer has
+  reviewed the exact pull-request diff.
+- A maintainer has checked security-sensitive meaning against this guide.
 - No enabled surface depends on untranslated user-facing source text that
   bypasses its platform catalog.
 - All placeholder, plural, syntax, and glossary checks are clean.
-- Release notes describe localization as UI work, not a cryptographic change.
+- Required repository CI is green.
 
-Before admitting a Fyne desktop locale to a release:
+Before merging a new Fyne desktop locale:
 
 - The catalog is complete against `src/internal/ui/translation/en.json` and
-  passes the generic embedded-catalog contract.
+  passes the embedded-catalog contract.
+- The locale, native display name, and plural forms are registered in the
+  runtime and its tests.
 - Runtime language switching and preference restoration preserve the full
   locale code.
-- Core workflows have been checked in a real packaged application: initial,
-  encrypt, decrypt, keyfiles, comments, force decrypt, verify-first, deletion
-  options, progress, and dialogs.
-- Windows 10/11 installer and portable builds, the supported macOS `.app`, and
-  Linux raw, `.deb`, and AppImage builds have no clipped controls or unexpected
-  width growth. Flatpak and Snap are checked when that catalog ships through
-  those channels.
-- Simplified Chinese, Korean, and Hindi additionally pass the system-font and
-  shaping checks in this guide. Hindi also requires grapheme-safe
-  application-owned truncation before `hi.json` is admitted.
+- Known rendering defects are documented and must not hide or reverse
+  security-sensitive meaning or destructive actions.
 
-Before admitting a native Android locale to a release:
+Before merging a new native Android locale:
 
 - Android resources compile and the relevant UI passes pseudolocale checks.
+- The resource directory, `androidResources.localeFilters`, generated release
+  LocaleConfig, and semantic catalog registry are in exact lockstep.
 - Hard-coded Kotlin user messages for the localized surface have been
   externalized or explicitly mapped.
 - Status, detail, and error mappings use semantic resource-backed values; raw
   diagnostic strings are not shown as translated UI.
-- Native or near-native linguistic review and real-device rendering cover text
-  expansion, notifications, font scale, Chinese line breaking, Korean
-  typography and line breaking, and Hindi shaping. Packaging a locale does not
-  waive this gate.
+
+Community linguistic and real-device review continues after merge as well as
+before it. Do not describe a catalog as native-reviewed unless that review is
+actually documented, and describe localization in release notes as UI work,
+not a cryptographic change.

--- a/docs/localization/WEBLATE_SETUP.md
+++ b/docs/localization/WEBLATE_SETUP.md
@@ -1,178 +1,223 @@
 # Picocrypt-NG Weblate Setup
 
-This document is the setup gate for Weblate localization in Picocrypt-NG. It is
-operational policy, not a marketing page. Do not open Weblate components until
-the gates below are satisfied.
+This document records the operational and security contract for Picocrypt-NG
+localization on Hosted Weblate.
 
-## Eligibility
+Last verified: 2026-07-25.
 
-Eligibility verification date: 2026-07-08.
+## Live Project
 
-Current result: Picocrypt-NG is likely eligible for hosted Weblate Libre while
-it remains a public libre project. Reverify this before actual setup; this is a
-dated finding, not a permanent entitlement.
+- Project: <https://hosted.weblate.org/projects/picocrypt-ng/>
+- Android app:
+  <https://hosted.weblate.org/projects/picocrypt-ng/android-app/>
+- Desktop app:
+  <https://hosted.weblate.org/projects/picocrypt-ng/desktop-app/>
+- Terminology:
+  <https://hosted.weblate.org/projects/picocrypt-ng/terminology/>
+- License: `GPL-3.0-only`
 
-Weblate's hosted pricing page says the hosted Libre plan is gratis for libre
-public projects and has the same limits as the 160k hosted plan. It also says
-the hosted Libre plan is only for public projects.
+The Hosted Weblate GitHub App is installed only for
+`Picocrypt-NG/Picocrypt-NG`. Do not add a personal access token, deploy key,
+legacy Weblate collaborator, or second Weblate-controlled GitHub identity.
 
-If hosted terms change, Picocrypt-NG no longer qualifies, or release-control
-requirements exceed hosted Libre controls, self-host Weblate instead.
+## Security Boundary
 
-## Hosted Libre Risk
+Hosted Weblate Libre projects are public. Treat every translation as an
+untrusted proposal until both Weblate review and GitHub repository controls
+accept it.
 
-Hosted Weblate gratis Libre projects are always Public. In Weblate access
-control, Public means visible to everybody, and any authenticated user can
-contribute.
+The required controls are:
 
-Mitigation:
+- The repository owner is the only component connected directly to GitHub.
+  It uses `github-app`, targets `main`, and has empty push URL and push branch.
+  In this configuration Hosted Weblate proposes changes from its fork through
+  a pull request instead of pushing to `main`.
+- The desktop component links to the Android component with
+  `weblate://picocrypt-ng/android-app`, so both surfaces share one repository
+  and one pull-request integration.
+- GitHub protection for `main` combines an active ruleset requiring a pull
+  request, at least one human approval, and dismissal of stale approvals after
+  a new push with strict required CI checks in classic branch protection.
+- The Weblate GitHub App is not a ruleset bypass actor.
+- The repository owner retains an emergency ruleset bypass for recovery. It is
+  not assigned to the Weblate App and must not be used for localization pull
+  requests.
+- Project review is enabled and the commit policy writes only approved
+  translations.
+- The review team enforces two-factor authentication and has an active
+  maintainer member.
+- Automatic suggestion acceptance is disabled.
+- Editing base English files and managing source strings are disabled in both
+  application components.
+- Cross-component translation propagation and contribution to project
+  translation memory are disabled. Shared terminology belongs in the glossary.
+- Components automatically lock on repository errors.
 
-- Treat Weblate contributions as proposed translations only.
-- Require Weblate pull requests for repository changes.
-- Require maintainer review, security review where applicable, and CI before
-  merge.
-- Never allow Weblate to push directly to protected release branches.
-- Use Weblate locking and review features during pull request review so
-  translation changes do not move under review.
+These controls are layered deliberately. Weblate approval protects the normal
+translation workflow; the GitHub ruleset and CI remain the security boundary
+if the Weblate account or App is compromised.
 
-## Setup Gates
+## Review Workflow
 
-Before opening any component:
+1. A contributor edits an existing target language or requests a new language
+   in Weblate.
+2. A Weblate reviewer approves the proposed units. Imported repository content
+   must not be bulk-approved merely to make statistics green.
+3. Weblate creates or updates a pull request from its fork.
+4. GitHub CI validates catalog structure, placeholders, plurals, locale
+   registration, and the affected application build.
+5. A human repository reviewer inspects the exact diff and approves it.
+6. A maintainer merges the pull request.
 
-1. Reverify hosted Libre eligibility and access-control behavior.
-2. Import the Picocrypt-NG glossary and security terms into Weblate.
-3. Configure Weblate to create pull requests, not direct protected-branch
-   pushes.
-4. Confirm required review and CI branch protection on the target branch.
-5. Confirm reviewers understand the P0/P1 rules in
-   [TRANSLATION_GUIDE.md](TRANSLATION_GUIDE.md).
-
-Glossaries can be imported with CSV or TBX. Use glossary entry types to mark
-brand names, acronyms, features, and security terms by meaning and audience:
-regular, Terminology, Untranslatable, or Forbidden.
-
-Weblate checks for placeholders, XML validity, tags, whitespace, newlines,
-plurals, and glossary issues are technical gates. They do not replace
-native-language review or maintainer/security review.
-
-## Review Rules
-
-- Machine translation may be suggestions only for P0/P1 strings.
-- P0/P1 strings require native-language review plus maintainer/security review.
-- Placeholder and format checks must be clean before merge, or a maintainer
-  must record why a warning is accepted.
-- Maintainers must reject translations that overpromise confidentiality,
-  recovery, deniability, or security.
-- Comments must remain described as plaintext metadata.
-- Authentication, password, keyfile, corruption, and integrity terms must stay
-  distinct.
+Community linguistic review is continuous. Existing bundled translations are
+not presented as certified native-language reviews; corrections follow the
+same reviewed pull-request path.
 
 ## Components
 
 ### Android App
 
-Enable Android first, after Android localization gates pass.
-
-Configuration:
-
-- Component: Android app
+- VCS owner: yes
+- VCS: GitHub via Hosted Weblate GitHub App
+- Branch: `main`
+- Push URL: empty
+- Push branch: empty
 - File mask: `android/app/src/main/res/values-*/strings.xml`
 - Base file: `android/app/src/main/res/values/strings.xml`
 - Format: Android String Resource
-- Base language: `en`
-- Translated languages after Android gates: `ru`, `de`, `fr`, `es`, `zh-Hans`, `hi`, `ko`
-- Android directory mapping: `zh-Hans` uses `values-b+zh+Hans`; Korean uses generic `values-ko`; Italian is not packaged
+- Base language: English
+- Edit base file: disabled
+- Manage strings: disabled
+- Adding a translation: create a new language file
+- Language-code style: Android
 
-Android string resources are monolingual in Weblate. The base file is
-`res/values/strings.xml`, and the typical translated file mask is
-`res/values-*/strings.xml`. Weblate's Android String Resource format supports
-plurals and flags/read-only strings. These are application UI resources;
-Fastlane currently has a separate English-only `en-US` store-listing/changelog
-surface and must not be inferred from the app-resource language list.
+The imported languages are `en`, `ru`, `de`, `fr`, `es`, `zh-Hans`, `hi`, and
+`ko`. Weblate maps Simplified Chinese to `values-b+zh+Hans`; Korean uses
+`values-ko`.
 
-### Fyne Desktop
+Android release admission is intentionally separate from file creation. The
+repository test suite requires the actual `strings.xml` directories,
+`androidResources.localeFilters`, generated release LocaleConfig, and semantic
+catalog registry to stay in lockstep. A pull request adding a language cannot
+merge until all of those contracts and the relevant plural rules are updated.
 
-Do not enable yet.
+### Desktop App
 
-Fyne Weblate setup is blocked until Picocrypt-NG proves exact round-trip for
-the Fyne JSON catalog shape in `src/internal/ui/translation/en.json`.
-
-Eight complete desktop catalogs currently exist for `en`, `ru`, `de`, `fr`,
-`es`, `zh-Hans`, `hi`, and `ko`, but no Fyne/Weblate JSON round-trip has been proved.
-The curated Russian Fyne catalog is a maintainer-reviewed in-repository
-translation exception. The Korean catalog is an engineering-reviewed
-in-repository exception and still requires native-language and device review
-before release. Both catalogs are gated by structural and semantic regression
-tests, not by Weblate. Those tests do not prove that Weblate can safely edit
-Fyne JSON catalogs.
-
-The desktop language selector does not by itself enable a Fyne Weblate
-component. Additional non-English Fyne production catalogs that are imported
-from Weblate remain blocked until a real Weblate JSON round-trip proves that
-Picocrypt-NG's flat keys, plural objects, UTF-8 content, and placeholder syntax
-survive export and import unchanged.
-
-Blocked configuration, for later validation only:
-
-- Component: Fyne desktop
+- VCS owner: no; linked to `Android app`
+- Repository link: `weblate://picocrypt-ng/android-app`
 - File mask: `src/internal/ui/translation/*.json`
 - Base file: `src/internal/ui/translation/en.json`
-- Format: JSON or JSON nested structure file, only after round-trip validation
+- Format: go-i18n v2 JSON
+- Base language: English
+- Edit base file: disabled
+- Manage strings: disabled
+- Adding a translation: create a new language file
+- Language-code style: BCP 47 with hyphens
 
-Required proof before opening the component:
+Do not switch this component to generic JSON or i18next. Picocrypt-NG catalogs
+use go-i18n v2 plural objects such as:
 
-- Weblate export/import preserves existing keys and object shape.
-- Fyne plural objects survive unchanged, for example:
-
-  ```json
-  {
-    "keyfiles.count": {
-      "one": "Using {{.Count}} keyfile",
-      "other": "Using {{.Count}} keyfiles"
-    }
+```json
+{
+  "keyfiles.count": {
+    "one": "{{.Count}} keyfile",
+    "other": "{{.Count}} keyfiles"
   }
-  ```
+}
+```
 
-- Placeholder markers such as `{{.Count}}` survive unchanged.
-- Fyne tests still pass after Weblate round-trip.
-
-Weblate's JSON docs say simple and nested JSON are supported and monolingual
-JSON with an English base is recommended, but generic JSON has no native plural
-support. Do not enable Fyne until that limitation is proven safe for the exact
-Fyne catalog objects Picocrypt-NG uses.
+On 2026-07-25 Hosted Weblate imported all eight desktop catalogs as 141 strings
+each. Downloads of every imported catalog were byte-identical to the
+corresponding repository file. Repository tests independently require exact
+keys, message shapes, placeholders, locale plural forms, and language
+registration.
 
 ### CLI
 
-No component.
+No component. Command names, flags, help, diagnostics, stdout/stderr, and shell
+examples remain an English scripting contract.
 
-CLI output, command names, flags, examples, stdout/stderr contracts, and
-diagnostics remain English-only.
+## New Languages
 
-## GitHub Integration
+Weblate may create a target-language file, but the file alone does not make the
+language shippable.
 
-Hosted Weblate can use the Hosted Weblate GitHub app to grant repository
-access, receive notifications, push translation branches, and create pull
-requests.
+An Android language pull request must also:
 
-Picocrypt-NG must configure that integration for pull requests only. Protected
-branches must require actual review and CI. Do not waive protected-branch
-review for a Weblate push user.
+- add the Android resource qualifier to `androidResources.localeFilters`;
+- register its catalog and CLDR plural quantities in the localization tests;
+- pass the generated release LocaleConfig and Android localization tests.
+
+A desktop language pull request must also:
+
+- register the locale and its native display name in the desktop language list;
+- define and test the go-i18n plural contract for the locale;
+- pass the embedded-catalog, placeholder, and runtime localization tests.
+
+This permits contributors to propose new languages while ensuring that an
+unregistered or untested catalog cannot silently enter a release.
+
+## Glossary
+
+The project glossary owns shared security terminology and explanations. It
+currently contains 19 source terms covering:
+
+- Picocrypt NG and Picocrypt-NG;
+- Reed-Solomon;
+- encryption and decryption;
+- password and keyfile;
+- comments as plaintext metadata;
+- authentication, integrity, and corruption;
+- deniability and Paranoid mode;
+- force decrypt and verify first;
+- destructive delete actions.
+
+`Picocrypt NG`, `Picocrypt-NG`, and `Reed-Solomon` are both terminology and
+untranslatable entries, so Weblate keeps their spelling in every glossary
+language. The remaining terminology entries deliberately await human
+target-language translations. Glossary guidance does not replace the
+repository's semantic regression tests or human review.
+
+## Operational Checks
+
+Before opening components after setup or an incident:
+
+1. Confirm the project and every component are locked while configuration is
+   changing.
+2. Confirm the GitHub App is still limited to this repository.
+3. Confirm the VCS owner still uses `github-app`, with empty push URL and push
+   branch, and the desktop component is still linked to it.
+4. Confirm base editing, source-string management, propagation, project
+   translation memory, and suggestion auto-accept remain disabled.
+5. Confirm approved-only commits and the GitHub approval/CI rules are active.
+6. Confirm a real upstream merge reaches Weblate through the GitHub App hook.
+7. Use the first genuine approved translation correction as the outbound
+   canary; do not fabricate a translation solely to create a test pull request.
+
+If any invariant fails, keep the project locked and repair the configuration
+before accepting contributions.
+
+## Hosted Libre
+
+Eligibility was rechecked on 2026-07-25. Hosted Weblate describes Libre hosting
+as gratis for eligible public libre projects. Picocrypt-NG must keep the live
+Weblate link visible in its README and recheck the current terms if the hosting
+plan or project visibility changes. Self-hosting remains the fallback if
+Hosted Libre terms or required controls no longer fit this project.
 
 ## Sources
 
-- Hosted Weblate pricing and Libre plan:
-  <https://weblate.org/en/hosting/>
-- Weblate access control:
-  <https://docs.weblate.org/en/latest/admin/access.html>
-- Hosted Weblate GitHub integration:
-  <https://docs.weblate.org/en/latest/vcs.html>
-- Weblate protected branches and continuous localization:
-  <https://docs.weblate.org/en/latest/admin/continuous.html>
-- Weblate Android format:
+- Hosted Weblate plans: <https://weblate.org/en/hosting/>
+- Code-hosting integration:
+  <https://docs.weblate.org/en/latest/admin/code-hosting.html>
+- Component configuration:
+  <https://docs.weblate.org/en/latest/admin/projects.html>
+- Access control: <https://docs.weblate.org/en/latest/admin/access.html>
+- Version-control links: <https://docs.weblate.org/en/latest/vcs.html>
+- Android resources:
   <https://docs.weblate.org/en/latest/formats/android.html>
-- Weblate JSON format:
-  <https://docs.weblate.org/en/latest/formats/json.html>
-- Weblate glossary:
-  <https://docs.weblate.org/en/latest/user/glossary.html>
-- Weblate checks:
-  <https://docs.weblate.org/en/latest/user/checks.html>
+- go-i18n JSON:
+  <https://docs.weblate.org/en/latest/formats/go-i18n.html>
+- Glossaries: <https://docs.weblate.org/en/latest/user/glossary.html>
+- GitHub rulesets:
+  <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets>

--- a/docs/localization/WEBLATE_SETUP.md
+++ b/docs/localization/WEBLATE_SETUP.md
@@ -44,8 +44,9 @@ The required controls are:
   requests.
 - Project review is enabled and the commit policy writes only approved
   translations.
-- The review team enforces two-factor authentication and has an active
-  maintainer member.
+- The review team enforces two-factor authentication. Weblate activates review
+  privileges only after the maintainer member completes its separate 2FA
+  enrollment.
 - Automatic suggestion acceptance is disabled.
 - Editing base English files and managing source strings are disabled in both
   application components.
@@ -189,9 +190,11 @@ Before opening components after setup or an incident:
    branch, and the desktop component is still linked to it.
 4. Confirm base editing, source-string management, propagation, project
    translation memory, and suggestion auto-accept remain disabled.
-5. Confirm approved-only commits and the GitHub approval/CI rules are active.
-6. Confirm a real upstream merge reaches Weblate through the GitHub App hook.
-7. Use the first genuine approved translation correction as the outbound
+5. Confirm at least one maintainer has active Review-team privileges after 2FA
+   enrollment.
+6. Confirm approved-only commits and the GitHub approval/CI rules are active.
+7. Confirm a real upstream merge reaches Weblate through the GitHub App hook.
+8. Use the first genuine approved translation correction as the outbound
    canary; do not fabricate a translation solely to create a test pull request.
 
 If any invariant fails, keep the project locked and repair the configuration


### PR DESCRIPTION
## Summary
- publish the live Hosted Weblate workflow for desktop and Android catalogs
- enforce lockstep between Android locale filters, packaged catalogs, generated LocaleConfig, and semantic checks
- document fork-based pull requests, approved-only Weblate commits, human review, required CI, new-language admission, and the shared security glossary

## Verification
- `:app:testDebugUnitTest` for `LocalizationResourcesTest` and `LocaleConfigurationPolicyTest`: 23 tests, 0 skipped, 0 failures, 0 errors
- Opengrep: 0 findings across the three changed Gradle/Kotlin files
- Gitleaks: no leaks in the complete branch diff

## Security notes
- no translation catalog content was changed or bulk-approved
- base catalog editing and source-string management remain disabled in Weblate
- Weblate can only propose repository changes through a fork pull request and is not a ruleset bypass actor
- the Hosted Weblate project remains locked until this PR is merged and the inbound GitHub App hook is verified