### PR TITLE
Add android universal apk app ID and SHA256 hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ sudo apt install -y libc6 libgcc-s1 libgl1 libgtk-3-0 libstdc++6 libx11-6
 ## Android
 The native Android app requires Android 7.0 or newer on a 64-bit ARM (<code>arm64-v8a</code>) or x86-64 device. Download the signed universal 64-bit APK <a href="https://github.com/Picocrypt-NG/Picocrypt-NG/releases/latest/download/Picocrypt-NG-android-universal.apk">here</a>, or choose the smaller matching per-ABI APK from the latest GitHub release. Historical 32-bit APKs remain available with their original releases but are no longer supported. PR artifacts remain debug/testing-only.
 
-*Verification info:*
-App ID: `io.github.picocrypt_ng.picocrypt_ng`
-SHA256 hash:
+**Verification info:**
+
+- App ID: `io.github.picocrypt_ng.picocrypt_ng`  
+- SHA256 hash:  
 ```
 E2:F2:A9:71:23:1A:A0:B8:68:82:C6:3B:87:B6:89:C7:16:32:C6:D5:51:68:B1:CE:85:69:52:D0:7F:61:72:B7
 ```

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ sudo apt install -y libc6 libgcc-s1 libgl1 libgtk-3-0 libstdc++6 libx11-6
 ## Android
 The native Android app requires Android 7.0 or newer on a 64-bit ARM (<code>arm64-v8a</code>) or x86-64 device. Download the signed universal 64-bit APK <a href="https://github.com/Picocrypt-NG/Picocrypt-NG/releases/latest/download/Picocrypt-NG-android-universal.apk">here</a>, or choose the smaller matching per-ABI APK from the latest GitHub release. Historical 32-bit APKs remain available with their original releases but are no longer supported. PR artifacts remain debug/testing-only.
 
+*Verification info:*
+App ID: `io.github.picocrypt_ng.picocrypt_ng`
+SHA256 hash:
+```
+E2:F2:A9:71:23:1A:A0:B8:68:82:C6:3B:87:B6:89:C7:16:32:C6:D5:51:68:B1:CE:85:69:52:D0:7F:61:72:B7
+```
+
 For local Android builds and architecture details, see <a href="android/README.md">android/README.md</a>.
 
 ## CLI


### PR DESCRIPTION
Hello,

It would be really nice if the README had the APK ID and sha256 hash for the Android release. Including the Android app ID and the APK’s sha256 hash in the README would help users confirm they’re working with the correct package and release artifact + would make it easier to reproduce installs and verify the downloaded APK hasn’t been corrupted or altered between builds/distribution. Hashes like these are often used with apps like AppVerifier by Android users who may be sideloading.

Feel free to make edits to the formatting/verify I used the correct sha256 hash.

Thanks!